### PR TITLE
pipe request headers to CloudFront

### DIFF
--- a/src/getDataset.js
+++ b/src/getDataset.js
@@ -53,13 +53,15 @@ const requestV1Dataset = async (metaJsonUrl, treeJsonUrl) => {
  * If neither the v1 nor the v2 dataset fetch / parse is successful,
  * then the promise will reject.
  */
-const requestMainDataset = async (res, fetchUrls) => {
+const requestMainDataset = async (_req, res, fetchUrls) => {
   return new Promise((resolve, reject) => {
     /* try to stream the (v2+) dataset JSON as the response */
     const req = request
-      .get(fetchUrls.main)
+      .get(fetchUrls.main);
+    _req.pipe(req);
+    req
       .on("response", async (response) => { // eslint-disable-line consistent-return
-        if (response.statusCode === 200) {
+        if (response.statusCode === 200 || response.statusCode === 304) {
           utils.verbose(`Successfully streaming ${fetchUrls.main}.`);
           req.pipe(res);
           return resolve();
@@ -151,7 +153,7 @@ const getDataset = async (req, res) => {
     }
   } else {
     try {
-      await requestMainDataset(res, fetchUrls);
+      await requestMainDataset(req, res, fetchUrls);
     } catch (err) {
       if (dataset.isRequestValidWithoutDataset) {
         utils.verbose("Request is valid, but no dataset available. Returning 204.");


### PR DESCRIPTION
### Description of proposed changes    
Pipes request headers to CloudFront

Before:

```
curl localhost:5000/charon/getDataset?prefix=/ncov/global -H "If-None-Match: \"27fee4ef7a4d2abc1774aaf8d8c0befc\"" -H "If-Modified-Since: Wed, 06 May 2020 14:57:56 GMT" -v > dump
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 5000 (#0)
> GET /charon/getDataset?prefix=/ncov/global HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/7.55.1
> Accept: */*
> If-None-Match: "27fee4ef7a4d2abc1774aaf8d8c0befc"
> If-Modified-Since: Wed, 06 May 2020 14:57:56 GMT
>
< HTTP/1.1 200 OK
< X-Powered-By: Express
< content-type: application/json
< content-length: 1599240
< connection: close
< date: Wed, 06 May 2020 23:51:55 GMT
< content-encoding: gzip
< last-modified: Wed, 06 May 2020 14:57:56 GMT
< x-amz-version-id: sXI6cOdg1mASQ0eS1Kf7peDG7hbMDlzs
< etag: "27fee4ef7a4d2abc1774aaf8d8c0befc"
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 edd6d90087c4f2b49e182778a2273adc.cloudfront.net (CloudFront)
< x-amz-cf-pop: AMS54-C1
< x-amz-cf-id: 21VQDhFpjEpjifuPRjVwIWNXXBlttWPQ_KAvc-nsECdR8Dts_Eb27g==
< age: 3060
< Vary: Accept-Encoding
<
{ [15863 bytes data]
100 1561k  100 1561k    0     0   520k      0  0:00:03  0:00:03 --:--:--  428k
* Closing connection 0
```

After:

```
curl localhost:5000/charon/getDataset?prefix=/ncov/global -H "If-None-Match: \"27fee4ef7a4d2abc1774aaf8d8c0befc\"" -H "If-Modified-Since: Wed, 06 May 2020 14:57:56 GMT" -v > dump
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 5000 (#0)
> GET /charon/getDataset?prefix=/ncov/global HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/7.55.1
> Accept: */*
> If-None-Match: "27fee4ef7a4d2abc1774aaf8d8c0befc"
> If-Modified-Since: Wed, 06 May 2020 14:57:56 GMT
>
< HTTP/1.1 304 Not Modified
< X-Powered-By: Express
< connection: close
< date: Thu, 07 May 2020 00:42:14 GMT
< x-amz-version-id: sXI6cOdg1mASQ0eS1Kf7peDG7hbMDlzs
< etag: "27fee4ef7a4d2abc1774aaf8d8c0befc"
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 4b28b963946514dd2cf9a90f74a8034a.cloudfront.net (CloudFront)
< x-amz-cf-pop: AMS54-C1
< x-amz-cf-id: Ksv1gFh6uMgE2XYhzbWYuydHK5ai8VDVf3U3d69ylTvdwl24nWx0Xg==
< age: 3020
<
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Closing connection 0
```

### Related issue(s)  
https://github.com/nextstrain/nextstrain.org/issues/150

### Testing
I think this should be fairly harmless otherwise.

### Thank you for contributing to Nextstrain!
