### PR TITLE
Replace list of github links with link to organization contributing guide in docs

### DIFF
--- a/static-site/content/docs/05-contributing/04-development.md
+++ b/static-site/content/docs/05-contributing/04-development.md
@@ -1,5 +1,5 @@
 ---
-title: "Contributing to Augur & Auspice Development"
+title: "Contributing to Nextstrain Development"
 ---
 
 Augur, Auspice, and all other components of the Nextstrain ecosystem are 100% open-source.
@@ -11,8 +11,4 @@ We would be grateful for code contributions, as well as constructive criticism a
 A list of potential issues is being actively maintained at https://github.com/orgs/nextstrain/projects/5.
 
 
-Please see the individual GitHub repos for more information about how to set up a local development environment, developer guidelines, and lists of current issues.
-
-* [Augur GitHub repo](https://github.com/nextstrain/augur)
-* [Auspice GitHub repo](https://github.com/nextstrain/auspice)
-* [Nextstrain CLI GitHub repo](https://github.com/nextstrain/cli)
+For a comprehensive guide to contributing to all Nextstrain projects (including Augur, Auspice, and nextstrain.org) see our organization's [contributing guide on Github](https://github.com/nextstrain/.github/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
### Description of proposed changes    
Replace the [list of links to github repos for various nextstrain projects](https://nextstrain.org/docs/contributing/development) with one link to the github nextstrain organization contributing guide. It seems like a great document for this purpose, i.e. a top level guide to contributing to the various nextstrain.org projects.

### Related issue(s)  
#164 

### Testing
Locally with gatsby + testing links work.

### Thank you for contributing to Nextstrain!
