### PR TITLE
charon/getDataset: Use (cached) fetch() instead of "request"

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "passport": "^0.4.0",
     "passport-oauth2": "^1.5.0",
     "query-string": "^4.2.3",
-    "request": "^2.88.0",
     "serve-favicon": "^2.5.0",
     "session-file-store": "^1.3.1",
     "yaml-front-matter": "^4.0.0"

--- a/src/getDataset.js
+++ b/src/getDataset.js
@@ -3,7 +3,7 @@ const utils = require("./utils");
 const helpers = require("./getDatasetHelpers");
 const {NoDatasetPathError} = require("./exceptions");
 const auspice = require("auspice");
-const {fetch} = require("./fetch");
+const fetch = require('node-fetch');
 
 /**
  *


### PR DESCRIPTION
### Description of proposed changes    

Switching to fetch makes it easier to handle low-level network errors
(i.e. not HTTP errors) fetching from upstream, like connect(2) timeouts,
rather than crashing the app.  This was an issue when CloudFront (for
data.nextstrain.org) was having latency issues earlier today.  Thanks to
async/await, such errors will be properly caught by the try/catch
surrounding the requestMainDataset() call.  The code is also less
tangled by leveraging async/await and removing callbacks that close over
the objects they're attached to.

In addition, I used our cached version of fetch() to avoid unnecessary
network transfers with upstream, which seems like an obvious win.  I'm
presuming it's faster to send data directly from our disk cache rather
than stream it off an upstream socket.  This should be true, but I guess
it's possible the link to CloudFront is really blazing fast and Heroku's
using really slow disks.  Profiling would confirm if we have doubts.

### Testing
I tested locally to confirm that streaming still appears to be working, the the newly added caching works, that fall backs to v1 datasets work, and that low-level errors are actually caught.