### PR TITLE
Don't show nav-bar buttons when viewing narratives

### DIFF
--- a/auspice/client/navbar.js
+++ b/auspice/client/navbar.js
@@ -118,12 +118,16 @@ const NavBar = ({sidebar, narrativeTitle, width}) => {
       {sidebar ? null : renderNextstrainTitle(styles.title)}
       <div style={{flex: 5}}/>
       <div style={styles.flexRows}>
-        <div style={{...styles.flexColumns, paddingRight: "12px"}}>
-          <div style={{flex: 5}}/>
-          {renderLink("DOCS", "/docs", styles.link)}
-          {renderLink("BLOG", "/blog", styles.link)}
-          <WhoAmI sidebar={sidebar}/>
-        </div>
+        {narrativeTitle ?
+          null : (
+            <div style={{...styles.flexColumns, paddingRight: "12px"}}>
+              <div style={{flex: 5}}/>
+              {renderLink("DOCS", "/docs", styles.link)}
+              {renderLink("BLOG", "/blog", styles.link)}
+              <WhoAmI sidebar={sidebar}/>
+            </div>
+          )
+        }
         {narrativeTitle ? renderNarrativeTitle(narrativeTitle, styles.narrativeTitle) : null}
       </div>
     </div>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/8350992/73151720-47154280-4131-11ea-9a03-c84dcbb40280.png)


After:
![image](https://user-images.githubusercontent.com/8350992/73151685-2351fc80-4131-11ea-9400-5fab308bdf75.png)

_P.S. See https://github.com/nextstrain/auspice/pull/853 for an improvement in the title display_