### PR TITLE
Remove duplication of repo name in getAvailable request field

### DIFF
--- a/src/getDatasetHelpers.js
+++ b/src/getDatasetHelpers.js
@@ -103,11 +103,10 @@ const joinPartsIntoPrefix = ({source, prefixParts, isNarrative = false}) => {
     // Community source requires an owner and repo name
     case "community":
       leadingParts.push(source.owner, source.repoNameWithBranch);
-      break;
-    // no default
+      return leadingParts.join("/");
+    default:
+      return [...leadingParts, ...prefixParts.filter((x) => x.length)].join("/");
   }
-
-  return [...leadingParts, ...prefixParts.filter((x) => x.length)].join("/");
 };
 
 /* Given the prefix (split on "/") -- is there an exact match in


### PR DESCRIPTION
#121 seems to be caused by having the repo name in both `source.repoNameWithBranch` and passed into `joinPartsIntoPrefix()` as an item in `prefixParts`. By treating this as a special case affecting community sources only, we can ignore `prefixParts` entirely for these sources.