### PR TITLE
remove python listed as static site dep

### DIFF
--- a/static-site/content/docs/05-contributing/03-documentation.md
+++ b/static-site/content/docs/05-contributing/03-documentation.md
@@ -40,11 +40,10 @@ While this isn't strictly necessary, you could just edit the Markdown files and 
 
 Prerequisites:
 * `nodejs` version 10
-* `python` version 2.7
 
 If you use `conda` you can grab these via
 ```
-conda create -n nextstrain.org nodejs=10 python=2.7
+conda create -n nextstrain.org nodejs=10
 ```
 
 


### PR DESCRIPTION
### Description of proposed changes    
We no longer need python to build the static site so this removes it from the build instructions

### Related issue(s)  
#172 
