### PR TITLE
Identify public & private groups for logged in users

### DIFF
--- a/auspice/server/sources.js
+++ b/auspice/server/sources.js
@@ -26,6 +26,9 @@ class Source {
   get baseUrl() {
     throw InvalidSourceImplementation("baseUrl() must be implemented by subclasses");
   }
+  static isGroup() { /* is the source a "nextstrain group"? */
+    return false;
+  }
   dataset(pathParts) {
     return new Dataset(this, pathParts);
   }
@@ -371,6 +374,9 @@ class PrivateS3Narrative extends Narrative {
 
 class PublicGroupSource extends S3Source {
   get bucket() { return `nextstrain-${this.name}`; }
+  static isGroup() {
+    return true;
+  }
 }
 
 class PrivateGroupSource extends PrivateS3Source {
@@ -378,6 +384,9 @@ class PrivateGroupSource extends PrivateS3Source {
 
   static visibleToUser(user) {
     return !!user && !!user.groups && user.groups.includes(this._name);
+  }
+  static isGroup() {
+    return true;
   }
 }
 

--- a/authn.js
+++ b/authn.js
@@ -210,25 +210,29 @@ function setup(app) {
   });
 
   /**
-   * Returns an array of names of Nextstrain groups that are visible to a
-   * given *user*.
+   * Returns an array of Nextstrain groups that are visible to a
+   * given *user* (or a non-logged in user). The order of groups returned
+   * matches the `sources` array in `sources.js`.
    *
    * FIX: Contains a hard-coded assumption that all Nextstrain groups match
    * their corresponding group name exactly.
    * See <https://github.com/nextstrain/nextstrain.org/issues/76> for more
    * context and to track this issue.
    *
-   * @param {Object} user
-   * @returns {Array}
+   * @param {Object | undefined} user. `undefined` represents a non-logged-in user
+   * @returns {Array} Each element is an object with keys `name` -> {str} (group name) and
+   *                  `private` -> {bool} (group is private)
    */
-  const visibleGroups = (user) => Array.from(sources.values())
-    .filter(source => source.visibleToUser(user))
-    .map(source => source._name)
-    .filter(source => user.groups.includes(source));
+  const visibleGroups = (user) => Array.from(sources)
+      .filter(([, source]) => source.isGroup())
+      .filter(([, source]) => source.visibleToUser(user))
+      .map(([sourceName, source]) => ({
+        name: sourceName,
+        private: !source.visibleToUser(undefined)
+      }));
 
   // Provide the client-side app with info about the current user
   app.route("/whoami").get((req, res) => {
-
     return res.format({
       html: () => res.redirect(
         req.user
@@ -238,7 +242,7 @@ function setup(app) {
       // Express's JSON serialization drops keys with undefined values
       json: () => res.json({
         user: req.user || null,
-        visibleGroups: (req.user && req.user.groups) ? visibleGroups(req.user) : []
+        visibleGroups: visibleGroups(req.user)
       })
     });
   });

--- a/static-site/src/components/Cards/index.jsx
+++ b/static-site/src/components/Cards/index.jsx
@@ -4,6 +4,7 @@ import React from "react";
 import * as Styles from "./styles";
 import { H1 } from "../splash/styles";
 import { MediumSpacer } from "../../layouts/generalComponents";
+import Padlock from "./padlock";
 
 // eslint-disable-next-line react/prefer-stateless-function
 class Cards extends React.Component {
@@ -37,6 +38,11 @@ class Cards extends React.Component {
                           <Styles.CardTitle>
                             {d.title}
                           </Styles.CardTitle>
+                          {d.private ? (
+                            <Styles.BottomRightLabel>
+                              <Padlock/>
+                            </Styles.BottomRightLabel>
+                          ) : null}
                           <Styles.CardImg src={require(`../../../static/splash_images/${d.img}`)} alt={""} color={d.color}/>
                         </a>
                       </Styles.CardInner>

--- a/static-site/src/components/Cards/padlock.js
+++ b/static-site/src/components/Cards/padlock.js
@@ -1,0 +1,12 @@
+import React from "react";
+
+const Padlock = () => (
+  <svg stroke="white" fill="white" width="16" height="19">
+    <path
+      fillRule="evenodd"
+      d="M4 13H3v-1h1v1zm8-6v7c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V7c0-.55.45-1 1-1h1V4c0-2.2 1.8-4 4-4s4 1.8 4 4v2h1c.55 0 1 .45 1 1zM3.8 6h4.41V4c0-1.22-.98-2.2-2.2-2.2-1.22 0-2.2.98-2.2 2.2v2H3.8zM11 7H2v7h9V7zM4 8H3v1h1V8zm0 2H3v1h1v-1z"
+    />
+  </svg>
+);
+
+export default Padlock;

--- a/static-site/src/components/Cards/styles.jsx
+++ b/static-site/src/components/Cards/styles.jsx
@@ -48,6 +48,19 @@ export const CardTitle = styled.div`
   background: rgba(0, 0, 0, 0.7);
 `;
 
+export const BottomRightLabel = styled.div`
+  font-family: ${(props) => props.theme.generalFont};
+  font-weight: 500;
+  font-size: 26px;
+  position: absolute;
+  border-radius: 3px;
+  padding: 10px 20px 10px 20px;
+  bottom: 20px;
+  right: 0px;
+  color: white;
+  background: rgba(0, 0, 0, 0.7);
+`;
+
 export const MoreIconContainer = styled.div`
   cursor: pointer;
   display: flex;

--- a/static-site/src/components/splash/styles.jsx
+++ b/static-site/src/components/splash/styles.jsx
@@ -128,6 +128,10 @@ const ButtonContainer = styled.button`
   }
 `;
 
+export const StrongerText = styled.span`
+  font-weight: 500;
+`;
+
 export const Button = ({to, children}) => (
   <a href={to}>
     <ButtonContainer>

--- a/static-site/src/components/splash/userGroups.jsx
+++ b/static-site/src/components/splash/userGroups.jsx
@@ -15,8 +15,8 @@ const UserGroups = (props) => {
     return (
       {
         img: "empty.png",
-        url: `/groups/${group}`,
-        title: group,
+        url: `/groups/${group.name}`,
+        title: group.name,
         color: groupColor
       }
     );

--- a/static-site/src/components/splash/userGroups.jsx
+++ b/static-site/src/components/splash/userGroups.jsx
@@ -17,7 +17,8 @@ const UserGroups = (props) => {
         img: "empty.png",
         url: `/groups/${group.name}`,
         title: group.name,
-        color: groupColor
+        color: groupColor,
+        private: group.private
       }
     );
   });
@@ -25,13 +26,15 @@ const UserGroups = (props) => {
   return (
     <Fragment>
       <ScrollableAnchor id={'groups'}>
-        <Styles.H1>Private Nextstrain Groups</Styles.H1>
+        <Styles.H1>Nextstrain Groups</Styles.H1>
       </ScrollableAnchor>
 
       <FlexCenter>
         <Styles.CenteredFocusParagraph>
-          Nextstrain groups are collections of datasets with controlled access.
-          You ({props.user.username}) have access to the following groups:
+          Nextstrain groups represent collections of datasets, potentially with controlled access.
+          You (
+          <Styles.StrongerText>{props.user.username}</Styles.StrongerText>
+          ) have access to the following groups (a padlock icon indicates a private group):
         </Styles.CenteredFocusParagraph>
       </FlexCenter>
 

--- a/static-site/src/pages/users.jsx
+++ b/static-site/src/pages/users.jsx
@@ -16,9 +16,9 @@ const UserPage = (props) => {
       </SubText>
 
       <UserGroupsList>
-        {visibleGroups.map((group) => (
+        {visibleGroups.filter((group) => group.private).map((group) => (
           <li>
-            <a href={`/groups/${group}`}>{group}</a>
+            <a href={`/groups/${group.name}`}>{group.name}</a>
           </li>
         ))}
       </UserGroupsList>


### PR DESCRIPTION
See commit messages for more details.

![image](https://user-images.githubusercontent.com/8350992/72314404-b59adf00-36f3-11ea-8817-21583d2c4bb6.png)

@tsibley can you please review b70246f as it adds some static methods to the `Source` class(es) and modifies the `visibleGroups` function.

@trvrb are you happy with the UI here? It would be simple to show this `Nextstrain Groups` section on the splash page for everyone (i.e. non logged in users), and this wouldn't be too bad with the small number of groups we currently have, but I don't think it should be above the core tiles. Let me know if you want me to do this.

Available for testing at https://nextstrain-dev.herokuapp.com/

Closes #80