### PR TITLE
fix: crash on "let" keyword in IE

### DIFF
--- a/static-site/package-lock.json
+++ b/static-site/package-lock.json
@@ -8706,9 +8706,9 @@
       }
     },
     "gatsby-remark-autolink-headers": {
-      "version": "2.1.23",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-2.1.23.tgz",
-      "integrity": "sha512-OXZi/XlA8o0NmZLkPoMqM03cXNIymugCRfuqpZxZTXqGObjjbYb+YbxLVSbogbJAVJdjw2xVEjYMG1ca0YMS1w==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-2.1.24.tgz",
+      "integrity": "sha512-8cVIE0UEYPo9BcTdVNwDF3phYvRJ2jfFNK0VXt2y1uJelfczjPwBDl7sL6GaHEA7WPPok5Ac7ZRI4jgYI84tPw==",
       "requires": {
         "@babel/runtime": "^7.7.6",
         "github-slugger": "^1.2.1",

--- a/static-site/package.json
+++ b/static-site/package.json
@@ -45,7 +45,7 @@
     "gatsby-plugin-sitemap": "^2.2.25",
     "gatsby-plugin-styled-components": "^3.1.17",
     "gatsby-plugin-twitter": "^2.1.18",
-    "gatsby-remark-autolink-headers": "^2.1.23",
+    "gatsby-remark-autolink-headers": "^2.1.24",
     "gatsby-remark-copy-linked-files": "^2.1.36",
     "gatsby-remark-images": "^3.1.42",
     "gatsby-remark-prismjs": "^3.3.30",


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextstrain.org/issues/113

Upgrades `gatsby-remark-autolink-headers` to version 2.1.24, which contains the necessary fix.
