### PR TITLE
fix: Display 404 page when needed

### DIFF
--- a/server.js
+++ b/server.js
@@ -153,7 +153,11 @@ app.get("/inrb-drc*", (req, res) => {
  */
 app.get("*", (req, res) => {
   utils.verbose(`Sending Gatsby entrypoint for ${req.originalUrl}`);
-  res.sendFile(gatsbyAssetPath("index.html"));
+  if (req.originalUrl.startsWith("/page-data/")) {
+    res.sendFile(gatsbyAssetPath("index.html"));
+  } else {
+    res.sendFile(gatsbyAssetPath("404.html"));
+  }
 });
 
 


### PR DESCRIPTION
Not too sure how to feel about this particular fix but from my local testing it seems that any pages that aren't one of the matching routes won't have the `/page-data/` prefix.

fixes #123 