### PR TITLE
Include redirect of /community to splash

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,6 +52,7 @@ const gatsbyRoutes = [
   "/docs*",
   "/reports*",
   "/tutorial*",
+  "/community",
   "/local*" // local shouldn't be handled by auspice for nextstrain.org
 ];
 app.get(gatsbyRoutes, (req, res) => {

--- a/static-site/redirects.json
+++ b/static-site/redirects.json
@@ -4,6 +4,7 @@
   "/about/overview": "/docs/getting-started/introduction",
   "/about/methods/introduction": "/docs/getting-started/introduction",
   "/about/methods": "/docs/getting-started/introduction",
+  "/community": "/#community",  
   "/docs/bioinformatics/introduction": "docs/bioinformatics/introduction-to-augur",
   "/docs/bioinformatics/output-jsons": "/docs/bioinformatics/data-formats",
   "/docs/visualisation": "/docs/interpretation/auspice",

--- a/static-site/src/components/Cards/index.jsx
+++ b/static-site/src/components/Cards/index.jsx
@@ -8,7 +8,6 @@ class Cards extends React.Component {
   render() {
     return (
       <div>
-        <HugeSpacer />
         <div className="row">
           <div className="col-md-1" />
           <div className="col-md-10">

--- a/static-site/src/components/splash/index.jsx
+++ b/static-site/src/components/splash/index.jsx
@@ -48,26 +48,36 @@ class Splash extends React.Component {
           </Styles.Button>
         </FlexCenter>
 
-        <SmallSpacer/>
+        <HugeSpacer/>
+
+        <ScrollableAnchor id={'pathogens'}>
+          <Styles.H1>Explore pathogens</Styles.H1>
+        </ScrollableAnchor>
+
+        <FlexCenter>
+          <Styles.CenteredFocusParagraph>
+            Genomic analyses of specific pathogens kept up-to-date by the Nextstrain team
+          </Styles.CenteredFocusParagraph>
+        </FlexCenter>
 
         <Cards
-          title="Explore pathogens"
-          subtext={
-            <span>
-              Views of the genomic epidemiology of specific pathogens kept up-to-date by the Nextstrain team
-            </span>}
           cards={nextstrainCards}
         />
 
         <HugeSpacer/>
 
+        <ScrollableAnchor id={'community'}>
+          <Styles.H1>From the community</Styles.H1>
+        </ScrollableAnchor>
+
+        <FlexCenter>
+          <Styles.CenteredFocusParagraph>
+            Analyses by independent groups <Link to="/docs/contributing/community-builds">stored and
+            accessed via public GitHub repos</Link>
+          </Styles.CenteredFocusParagraph>
+        </FlexCenter>
+
         <Cards
-          numCardsToShow={3}
-          title="From the community"
-          subtext={
-            <span>
-              Analyses by independent groups <Link to="/docs/contributing/community-builds">stored and accessed via public GitHub repos</Link>
-            </span>}
           cards={communityCards}
         />
 


### PR DESCRIPTION
It seems like it would be common to expect nextstrain.org/community to exist given that there are pages under this heading. This commit creates a redirect from `/community` to the splash page cards at `/#community`. This required adding scrollable anchor tags to the splash page.