### PR TITLE
Fixing Typo in Section: Make a TSV File Containing your Clade Mutations

### DIFF
--- a/static-site/content/docs/03-tutorials/03-defining-clades.md
+++ b/static-site/content/docs/03-tutorials/03-defining-clades.md
@@ -29,7 +29,7 @@ The header of this TSV file should have the following entries: clade`\t`gene`\t`
 
 * `alt` is the nucleotide that the site mutated to. For example if the nucleotide mutation is `G9417A`, then `alt` would be `A`.
 
-Note that some clades will be defined by more than one mutation. To avoid any conflicts with other clades, you should list all the mutations in the TSV file (using the same clade name, but different site information). A picture of what this tsv file should look like, showing invisible characters, is given below. Note that clades `c1`, `c2`, `c3`, `c4`, and `c5` are defined by only one mutation, but that `c6` is defined by two mutations, and thus has two entries, one for each mutation. Along the same lines, there are six mutations defining clade `c6`, and thus there are six entries in the `tsv` file.
+Note that some clades will be defined by more than one mutation. To avoid any conflicts with other clades, you should list all the mutations in the TSV file (using the same clade name, but different site information). A picture of what this tsv file should look like, showing invisible characters, is given below. Note that clades `c1`, `c2`, `c3`, `c4`, and `c5` are defined by only one mutation, but that `c6` is defined by two mutations, and thus has two entries, one for each mutation. Along the same lines, there are six mutations defining clade `c7`, and thus there are six entries in the `tsv` file.
 
 ![](./img/tsv.png)
 


### PR DESCRIPTION
In the phrase: Along the same lines, there are six mutations defining clade `c7`, and thus there are six entries in the `tsv` file.

The c6 should be a c7, according to the data in the section.

### Description of proposed changes    
What is the goal of this pull request? What does this pull request change?

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #  N/A
Related to #  N/A

### Testing
What steps should be taken to test the changes you've proposed?  N/A
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  No. Fixing a typo.

### Thank you for contributing to Nextstrain!
