### PR TITLE
Add "groups" prefix to Nextstrain groups URLs

### DIFF
--- a/auspice/server/getDataset.js
+++ b/auspice/server/getDataset.js
@@ -86,6 +86,16 @@ const getDataset = async (req, res) => {
   if (!query.prefix) {
     return helpers.handleError(res, `getDataset request must define a prefix`);
   }
+
+  /*
+   * "inrb-drc" was the first of the Nextstrain groups. Groups now live at
+   * `nextstrain.org/groups`, but we want to support old URLs for INRB DRC by
+   * redirecting requests from "/inrb-drc" to "/groups/inrb-drc".
+   */
+  if (query.prefix.startsWith('/inrb-drc')) {
+    return res.redirect("getDataset?prefix=/groups" + query.prefix);
+  }
+
   utils.log(`Getting (nextstrain) datasets for: ${req.url.split('?')[1]}`);
 
   // construct fetch URL

--- a/auspice/server/getDatasetHelpers.js
+++ b/auspice/server/getDatasetHelpers.js
@@ -36,9 +36,21 @@ const splitPrefixIntoParts = (prefix) => {
   /* The first part of the prefix is an optional source name.  The rest is the
    * source path parts.
    */
-  const sourceName = sources.has(prefixParts[0])
-    ? prefixParts.shift()
-    : "core";
+  let sourceName;
+
+  switch (prefixParts[0]) {
+    case "community":
+    case "staging":
+      sourceName = prefixParts.shift();
+      break;
+    case "groups":
+      prefixParts.shift();
+      sourceName = prefixParts.shift();
+      break;
+    default:
+      sourceName = "core";
+      break;
+  }
 
   const isNarrative = prefixParts[0] === "narratives";
 
@@ -72,8 +84,15 @@ const splitPrefixIntoParts = (prefix) => {
 const joinPartsIntoPrefix = ({source, prefixParts, isNarrative = false}) => {
   const leadingParts = [];
 
-  if (source.name !== "core") {
-    leadingParts.push(source.name);
+  switch (source.name) {
+    case "core":
+      break;
+    case "community":
+    case "staging":
+      leadingParts.push(source.name);
+      break;
+    default:
+      leadingParts.push("groups", source.name);
   }
 
   if (isNarrative) {

--- a/auspice/server/getDatasetHelpers.js
+++ b/auspice/server/getDatasetHelpers.js
@@ -210,4 +210,3 @@ module.exports = {
   unauthorized,
   parsePrefix
 };
-

--- a/auspice/server/getNarrative.js
+++ b/auspice/server/getNarrative.js
@@ -12,6 +12,15 @@ const getNarrative = async (req, res) => {
     return helpers.handleError(res, "No prefix in narrative URL query");
   }
 
+  /*
+   * "inrb-drc" was the first of the Nextstrain groups. Groups now live at
+   * `nextstrain.org/groups`, but we want to support old URLs for INRB DRC by
+   * redirecting requests from "/inrb-drc" to "/groups/inrb-drc".
+   */
+  if (prefix.startsWith('/inrb-drc')) {
+    return res.redirect("getNarrative?prefix=/groups" + prefix);
+  }
+
   const {source, prefixParts} = helpers.splitPrefixIntoParts(prefix);
 
   // Authorization

--- a/package-lock.json
+++ b/package-lock.json
@@ -5658,7 +5658,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5676,11 +5677,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5693,15 +5696,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5814,6 +5820,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5826,17 +5833,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5853,6 +5863,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5933,7 +5944,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5943,6 +5955,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6018,7 +6031,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6048,6 +6062,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6065,6 +6080,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6103,7 +6119,8 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",

--- a/server.js
+++ b/server.js
@@ -125,18 +125,14 @@ const auspicePaths = [
   "/narratives/*",
   "/staging",
   "/staging/*",
+  "/groups",
+  "/groups/*",
 
   /* Auspice gets specific /community paths so it can show an index of datasets
    * and narratives, but Gatsby gets top-level /community.
    */
   "/community/:user/:repo",
   "/community/:user/:repo/*",
-
-  /* XXX TODO: Remove the following two lines once PR #59 is merged and replace
-   * with an appropriate /groups/… path pattern.
-   */
-  "/inrb-drc",
-  "/inrb-drc/*",
 ];
 
 app.route(auspicePaths).get((req, res) => {
@@ -144,6 +140,10 @@ app.route(auspicePaths).get((req, res) => {
   res.sendFile(auspiceAssetPath("index.html"));
 });
 
+/* handle redirects for inrb-drc (first of the Nextstrain groups) */
+app.get("/inrb-drc*", (req, res) => {
+  res.redirect(`/groups${req.originalUrl}`);
+});
 
 /* Everything else hits our Gatsby app's entrypoint.
  */

--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ const version = utils.getGitHash();
 const nextstrainAbout = `
   Nextstrain is an open-source project to harness the scientific and public health potential
   of pathogen genome data. This is the server behind nextstrain.org.
-  It delivers the static content (https://github.com/nextstrain/static) as well as the interactive 
+  It delivers the static content (https://github.com/nextstrain/static) as well as the interactive
   visualisation app auspice (https://github.com/nextstrain/auspice), with customisations.
 `;
 const parser = new argparse.ArgumentParser({


### PR DESCRIPTION
Solves https://github.com/nextstrain/nextstrain.org/issues/50

Add a "/groups" prefix to Nextstrain groups URLs, like for `inrb-drc`,
to distinguish from and avoid namespace collisions with core Nextstrain
data sources.
Redirect old "inrb-drc" URLs to the new `/groups` endpoints.