### PR TITLE
Customisable auspice splash pages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -51,6 +51,7 @@ rules:
   react-hooks/rules-of-hooks: "error"
   react-hooks/exhaustive-deps: "warn"
   react/no-danger: off # gatsby uses this a lot
+  no-use-before-define: ["error", { "functions": false }]
 parserOptions:
   ecmaVersion: 6
   sourceType: module

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ If you're installing from a local development copy of Auspice's source, you can 
 
 ```bash
 npm link <path to auspice repo>
+npm link <path to auspice repo>/node_modules/react
 ```
 
 This uses symlinks both globally and within the local `node_modules/` directory to point the local Auspice dependency to your local Auspice source.

--- a/auspice/client/config.json
+++ b/auspice/client/config.json
@@ -9,6 +9,7 @@
     "unselectedBackground": "#888"
   },
   "navbarComponent": "navbar.js",
+  "splashComponent": "splash.js",
   "browserTitle": "nextstrain",
   "googleAnalyticsKey": "UA-92687617-1"
 }

--- a/auspice/client/splash.js
+++ b/auspice/client/splash.js
@@ -1,0 +1,187 @@
+import React, {useState, useEffect} from "react"; // eslint-disable-line
+import styled from 'styled-components'; // eslint-disable-line
+import NavBar from "./navbar";
+
+/* WHy is this here? See https://reactjs.org/warnings/invalid-hook-call-warning.html
+Running locally, I had multiple versions of react running.
+This could be due to `npm link`.
+See https://github.com/nextstrain/auspice/issues/689
+Fixed by running `npm link ../auspice/node_modules/react`
+Need to test via a npm install from the registry.
+THIS SHOULD BE REMOVED BEFORE MERGING INTO MASTER
+*/
+require('react-dom'); // eslint-disable-line
+window.React2 = require('react'); // eslint-disable-line
+console.log(window.React1 === window.React2);
+
+
+/**
+ * The defaultPageInfo will only be displayed on two conditions:
+ * (1) the router has decided that the pathname should be handled by the auspice client and
+ * (2) the appropriate `getDataset` requests have failed."
+ * Note that there will also be an errorMessage displayed in this case!
+ */
+const defaultPageInfo = {
+  showDatasets: true,
+  showNarratives: true
+};
+
+
+const Splash = ({available, browserDimensions, dispatch, errorMessage, changePage}) => {
+
+  const [pageInfo, setPageInfo] = useState(defaultPageInfo);
+  useEffect(
+    () => {getSourceInfo(setPageInfo);},
+    [setPageInfo]
+  );
+
+  return (
+    <>
+      <NavBar sidebar={false}/>
+      {errorMessage ? <ErrorMessage errorMessage={errorMessage}/> : null}
+      <div className="static container">
+        <Title avatarSrc={pageInfo.avatar}>
+          {pageInfo.title}
+        </Title>
+        <Byline>{pageInfo.byline}</Byline>
+        {pageInfo.showDatasets ?
+          <ListAvailable type="datasets" data={available.datasets} width={browserDimensions.width} dispatch={dispatch} changePage={changePage}/> :
+          null
+        }
+        {pageInfo.showNarratives ?
+          <ListAvailable type="narratives" data={available.narratives} width={browserDimensions.width} dispatch={dispatch} changePage={changePage}/> :
+          null
+        }
+      </div>
+    </>
+  );
+};
+
+
+/* lifted from auspice's default splash page */
+function ListAvailable({type, data, width, dispatch, changePage}) {
+  const numCols = width > 1000 ? 3 : width > 750 ? 2 : 1;
+  const ColumnList = styled.ul`
+    -moz-column-count: ${numCols};
+    -moz-column-gap: 20px;
+    -webkit-column-count: ${numCols};
+    -webkit-column-gap: 20px;
+    column-count: ${numCols};
+    column-gap: 20px;
+  `;
+  return (
+    <>
+      <div style={{fontSize: "26px"}}>
+        {`Available ${type}:`}
+      </div>
+      <div style={{display: "flex", flexWrap: "wrap"}}>
+        <div style={{flex: "1 50%", minWidth: "0"}}>
+          {(data && data.length) ? (
+            <ColumnList>
+              {data.map((d) => formatDataset(d.request, dispatch, changePage))}
+            </ColumnList>
+          ) :
+            "None found."
+          }
+        </div>
+      </div>
+    </>
+  );
+}
+
+function ErrorMessage({errorMessage}) {
+  const FixedBanner = styled.div`
+    left: 0px;
+    width: 100%;
+    background-color: #E04929;
+    color: white;
+    font-size: 16px;
+    padding: 15px 5%;
+    margin: 25px 0px;
+  `;
+  return (
+    <FixedBanner>
+      There seems to have been an error accessing that dataset.
+      <p style={{fontSize: "14px"}}>
+        {`Details: ${errorMessage}. Please `}
+        <a href={"mailto:hello@nextstrain,.org"} style={{color: "inherit", textDecoration: "underline"}}>
+          email us
+        </a>
+        {` if you think this is a bug.`}
+      </p>
+    </FixedBanner>
+  );
+}
+
+/* lifted from auspice's default splash page */
+function formatDataset(requestPath, dispatch, changePage) {
+  return (
+    <li key={requestPath}>
+      <div
+        style={{color: "#5097BA", textDecoration: "none", cursor: "pointer", fontWeight: "400", fontSize: "94%"}}
+        onClick={() => dispatch(changePage({path: requestPath, push: true}))}
+      >
+        {requestPath}
+      </div>
+    </li>
+  );
+}
+
+
+function Title({avatarSrc, children}) {
+  if (!children) return null;
+  const AvatarImg = styled.img`
+    width: 120px;
+    margin-right: 5%;
+  `;
+  const TitleDiv = styled.div`
+    && {
+      font-weight: 500;
+      font-size: 150%;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+  `;
+  return (
+    <div style={{display: "flex", justifyContent: "center", padding: "5% 0px"}}>
+      {avatarSrc ?
+        <AvatarImg alt="avatar" src={avatarSrc}/> :
+        null
+      }
+      <TitleDiv>
+        {children}
+      </TitleDiv>
+    </div>
+  );
+}
+
+function Byline({children}) {
+  if (!children) return null;
+  const Div = styled.div`
+    && {
+      max-width: 70%;
+      margin: 20px auto 40px auto;
+      text-align: center;
+      font-weight: 400;
+      line-height: 1.428;
+    }
+  `;
+  return (<Div>{children}</Div>);
+}
+
+async function getSourceInfo(setPageInfo) {
+  const pageInfo = await (
+    fetch(`/charon/getSourceInfo?prefix=${window.location.pathname}`)
+      .then((res) => {
+        if (res.status !== 200) {
+          throw new Error(res.statusText);
+        }
+        return res;
+      })
+      .then((res) => res.json())
+  );
+  setPageInfo(pageInfo);
+}
+
+export default Splash;

--- a/auspice/server/getDataset.js
+++ b/auspice/server/getDataset.js
@@ -79,7 +79,7 @@ const getDataset = async (req, res) => {
     return helpers.handleError(res, `Couldn't parse the url "${query.prefix}"`, err.message);
   }
 
-  const {source, fetchUrls, auspiceDisplayUrl} = datasetInfo;
+  const {source, dataset, fetchUrls, auspiceDisplayUrl} = datasetInfo;
 
   // Authorization
   if (!source.visibleToUser(req.user)) {
@@ -108,6 +108,10 @@ const getDataset = async (req, res) => {
     try {
       await requestMainDataset(res, req, fetchUrls);
     } catch (err) {
+      if (dataset.isRequestValidWithoutDataset) {
+        utils.verbose("Request is valid, but no dataset available. Returning 204.");
+        return res.status(204).end();
+      }
       return helpers.handleError(res, `Couldn't fetch JSONs`, err.message);
     }
   }

--- a/auspice/server/getDatasetHelpers.js
+++ b/auspice/server/getDatasetHelpers.js
@@ -198,7 +198,7 @@ const parsePrefix = (prefix, otherQueries) => {
     fetchUrls.additional = dataset.urlFor(otherQueries.type);
   }
 
-  return ({fetchUrls, auspiceDisplayUrl, treeName, secondTreeName, source});
+  return ({fetchUrls, auspiceDisplayUrl, treeName, secondTreeName, source, dataset});
 
 };
 

--- a/auspice/server/getSourceInfo.js
+++ b/auspice/server/getSourceInfo.js
@@ -1,0 +1,27 @@
+const queryString = require("query-string");
+const helpers = require("./getDatasetHelpers");
+
+/**
+ * Prototype implementation.
+ */
+const getSourceInfo = async (req, res) => {
+  const query = queryString.parse(req.url.split('?')[1]);
+  if (!query.prefix) {
+    throw new Error("No prefix defined");
+  }
+  const {source} = helpers.splitPrefixIntoParts(query.prefix);
+
+  let sourceInfo;
+  try {
+    sourceInfo = await source.getInfo();
+  } catch (err) {
+    return helpers.handleError(res, `No source info available`, err.message);
+  }
+  return res.json(sourceInfo);
+};
+
+
+module.exports = {
+  getSourceInfo,
+  default: getSourceInfo
+};

--- a/auspice/server/index.js
+++ b/auspice/server/index.js
@@ -2,9 +2,11 @@ require("./setAvailableDatasets"); // sets globals
 const getAvailable = require("./getAvailable").default;
 const getDataset = require("./getDataset").default;
 const getNarrative = require("./getNarrative").default;
+const getSourceInfo = require("./getSourceInfo").default;
 
 module.exports = {
   getAvailable,
   getDataset,
-  getNarrative
+  getNarrative,
+  getSourceInfo
 };

--- a/auspice/server/sources.js
+++ b/auspice/server/sources.js
@@ -232,6 +232,21 @@ class CommunitySource extends Source {
         .split("_")
         .join("/"));
   }
+  async getInfo() {
+    /* could attempt to fetch a certain file from the repository if we want to implement
+    this functionality in the future */
+    return {
+      title: `${this.owner}'s Nextstrain community builds for ${this.repoName}`,
+      byline: "Nextstrain community builds source datasets from GitHub repositories, in this case" +
+        ` https://github.com/${this.owner}/${this.repoName}. You can see the available datasets listed below :)`,
+      showDatasets: true,
+      showNarratives: true,
+      /* avatar could be fetched here & sent in base64 or similar, or a link sent. The former (or similar) has the advantage
+      of private S3 buckets working, else the client will have to make (a) an authenticated request (too much work)
+      or (b) a subsequent request to nextstrain.org/charon (why not do it at once?) */
+      avatar: `https://github.com/${this.owner}.png?size=200`
+    };
+  }
 }
 
 class CommunityDataset extends Dataset {
@@ -290,6 +305,28 @@ class PrivateS3Source extends Source {
         .replace(/[.]md$/, "")
         .split("_")
         .join("/"));
+  }
+  /**
+   * Get information about a (particular) source.
+   * The data could be a JSON, or a markdown with YAML frontmatter. Or something else.
+   * This is very similar to our previous discussions around moving the auspice footer
+   * content to the dataset JSON - it would be nice to allow links etc to be written in
+   * the title/byline. One advantage of this being outside of the auspice codebase is that
+   * we can iterate on it after pushing live to nextstrain.org
+   */
+  async getInfo() {
+    try {
+      /* attempt to fetch customisable information from S3 bucket */
+      throw new Error();
+    } catch (err) {
+      /* Appropriate fallback if no customised data is available */
+      return {
+        title: `Nextstrain group page for ${this.bucket}`,
+        byline: `The following are the available datasets & narratives for this nextstrain group:`,
+        showDatasets: true,
+        showNarratives: true
+      };
+    }
   }
 }
 

--- a/auspice/server/sources.js
+++ b/auspice/server/sources.js
@@ -76,6 +76,9 @@ class Dataset {
     const url = new URL(this.baseNameFor(type), this.source.baseUrl);
     return url.toString();
   }
+  get isRequestValidWithoutDataset() {
+    return false;
+  }
 }
 
 class Narrative {
@@ -254,6 +257,12 @@ class CommunityDataset extends Dataset {
     // We require datasets are in the auspice/ directory and include the repo
     // name in the file basename.
     return [`auspice/${this.source.repoName}`, ...this.pathParts];
+  }
+  get isRequestValidWithoutDataset() {
+    if (!this.pathParts.length) {
+      return true;
+    }
+    return false;
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -91,6 +91,7 @@ app.get(gatsbyRoutes, (req, res) => {
 app.get("/charon/getAvailable", auspiceServerHandlers.getAvailable);
 app.get("/charon/getDataset", auspiceServerHandlers.getDataset);
 app.get("/charon/getNarrative", auspiceServerHandlers.getNarrative);
+app.get("/charon/getSourceInfo", auspiceServerHandlers.getSourceInfo);
 app.get("/charon*", (req, res) => {
   res.statusMessage = `Query unhandled: ${req.originalUrl}`;
   utils.warn(res.statusMessage);


### PR DESCRIPTION
This commit sets up a prototype implementation of a custom auspice splash
page, by adding an auspice built-time extension for the splash page.
No changes to the auspice source code were needed, this is all done as
a build-time extension, which I think is really cool.

The auspice splash page is accessed when the nextstrain.org router decides
a path should be handled by auspice, but auspice's request for the dataset
returns 500 or 204 (i.e. it doesn't exist). This commonly occurs in the
following cases (with this response code):
* nextstrain.org/doesnotexist (500)
* nextstrain.org/staging (204)
* nextstrain.org/<group_name> (204)
* nextstrain.org/community/<org_name> (500)
* nextstrain.org/community/<org_name>/<repo_name> (behavior has changed in this PR, it is now 204 if there is not an appropriate dataset in the repo)

Here I implement a custom nextstrain.org auspice splash page which makes
a API call to `/charon/getSourceInfo` (and implement the relevant handlers).
The response of this API call defines fields to be rendered, such as title,
byline etc (the exact structure of this is to be finalised, but note that
we can iterate on this after it is live but before publicising).

The intent of this (not yet implemented) is to allow different sources (e.g.
community GitHub repo, "nextstrain group") to define a JSON specifying this
which will be displayed via this splash page.

Screenshots:
![image](https://user-images.githubusercontent.com/8350992/69386452-91d89f80-0d27-11ea-9583-e8a8e19cfad4.png)
![image](https://user-images.githubusercontent.com/8350992/69386466-9c933480-0d27-11ea-919b-4185553e9118.png)
![image](https://user-images.githubusercontent.com/8350992/69386479-a4eb6f80-0d27-11ea-9792-771951922b7f.png)
![image](https://user-images.githubusercontent.com/8350992/69386491-ac127d80-0d27-11ea-8cfa-d13984523569.png)

(and there is a default implementation for groups too, no screenshot included here)

This PR isn't intended for merge currently. There are still some parts of the code to improve, and I'm hoping to get feedback about this general direction. But I think it's a step in the right direction, and the fact that this requires zero modifications to auspice means we deploy this to nextstrain.org and implement additional functionality in future commits.
