### PR TITLE
fix(static-site): remove gatsby-inlined-css

### DIFF
--- a/static-site/src/html.jsx
+++ b/static-site/src/html.jsx
@@ -4,28 +4,9 @@
 import React from "react";
 import favicon from "../../favicon.png";
 
-let inlinedStyles = "";
-if (process.env.NODE_ENV === "production") {
-  try {
-    // eslint-disable-next-line import/no-webpack-loader-syntax
-    inlinedStyles = require("!raw-loader!../public/styles.css");
-  } catch (e) {
-    console.log(e);
-  }
-}
-
 // eslint-disable-next-line react/prefer-stateless-function
 export default class HTML extends React.Component {
   render() {
-    let css;
-    if (process.env.NODE_ENV === "production") {
-      css = (
-        <style
-          id="gatsby-inlined-css"
-          dangerouslySetInnerHTML={{ __html: inlinedStyles }}
-        />
-      );
-    }
     return (
       <html lang="en">
         <head>
@@ -36,7 +17,6 @@ export default class HTML extends React.Component {
           />
           {this.props.headComponents}
           <link rel="shortcut icon" href={favicon} />
-          {css}
         </head>
         <body>
           <div


### PR DESCRIPTION
Since Gatsby v2  CSS is inlined automagically and the explicit setup relying on existence of `public/styles.css` (previously containing a portion of styles to be inlined) is no longer necessary, and, even worse, fails the production build with an error: 

   > Cannot find module '!raw-loader!../public/styles.css'.

because `public/styles.css` is no longer provided by Gatsby v2.

This PR removes the explicit setup and resolves the error. Complements #75. Resolves #104.

See discussion in:
 - https://github.com/nextstrain/nextstrain.org/issues/104
 - https://github.com/nextstrain/nextstrain.org/pull/75#issuecomment-574019845

Relevant gatsby docs:
 - https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#remove-inlined-css-in-htmljs

