### PR TITLE
Detangle Cognito, sources, & group logic on authn

### DIFF
--- a/authn.js
+++ b/authn.js
@@ -73,12 +73,17 @@ function setup(app) {
           Username: profile.username
         }).promise();
 
-        const groups = response.Groups
-          .map((g) => g.GroupName)
-          .filter((g) => sources.has(g));
+        const groups = response.Groups.map((g) => g.GroupName);
 
         // All users are ok, as we control the entire user pool.
-        return done(null, {...profile, groups});
+        const user = {...profile, groups};
+
+        user.visibleGroups = Array.from(sources.values())
+          .filter(source => source.visibleToUser(user))
+          .map(source => source._name)
+          .filter(source => groups.includes(source));
+
+        return done(null, user);
       }
     )
   );

--- a/static-site/src/components/splash/userGroups.jsx
+++ b/static-site/src/components/splash/userGroups.jsx
@@ -9,7 +9,7 @@ const UserGroups = (props) => {
 
   const colors = [...theme.titleColors];
 
-  const groupCards = props.user.groups.map((group) => {
+  const groupCards = props.user.visibleGroups.map((group) => {
     const groupColor = colors[0];
     colors.push(colors.shift());
 

--- a/static-site/src/pages/users.jsx
+++ b/static-site/src/pages/users.jsx
@@ -16,7 +16,7 @@ const UserPage = (props) => {
       </SubText>
 
       <UserGroupsList>
-        {user.groups.map((group) => (
+        {user.visibleGroups.map((group) => (
           <li>
             <a href={`/groups/${group}`}>{group}</a>
           </li>


### PR DESCRIPTION
Centralize the computation of the list of sources visible to the current
user, but using a different property that doesn't conflate Cognito
groups with our internal sources.

Additionally, centralize the authz decisions to stay within the Source
object.

This change was originally [requested by Thomas on a recently closed
PR](https://github.com/nextstrain/nextstrain.org/commit/1a65e10b0094e74642668cea2abd58ae91420c19#commitcomment-36703817).