### PR TITLE
fix(static-site): add polyfills and target config for Internet Explorer

### DIFF
--- a/static-site/.browserslistrc
+++ b/static-site/.browserslistrc
@@ -1,1 +1,6 @@
+[development]
 Last 2 versions
+
+[production]
+cover 99%
+ie >= 9

--- a/static-site/gatsby-browser.js
+++ b/static-site/gatsby-browser.js
@@ -1,0 +1,5 @@
+export function onClientEntry() {
+  if (typeof fetch === 'undefined') {
+    require('whatwg-fetch'); // eslint-disable-line global-require
+  }
+}

--- a/static-site/package.json
+++ b/static-site/package.json
@@ -66,7 +66,8 @@
     "react-tweet-embed": "^1.1.0",
     "react-twitter-widgets": "^1.4.0",
     "save": "^2.3.2",
-    "styled-components": "^2.4.1"
+    "styled-components": "^2.4.1",
+    "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
     "cli-glob": "^0.1.0",


### PR DESCRIPTION
This resolves nexstrain.org main page crash with console errors when using IE browser.

Changes:
 - added polyfill for `fetch`
 - changed babel's transpilation target to cover 99% of active browsers, including IE versions above 9 (inclusive).

Note: On this particular commit build is failing, until https://github.com/nextstrain/nextstrain.org/issues/104 is resolved. However I made it independent on the fix https://github.com/nextstrain/nextstrain.org/pull/108 to avoid collisions in case someone will have the build issues resolved earlier.


Verified with
 - Internet Explorer 10.0.9200.17457
 - Internet Explorer 11.0.9600.18920
