### PR TITLE
fix(static-site): add X-UA-Compatible meta tag for IE doc mode

### DIFF
--- a/static-site/src/html.jsx
+++ b/static-site/src/html.jsx
@@ -10,6 +10,7 @@ export default class HTML extends React.Component {
     return (
       <html lang="en">
         <head>
+          <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
           <meta charSet="utf-8" />
           <meta
             name="viewport"


### PR DESCRIPTION
This fixes newer IE versions to paradoxically render blank page on nextstrain.org, while older versions work fine.

This fix prevents newer IE  versions (currently affected are 11.8xx and 11.9xx, but not 11.1xx or 10.xxx) to automatically switch to compatibility mode, in which case it is falling back to older IE standards. Apparently they fall back way to far, beyond our current compatibility (IE 10+).

"Edge" content value of this tag tells IE and Edge, no matter which version, to enable its latest available features and to not enable compatibility with older versions.

This tag should come very first in the `<head/>`, otherwise preceding tags may be interpreted in older mode, before browser switches to "edge" mode.

Note, that this tag may be ignored if compatibility is set in IE developer tools (F12).

For more information see:

 - https://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-ua-compatible-content-ie-edge-do