### PR TITLE
Support alternate Git branches for community sources

### DIFF
--- a/auspice/server/getDatasetHelpers.js
+++ b/auspice/server/getDatasetHelpers.js
@@ -102,7 +102,7 @@ const joinPartsIntoPrefix = ({source, prefixParts, isNarrative = false}) => {
   switch (source.name) {
     // Community source requires an owner and repo name
     case "community":
-      leadingParts.push(source.owner, source.repoName);
+      leadingParts.push(source.owner, source.repoNameWithBranch);
       break;
     // no default
   }

--- a/auspice/server/sources.js
+++ b/auspice/server/sources.js
@@ -18,13 +18,13 @@ const S3 = new AWS.S3();
 
 class Source {
   static get _name() {
-    throw InvalidSourceImplementation("_name() must be implemented by subclasses");
+    throw new InvalidSourceImplementation("_name() must be implemented by subclasses");
   }
   get name() {
     return this.constructor._name;
   }
   get baseUrl() {
-    throw InvalidSourceImplementation("baseUrl() must be implemented by subclasses");
+    throw new InvalidSourceImplementation("baseUrl() must be implemented by subclasses");
   }
   static isGroup() { /* is the source a "nextstrain group"? */
     return false;
@@ -271,7 +271,7 @@ class CommunityNarrative extends Narrative {
 
 class S3Source extends Source {
   get bucket() {
-    throw InvalidSourceImplementation("bucket() must be implemented by subclasses");
+    throw new InvalidSourceImplementation("bucket() must be implemented by subclasses");
   }
   get baseUrl() {
     return `https://${this.bucket}.s3.amazonaws.com`;
@@ -333,7 +333,7 @@ class PrivateS3Source extends S3Source {
     return new PrivateS3Narrative(this, pathParts);
   }
   static visibleToUser(user) { // eslint-disable-line no-unused-vars
-    throw InvalidSourceImplementation("visibleToUser() must be implemented explicitly by subclasses (not inherited from PrivateS3Source)");
+    throw new InvalidSourceImplementation("visibleToUser() must be implemented explicitly by subclasses (not inherited from PrivateS3Source)");
   }
 }
 

--- a/auspice/server/sources.js
+++ b/auspice/server/sources.js
@@ -233,10 +233,14 @@ class CommunitySource extends Source {
   async getInfo() {
     /* could attempt to fetch a certain file from the repository if we want to implement
     this functionality in the future */
+    const githubUrl = `https://github.com/${this.owner}/${this.repoName}`;
     return {
-      title: `${this.owner}'s Nextstrain community builds for ${this.repoName}`,
-      byline: "Nextstrain community builds source datasets from GitHub repositories, in this case" +
-        ` https://github.com/${this.owner}/${this.repoName}. You can see the available datasets listed below :)`,
+      title: `${this.owner}'s "${this.repoName}" Nextstrain community build`,
+      byline: `
+        Nextstrain community builds are fetched directly from GitHub
+        repositories, in this case ${githubUrl}.  The available datasets and
+        narratives in this repository are listed below.
+      `,
       showDatasets: true,
       showNarratives: true,
       /* avatar could be fetched here & sent in base64 or similar, or a link sent. The former (or similar) has the advantage
@@ -316,8 +320,8 @@ class S3Source extends Source {
     } catch (err) {
       /* Appropriate fallback if no customised data is available */
       return {
-        title: `Nextstrain group page for ${this.bucket}`,
-        byline: `The following are the available datasets & narratives for this nextstrain group:`,
+        title: `"${this.name}" Nextstrain group`,
+        byline: `The available datasets and narratives in this group are listed below.`,
         showDatasets: true,
         showNarratives: true
       };

--- a/auspice/server/sources.js
+++ b/auspice/server/sources.js
@@ -55,6 +55,10 @@ class Source {
   visibleToUser(user) {
     return this.constructor.visibleToUser(user);
   }
+
+  async getInfo() {
+    throw new InvalidSourceImplementation("getInfo() must be implemented by subclasses");
+  }
 }
 
 class Dataset {

--- a/auspice/server/sources.js
+++ b/auspice/server/sources.js
@@ -125,7 +125,7 @@ class CoreSource extends Source {
     const response = await fetch(`https://api.github.com/repos/${this.repo}/contents?${qs}`);
 
     if (!response.ok) {
-      utils.warn(`Error fetching available narratives from GitHub for source ${this.name}`);
+      utils.warn(`Error fetching available narratives from GitHub for source ${this.name}`, await utils.responseDetails(response));
       return [];
     }
 
@@ -185,7 +185,7 @@ class CommunitySource extends Source {
     const response = await fetch(`https://api.github.com/repos/${this.repo}/contents/auspice?${qs}`);
 
     if (!response.ok) {
-      utils.warn(`Error fetching available datasets from GitHub for source ${this.name}`);
+      utils.warn(`Error fetching available datasets from GitHub for source ${this.name}`, await utils.responseDetails(response));
       return [];
     }
 
@@ -208,7 +208,7 @@ class CommunitySource extends Source {
     if (!response.ok) {
       if (!response.statusText !== "Not Found") {
         // not found doesn't warrant an error print, it means there are no narratives for this repo
-        utils.warn(`Error fetching available narratives from GitHub for source ${this.name}`);
+        utils.warn(`Error fetching available narratives from GitHub for source ${this.name}`, await utils.responseDetails(response));
       }
       return [];
     }

--- a/auspice/server/sources.js
+++ b/auspice/server/sources.js
@@ -166,16 +166,26 @@ class CommunitySource extends Source {
 
     // The GitHub owner and repo names are required.
     if (!owner) throw new Error(`Cannot construct a ${this.constructor.name} without an owner`);
-    if (!repoName) throw new Error(`Cannot construct a ${this.constructor.name} without an repoName`);
+    if (!repoName) throw new Error(`Cannot construct a ${this.constructor.name} without a repoName`);
 
     this.owner = owner;
-    this.repoName = repoName;
+    [this.repoName, this.branch] = repoName.split(/@/, 2);
+
+    if (!this.repoName) throw new Error(`Cannot construct a ${this.constructor.name} without a repoName after splitting on /@/`);
+    if (!this.branch) {
+      this.branch = "master";
+    }
   }
 
   static get _name() { return "community"; }
   get repo() { return `${this.owner}/${this.repoName}`; }
-  get branch() { return "master"; }
   get baseUrl() { return `https://raw.githubusercontent.com/${this.repo}/${this.branch}/`; }
+
+  get repoNameWithBranch() {
+    return this.branch === "master"
+      ? this.repoName
+      : `${this.repoName}@${this.branch}`;
+  }
 
   dataset(pathParts) {
     return new CommunityDataset(this, pathParts);
@@ -233,7 +243,7 @@ class CommunitySource extends Source {
   async getInfo() {
     /* could attempt to fetch a certain file from the repository if we want to implement
     this functionality in the future */
-    const githubUrl = `https://github.com/${this.owner}/${this.repoName}`;
+    const githubUrl = `https://github.com/${this.owner}/${this.repoName}/tree/${this.branch}`;
     return {
       title: `${this.owner}'s "${this.repoName}" Nextstrain community build`,
       byline: `

--- a/auspice/server/utils.js
+++ b/auspice/server/utils.js
@@ -59,6 +59,11 @@ const printStackTrace = (err) => {
   }
 };
 
+const responseDetails = async (response) => [
+  `${response.status} ${response.statusText}`,
+  await response.text()
+];
+
 /**
  * Given a list of files, return a list of URL pathnames of
  * datasets which can be fetched
@@ -105,5 +110,6 @@ module.exports = {
   error,
   fetchJSON,
   printStackTrace,
+  responseDetails,
   getDatasetsFromListOfFilenames
 };

--- a/auspice/server/utils.js
+++ b/auspice/server/utils.js
@@ -20,14 +20,14 @@ const verbose = (msg, ...rest) => {
     console.log(chalk.greenBright(`[verbose]\t${msg}`), ...rest);
   }
 };
-const log = (msg) => {
-  console.log(chalk.blueBright(msg));
+const log = (msg, ...rest) => {
+  console.log(chalk.blueBright(msg), ...rest);
 };
-const warn = (msg) => {
-  console.warn(chalk.redBright(`[warning]\t${msg}`));
+const warn = (msg, ...rest) => {
+  console.warn(chalk.redBright(`[warning]\t${msg}`), ...rest);
 };
-const error = (msg) => {
-  console.error(chalk.redBright(`[error]\t${msg}`));
+const error = (msg, ...rest) => {
+  console.error(chalk.redBright(`[error]\t${msg}`), ...rest);
   process.exit(2);
 };
 


### PR DESCRIPTION
Community URLs may now include an alternate branch name with the syntax
`/community/<user>/<repo>@<branch>/…` to view datasets and narratives on a
branch other than "master".  If no branch is specified, "master" will be
used.

This change was made to allow translators of the 2019-nCoV narratives to
preview their work on their topic branches.