### PR TITLE
Fix community errors

### DIFF
--- a/auspice/server/sources.js
+++ b/auspice/server/sources.js
@@ -206,7 +206,10 @@ class CommunitySource extends Source {
     const response = await fetch(`https://api.github.com/repos/${this.repo}/contents/narratives?${qs}`);
 
     if (!response.ok) {
-      utils.warn(`Error fetching available narratives from GitHub for source ${this.name}`);
+      if (!response.statusText !== "Not Found") {
+        // not found doesn't warrant an error print, it means there are no narratives for this repo
+        utils.warn(`Error fetching available narratives from GitHub for source ${this.name}`);
+      }
       return [];
     }
 


### PR DESCRIPTION
The move to streaming of datasets caused `getDataset` requests for which the dataset didn't exist to _always_ return a 404 to the client. This wasn't the intention of the code -- for instance, community URLs should check `dataset.isRequestValidWithoutDataset` and return 204 if true, which wasn't happening.
