### PR TITLE
Fix visibleGroups is undefined error

### DIFF
--- a/static-site/src/components/splash/index.jsx
+++ b/static-site/src/components/splash/index.jsx
@@ -51,8 +51,7 @@ class Splash extends React.Component {
         </FlexCenter>
 
         <HugeSpacer/>
-
-        {this.props.user && <UserGroups user={this.props.user}/>}
+        {this.props.user && <UserGroups user={this.props.user} visibleGroups={this.props.visibleGroups} />}
 
         <ScrollableAnchor id={'pathogens'}>
           <Styles.H1>Explore pathogens</Styles.H1>

--- a/static-site/src/components/splash/userGroups.jsx
+++ b/static-site/src/components/splash/userGroups.jsx
@@ -6,10 +6,9 @@ import { HugeSpacer, FlexCenter } from "../../layouts/generalComponents";
 import { theme } from "../../layouts/theme";
 
 const UserGroups = (props) => {
-
   const colors = [...theme.titleColors];
 
-  const groupCards = props.user.visibleGroups.map((group) => {
+  const groupCards = props.visibleGroups.map((group) => {
     const groupColor = colors[0];
     colors.push(colors.shift());
 

--- a/static-site/src/layouts/userDataWrapper.jsx
+++ b/static-site/src/layouts/userDataWrapper.jsx
@@ -2,7 +2,8 @@ import React from "react";
 
 export default class UserDataWrapper extends React.Component {
   state = {
-    user: undefined
+    user: undefined,
+    visibleGroups: undefined,
   }
 
   componentDidMount() {
@@ -21,7 +22,8 @@ export default class UserDataWrapper extends React.Component {
     const childElements = React.Children.map(children, child =>
       // Passes the user state as a prop to all children elements via the prop `user`
       child && React.cloneElement(child, {
-        user: this.state.user
+        user: this.state.user,
+        visibleGroups: this.state.visibleGroups,
       })
     );
     return <div>{ childElements }</div>;

--- a/static-site/src/pages/users.jsx
+++ b/static-site/src/pages/users.jsx
@@ -5,7 +5,7 @@ import NavBar from '../components/nav-bar';
 import { Logos } from "../components/logos";
 
 const UserPage = (props) => {
-  const { user } = props;
+  const { user, visibleGroups } = props;
 
   const LoggedIn = () => (
     <Fragment>
@@ -16,7 +16,7 @@ const UserPage = (props) => {
       </SubText>
 
       <UserGroupsList>
-        {user.visibleGroups.map((group) => (
+        {visibleGroups.map((group) => (
           <li>
             <a href={`/groups/${group}`}>{group}</a>
           </li>


### PR DESCRIPTION
In further testing of #74, we found an error when a user is logged-out
that prevented the splash page of nextstrain.org from loading.

Fix the error by checking if visibleGroups is defined in addition to
user before rendering the `<UserGroups>` component.