### PR TITLE
Link non-conda install methods to respective docs

### DIFF
--- a/static-site/content/docs/01-getting-started/04-local-installation.md
+++ b/static-site/content/docs/01-getting-started/04-local-installation.md
@@ -16,8 +16,8 @@ If you have any issues with installing Augur/Auspice using any of these methods,
 - [Install Augur & Auspice with Conda (recommended)](#install-augur--auspice-with-conda-recommended)
 - [Updating `augur`, `auspice`, and `nextstrain`:](#updating-augur-auspice-and-nextstrain)
 - [Install Augur with Python](#install-augur-with-python)
-- [Install Auspice Using npm](#install-auspice-using-npm)
 - [Install Augur from Source](#install-augur-from-source)
+- [Install Auspice Using npm](#install-auspice-using-npm)
 - [Install Auspice from Source](#install-auspice-from-source)
 
 
@@ -70,51 +70,8 @@ npm update --global auspice
 
 If you'd rather not use Conda to manage things, then you'll have to do a bit more work!
 This requires you to manage your Python installation (Python 3.4 or above is required).
-Augur's published on [PyPi](https://pypi.org/) as [nextstrain-augur](https://pypi.org/project/nextstrain-augur), so you can install it with pip like so:
 
-```
-python -m pip install nextstrain-augur
-```
-
-Test your installation.
-
-```
-augur -h
-```
-
-Augur uses some common external bioinformatics programs which you’ll need to install to have a fully functioning toolkit.
-* `augur align` requires `mafft`
-* `augur tree` requires at least one of
-  * [IQ-TREE](http://www.iqtree.org/) (used by default)
-  * [RAxML](https://sco.h-its.org/exelixis/web/software/raxml/) (optional alternative)
-  * [FastTree](http://www.microbesonline.org/fasttree/) (optional alternative)
-* Bacterial data (or any VCF usage) requires [vcftools](https://vcftools.github.io/)
-
-
-On macOS, you can install these external programs using Homebrew with:
-
-```
-brew install mafft iqtree raxml fasttree vcftools
-```
-
-On Debian/Ubuntu, you can install them via:
-
-```
-sudo apt install mafft iqtree raxml fasttree vcftools
-```
-
-Other Linux distributions will likely have the same packages available, although the names may differ slightly.
-
----
-## Install Auspice Using npm
-
-You'll need to have an installation of Node.js to install Auspice. This can be done via Conda as simply as `conda create -yn auspice nodejs=10`, or by using [nvm](https://github.com/nvm-sh/nvm) or by [installing manually](https://nodesource.com/blog/installing-node-js-tutorial-using-nvm-on-mac-os-x-and-ubuntu/).
-Once this is done (check via `node --version`), then:
-
-```
-npm install --global auspice
-auspice --help # to check things worked
-```
+Use [these instructions [external link]](https://nextstrain-augur.readthedocs.io/en/stable/installation/installation.html#using-pip-from-pypi) to install Augur with `pip` from [PyPi](https://pypi.org/project/nextstrain-augur).
 
 ---
 ## Install Augur from Source
@@ -122,51 +79,22 @@ auspice --help # to check things worked
 This is useful for debugging, modifying the source code, or using an unpublished feature branch.
 Similar to [installing Augur with python](#install-augur-with-python) you'll need a copy of python and the required dependencies.
 
-We're going to use Conda to manage environments here, but there's a number of ways you can do this.
+Use [these instructions [external link]](https://nextstrain-augur.readthedocs.io/en/stable/installation/installation.html#install-from-source) to install Augur with `pip` from [source](https://github.com/nextstrain/augur).
 
-```
-# Clone the GitHub repo
-git checkout https://github.com/nextstrain/augur.git
-cd augur
+Note that you can use `pip install .` as the final step, but this means changes to the source code won't be reflected in your `augur` version, which you probably want if you're going to the trouble of installing from source!
 
-# Make sure Python & dependencies are installed.
+---
+## Install Auspice Using npm
 
-# If you'd like to use the "Augur" pre-made Conda environment then:
-conda env create -f environment.yml
-conda activate augur
+You'll need to have an installation of Node.js to install Auspice. This can be done via Conda as simply as `conda create -yn auspice nodejs=10`, or by using [nvm](https://github.com/nvm-sh/nvm) or by [installing manually](https://nodesource.com/blog/installing-node-js-tutorial-using-nvm-on-mac-os-x-and-ubuntu/).
+Once this is done (check via `node --version`), then:
 
-# Install Augur from source
-pip install -e .[dev]
-
-# Test it works!
-augur --version
-```
-
-Note that you can use `pip install .` as the final step, but this means changes to the source code won't be reflected in your `auspice` version, which you probably want if you're going to the trouble of installing from source!
+Use [these instructions [external link]](https://nextstrain.github.io/auspice/introduction/install#install-auspice-from-npm) to install Auspice with `npm`.
 
 ---
 ## Install Auspice from Source
 
 This gives us the same advantages as installing Augur from source 😀 Note that here we're using Conda to create an "Auspice" environment with Node.js installed -- if you'd prefer to do something else then just replace those two steps.
 
-
-```
-# Use Conda to create an environment with nodejs 10
-conda create -yn auspice nodejs=10
-conda activate auspice
-
-# Grab the GitHub Auspice repo
-git checkout https://github.com/nextstrain/auspice.git
-cd auspice
-
-# Install using npm
-npm install --global .
-
-# Test it works
-auspice --version
-auspice --help
-```
-
-Auspice should now be available everywhere, as long as you're in this environment.
-At least on macOS, changes to the source code are reflected in this system-wide install.
+Use [these instructions [external link]](https://nextstrain.github.io/auspice/introduction/install#installing-from-source) to install Auspice with `npm` from [the source code on Github](https://github.com/nextstrain/auspice).
 


### PR DESCRIPTION
### Description of proposed changes    
This replaces the specific instructions of how to install augur and auspice using pip and npm respectively with links to their own documentations, so that these instructions don't become out of sync with the latest install practices for either tool. 

This is one of multiple such PRs I will be submitting as we try to deduplicate things between the nextstrain.org docs and other docs, while **aiming not to have too many links buried in text on the nextstrain.org docs such that they are not found when folks are looking for them.**

One strategy I've discussed with @jameshadfield to accomplish that aim is to (where possible) instead of replacing some chunk of text in a given document with an external link, try to break up the information in that document into seperate documents so that sections or even entire documents/pages on the nextstrain.org docs can be replaced with an external link. This allows us to prominently display that link in the sidebar hierarchy of topics and avoid burying it the document text somewhere.

The difference might look something like this, going from having links _in_ the document:

![Screen Shot 2020-05-13 at 4 14 52 PM](https://user-images.githubusercontent.com/12140437/81875341-ef121880-9534-11ea-8784-2ce802230ffe.png)

to removing those sections from the document and replacing them with links in the sidebar as subheadings of Local Installation:

![Screen Shot 2020-05-13 at 4 14 44 PM](https://user-images.githubusercontent.com/12140437/81875352-f46f6300-9534-11ea-8468-5c07d379e15e.png)

This also allows for a more straightforward swap if we want to try to inject the content from that external (e.g. auspice) document into the nextstrain.org document to improve the docs user experience.

### Testing
Just tested locally with gatsby.

### Thank you for contributing to Nextstrain!
