### PR TITLE
Add nCoV redirects

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -6,6 +6,10 @@ const setup = (app) => {
   app.route("/auspice")
     .get((req, res) => res.redirect('https://nextstrain.github.io/auspice/'));
 
+  /* we don't yet have a community page */
+  app.route("/community")
+    .get((req, res) => res.redirect('/#community'));
+
   /* we don't yet have a narratives page. Send /narratives to the narratives section of the frontpage */
   app.route("/narratives")
     .get((req, res) => res.redirect('/#narratives'));

--- a/redirects.js
+++ b/redirects.js
@@ -10,6 +10,11 @@ const setup = (app) => {
   app.route("/narratives")
     .get((req, res) => res.redirect('/#narratives'));
 
+  /* The URLs and nextstrain.org/narratives/ncov and nextstrain.org/narratives/ncov/sit-rep
+  aren't valid - redirect instead to the nCoV section of the splash page */
+  app.route(["/narratives/ncov", "/narratives/ncov/sit-rep"])
+    .get((req, res) => res.redirect('/#ncov'));
+
 };
 
 module.exports = {

--- a/redirects.js
+++ b/redirects.js
@@ -1,0 +1,13 @@
+
+
+const setup = (app) => {
+
+  /* send auspice to the auspice docs (currently hosted as github pages) */
+  app.route("/auspice")
+    .get((req, res) => res.redirect('https://nextstrain.github.io/auspice/'));
+
+};
+
+module.exports = {
+  setup
+};

--- a/redirects.js
+++ b/redirects.js
@@ -6,6 +6,10 @@ const setup = (app) => {
   app.route("/auspice")
     .get((req, res) => res.redirect('https://nextstrain.github.io/auspice/'));
 
+  /* we don't yet have a narratives page. Send /narratives to the narratives section of the frontpage */
+  app.route("/narratives")
+    .get((req, res) => res.redirect('/#narratives'));
+
 };
 
 module.exports = {

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ global.verbose = args.verbose;
 const auspiceServerHandlers = require("./auspice/server");
 const authn = require("./authn");
 const sources = require("./auspice/server/sources");
-
+const redirects = require("./redirects");
 
 /* Path helpers for static assets, to make routes more readable.
  */
@@ -71,8 +71,7 @@ authn.setup(app);
 
 /* Redirects.
  */
-app.route("/auspice")
-  .get((req, res) => res.redirect('https://nextstrain.github.io/auspice/'));
+redirects.setup(app);
 
 
 /* Static assets.  Auspice hardcodes /dist/… in its Webpack config.

--- a/static-site/src/components/splash/index.jsx
+++ b/static-site/src/components/splash/index.jsx
@@ -54,7 +54,7 @@ class Splash extends React.Component {
         <HugeSpacer/>
         {this.props.user && <UserGroups user={this.props.user} visibleGroups={this.props.visibleGroups} />}
 
-        <ScrollableAnchor id={'pathogens'}>
+        <ScrollableAnchor id={'ncov'}>
           <Styles.H1>Novel coronavirus (2019-nCoV)</Styles.H1>
         </ScrollableAnchor>
 


### PR DESCRIPTION
See commits. 

I chose to redirect nextstrain.org/narratives/ncov/sit-rep to the splash page instead of the current narrative as the latter would require us to update the server code as we updated the narrative. However we have to modify the server anyway (to update the splash tiles) so we could also keep this redirect pointing to the most recent narrative.