### PR TITLE
Check for index.html in auspice's dist dir

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const favicon = require('serve-favicon');
 const compression = require('compression');
 const argparse = require('argparse');
 const utils = require("./src/utils");
+const fs = require("fs");
 
 const production = process.env.NODE_ENV === "production";
 
@@ -140,9 +141,13 @@ const auspicePaths = [
   "/community/:user/:repo/*",
 ];
 
+const auspiceIndexPath =
+  fs.existsSync(auspiceAssetPath("dist/index.html"))
+    ? auspiceAssetPath("dist/index.html")
+    : auspiceAssetPath("index.html");
 app.route(auspicePaths).get((req, res) => {
   utils.verbose(`Sending Auspice entrypoint for ${req.originalUrl}`);
-  res.sendFile(auspiceAssetPath("index.html"));
+  res.sendFile(auspiceIndexPath);
 });
 
 /* handle redirects for inrb-drc (first of the Nextstrain groups) */


### PR DESCRIPTION
### Description of proposed changes    
Allow to serve auspice's index.html from the dist folder, this is necessary if `index.html` is a build artifact (useful for e.g. dynamic script hashes for caching)

### Related issue(s)
https://github.com/nextstrain/auspice/pull/1126

### Testing
I tested it both with master build of auspice and with proposed changed build, seems to work fine in both scenarios.

### Thank you for contributing to Nextstrain!
