### PR TITLE
Return v2 JSONs for private S3 sources

### DIFF
--- a/auspice/server/sources.js
+++ b/auspice/server/sources.js
@@ -189,34 +189,16 @@ class CommunitySource extends Source {
       return [];
     }
 
-    const files = await response.json();
-    const jsonFiles = files
+    const filenames = (await response.json())
       .filter((file) => file.type === "file")
-      .filter((file) => file.name.endsWith(".json"))
+      // remove anything which doesn't start with the repo name, which is required of community datasets
       .filter((file) => file.name.startsWith(this.repoName))
       .map((file) => file.name);
-
-    const sidecarSuffixes = ["meta", "tree", "root-sequence", "seq", "tip-frequencies"];
-    const notSidecar = (filename) =>
-      !sidecarSuffixes.some((suffix) => filename.endsWith(`_${suffix}.json`));
-
-    // All JSON files which aren't a sidecar file with a known suffix.
-    const v2 = jsonFiles
-      .filter(notSidecar)
-      .map((filename) => filename.replace(/[.]json$/, ""));
-
-    // All *_meta.json files which have a corresponding *_tree.json.
-    const v1 = jsonFiles
-      .filter((filename) => filename.endsWith("_meta.json"))
-      .filter((filename) => jsonFiles.includes(filename.replace(/_meta[.]json$/, "_tree.json")))
-      .map((filename) => filename.replace(/_meta[.]json$/, ""));
-
-    return Array.from(new Set([...v2, ...v1]))
-      .map((filename) => filename
-        .replace(this.repoName, "")
-        .replace(/^_/, "")
-        .split("_")
-        .join("/"));
+    const pathnames = utils.getDatasetsFromListOfFilenames(filenames)
+      // strip out the repo name from the start of the pathnames
+      // as CommunityDataset().baseParts will add this in
+      .map((pathname) => pathname.replace(`${this.repoName}/`, ""));
+    return pathnames;
   }
 
   async availableNarratives() {
@@ -297,15 +279,9 @@ class S3Source extends Source {
     return list.Contents;
   }
   async availableDatasets() {
-    // Walking logic borrowed from auspice's cli/server/getAvailable.js
     const objects = await this._listObjects();
-    return objects
-      .map((object) => object.Key)
-      .filter((file) => file.endsWith("_tree.json"))
-      .map((file) => file
-        .replace(/_tree[.]json$/, "")
-        .split("_")
-        .join("/"));
+    const pathnames = utils.getDatasetsFromListOfFilenames(objects.map((object) => object.Key));
+    return pathnames;
   }
   async availableNarratives() {
     // Walking logic borrowed from auspice's cli/server/getAvailable.js

--- a/auspice/server/utils.js
+++ b/auspice/server/utils.js
@@ -59,6 +59,39 @@ const printStackTrace = (err) => {
   }
 };
 
+/**
+ * Given a list of files, return a list of URL pathnames of
+ * datasets which can be fetched
+ * @param {Array} files. Array of strings.
+ * @returns {Array}
+ */
+const getDatasetsFromListOfFilenames = (filenames) => {
+  const jsonFiles = filenames
+    .filter((file) => file.endsWith(".json"));
+
+  // All JSON files which aren't a sidecar file with a known suffix are assumed to
+  // be v2+ JSONs (aka "unified" JSONs)
+  const sidecarSuffixes = ["meta", "tree", "root-sequence", "seq", "tip-frequencies"];
+  const datasets = jsonFiles
+    .filter((filename) => !sidecarSuffixes.some((suffix) => filename.endsWith(`_${suffix}.json`)))
+    .map((filename) => filename.replace(/[.]json$/, ""));
+
+  // All *_meta.json files which have a corresponding *_tree.json are assumed to
+  // be v1 JSONs.
+  jsonFiles
+    .filter((filename) => filename.endsWith("_meta.json"))
+    .filter((filename) => jsonFiles.includes(filename.replace(/_meta[.]json$/, "_tree.json")))
+    .map((filename) => filename.replace(/_meta[.]json$/, ""))
+    .filter((filename) => !datasets.includes(filename))
+    .forEach((filename) => datasets.push(filename));
+
+  // modify the filenames to represent URL pathnames not filenames
+  return datasets.map((filename) => filename
+    .split("_")
+    .join("/"));
+};
+
+
 module.exports = {
   getGitHash,
   verbose,
@@ -66,5 +99,6 @@ module.exports = {
   warn,
   error,
   fetchJSON,
-  printStackTrace
+  printStackTrace,
+  getDatasetsFromListOfFilenames
 };

--- a/auspice/server/utils.js
+++ b/auspice/server/utils.js
@@ -66,6 +66,11 @@ const printStackTrace = (err) => {
  * @returns {Array}
  */
 const getDatasetsFromListOfFilenames = (filenames) => {
+  /* Please see https://github.com/nextstrain/nextstrain.org/pull/65 for comments
+  which indicate that this function "weirdly mixes a functional, stream-based
+  approach with a procedural approach" and is a candidate for refactoring.
+                                                            James // Jan 2020 */
+
   const jsonFiles = filenames
     .filter((file) => file.endsWith(".json"));
 


### PR DESCRIPTION
Previously `availableDatasets` for (private) S3 sources were not returning v2 JSONs. This commit creates a helper function to perform this task as we use it in multiple places.