### PR TITLE
Workaround to ensure that ES6 classes don't leak into the bundle from iso-639-1 package

### DIFF
--- a/auspice/client/languageSelector.js
+++ b/auspice/client/languageSelector.js
@@ -1,5 +1,5 @@
 import React from "react"; // eslint-disable-line
-import ISO6391 from "iso-639-1";
+import ISO6391 from "iso-639-1/build/index";
 import {parseNarrativeLanguage} from "../server/utils";
 
 class LanguageSelector extends React.Component {


### PR DESCRIPTION
This does not solve the problem, but temporarily patches  https://github.com/nextstrain/auspice/issues/902, unlocking nextstrain.org users with some of the older browsers.

This works by forcing the import of ES5 version of `iso-639-1`

