### PR TITLE
Switch to Heroku's native support for deploying after Travis CI checks are successful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ install:
 script:
   - npm run build
   - npm run lint
-after_success:
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then
-      npm run redeploy-site;
-    fi
 notifications:
   email:
     on_success: never

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ See the [charon API auspice documentation](https://nextstrain.github.io/auspice/
 ---
 ## Deploy nextstrain.org
 All commits pushed to github trigger [Travis-CI](https://travis-ci.com/nextstrain/nextstrain.org), which runs the `npm run build` script & runs [eslint](https://eslint.org/) via `npm run lint`.
-If there are no errors, and we're on the master branch, Travis-CI then triggers the heroku server to rebuild (via `npm run redeploy-site`).
-Heroku rebuilds by running `npm run build` and, upon success, starts the server (`npm run server`).
+Heroku will deploy commits pushed to the `master` branch automatically if there are no Travis CI errors.
+Heroku builds by running `npm run build` and, upon success, starts the server (`npm run server`).
 
 
 ---

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "lint": "eslint --ext .js,.jsx .",
     "set-up": "npm run build",
     "server": "node server.js",
-    "start": "npm run server",
-    "redeploy-site": "./redeploy-site.sh"
+    "start": "npm run server"
   },
   "dependencies": {
     "argparse": "^1.0.10",

--- a/redeploy-site.sh
+++ b/redeploy-site.sh
@@ -1,7 +1,0 @@
-echo "Pinging Heroku Platform API to rebuild site"
-
-curl -n -X POST https://api.heroku.com/apps/nextstrain-server/builds \
--d '{"source_blob":{"url":"https://github.com/nextstrain/nextstrain.org/archive/master.tar.gz"}}' \
--H 'Accept: application/vnd.heroku+json; version=3' \
--H "Content-Type: application/json" \
--H "Authorization: Bearer $HEROKU_AUTH_TOKEN"


### PR DESCRIPTION
Removes the need to manage this logic ourselves.