### PR TITLE
Add regional builds to splash page & squash tiles.

### DIFF
--- a/static-site/src/components/Cards/coreCards.js
+++ b/static-site/src/components/Cards/coreCards.js
@@ -2,7 +2,7 @@ const coreCards = [
   {
     img: "ncov.png",
     url: "/ncov",
-    title: "nCoV 2019-20"
+    title: "SARS-CoV-2"
   },
   {
     img: "seasonalinfluenza.png",

--- a/static-site/src/components/Cards/index.jsx
+++ b/static-site/src/components/Cards/index.jsx
@@ -32,10 +32,10 @@ class Cards extends React.Component {
               {this.props.cards.map((d) => (
                 <div key={d.title}>
                   <div className="col-sm-4">
-                    <Styles.CardOuter>
+                    <Styles.CardOuter squashed={this.props.squashed}>
                       <Styles.CardInner>
                         <a href={`${d.url}`}>
-                          <Styles.CardTitle>
+                          <Styles.CardTitle squashed={this.props.squashed}>
                             {d.title}
                           </Styles.CardTitle>
                           {d.private ? (

--- a/static-site/src/components/Cards/nCoVCards.js
+++ b/static-site/src/components/Cards/nCoVCards.js
@@ -1,8 +1,38 @@
 const nCoVCards = [
   {
     img: "ncov.png",
-    url: "/ncov",
-    title: "Latest data and analysis"
+    url: "/ncov/global",
+    title: "Latest global analysis"
+  },
+  {
+    img: "ncov.png",
+    url: "/ncov/north-america",
+    title: "Latest analysis for North America"
+  },
+  {
+    img: "ncov.png",
+    url: "/ncov/europe",
+    title: "Latest analysis for Europe"
+  },
+  {
+    img: "ncov.png",
+    url: "/ncov/asia",
+    title: "Latest analysis for Asia"
+  },
+  {
+    img: "ncov.png",
+    url: "/ncov/south-america",
+    title: "Latest analysis for Oceania"
+  },
+  {
+    img: "ncov.png",
+    url: "/ncov/africa",
+    title: "Latest analysis for Africa"
+  },
+  {
+    img: "ncov.png",
+    url: "/ncov/south-america",
+    title: "Latest analysis for South America"
   },
   {
     img: "ncov_narrative.png",

--- a/static-site/src/components/Cards/styles.jsx
+++ b/static-site/src/components/Cards/styles.jsx
@@ -21,10 +21,10 @@ export const CardOuter = styled.div`
   overflow: hidden;
   position: relative;
   padding: 15px 0px 15px 0px;
-  height: 250px;
+  height: ${(props) => props.squashed ? "150px" : "250px"};
   width: 250px;
   @media (max-width: 992px) {
-    height: 200px;
+    height: ${(props) => props.squashed ? "150px" : "200px"};
     width: 200px;
   }
   @media (max-width: 768px) {
@@ -41,7 +41,10 @@ export const CardOuter = styled.div`
 export const CardTitle = styled.div`
   font-family: ${(props) => props.theme.generalFont};
   font-weight: 500;
-  font-size: 26px;
+  font-size: ${(props) => props.squashed ? "22px" : "26px"};
+  @media (max-width: 768px) {
+    font-size: 22px;
+  }
   position: absolute;
   border-radius: 3px;
   padding: 10px 20px 10px 20px;

--- a/static-site/src/components/splash/index.jsx
+++ b/static-site/src/components/splash/index.jsx
@@ -66,6 +66,7 @@ class Splash extends React.Component {
         </FlexCenter>
 
         <Cards
+          squashed
           cards={nCoVCards}
         />
 

--- a/static-site/src/components/splash/index.jsx
+++ b/static-site/src/components/splash/index.jsx
@@ -55,13 +55,13 @@ class Splash extends React.Component {
         {this.props.user && <UserGroups user={this.props.user} visibleGroups={this.props.visibleGroups} />}
 
         <ScrollableAnchor id={'ncov'}>
-          <Styles.H1>Novel coronavirus (2019-nCoV)</Styles.H1>
+          <Styles.H1>Novel coronavirus</Styles.H1>
         </ScrollableAnchor>
 
         <FlexCenter>
           <Styles.CenteredFocusParagraph>
-            We are incorporating nCoV genomes as soon as they are shared and providing analyses and situation reports.
-            Please see below for the latest updates.
+            We are incorporating SARS-CoV-2 genomes as soon as they are shared and providing analyses and situation reports.
+            Please see below for the latest analyses and situation reports.
           </Styles.CenteredFocusParagraph>
         </FlexCenter>
 

--- a/static-site/src/components/splash/userGroups.jsx
+++ b/static-site/src/components/splash/userGroups.jsx
@@ -38,7 +38,7 @@ const UserGroups = (props) => {
         </Styles.CenteredFocusParagraph>
       </FlexCenter>
 
-      <Cards cards={groupCards}/>
+      <Cards cards={groupCards} squashed/>
 
       <HugeSpacer/>
     </Fragment>


### PR DESCRIPTION
Here we add the regional builds as tiles to the splash page. 

As we now have so many nCoV cards (due to all the amazing translations) we set these cards to be "squashed" so that they take up less vertical space. 

We also make minor changes to the title: 
```diff
- Novel coronavirus (2019-nCoV)
+ Novel coronavirus

- We are incorporating nCoV genomes as soon as they are shared and providing analyses and situation reports.
- Please see below for the latest updates.
+ We are incorporating SARS-CoV-2 genomes as soon as they are shared and providing analyses and situation reports.
+ Please see below for the latest analyses and situation reports.
```


