### PR TITLE
Add page where you can search samples across datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ scratch
 
 # local sessions
 /sessions/
+
+# generated data
+/data

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Please see [the auspice documentation](https://nextstrain.github.io/auspice/cust
 
 ### Testing locally
 Make sure you've installed dependencies with `npm install` first (and activated your conda environment if using one).
+
+If you have AWS credentials make sure they are set as environment variables (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).
+These are not necessary, but some functionality will be missing if these aren't available.
+
 Then run:
 
 ```bash

--- a/build.sh
+++ b/build.sh
@@ -20,8 +20,11 @@ main() {
             build-static;;
         auspice)
             build-auspice;;
+        generate-data)
+            generate-data;;
         all)
             echo "Running the nextstrain.org build script"
+            generate-data # must come before build-static, as that depends on output from this
             build-static
             build-auspice
             echo "Build complete. Next step: \"npm run server\"";;
@@ -44,6 +47,11 @@ build-auspice() {
     cd auspice-client
     ../node_modules/.bin/auspice build --verbose --extend ./customisations/config.json
     cd ..
+}
+
+generate-data() {
+    echo "Running scripts to generate data at start time"
+    node scripts/collect-strains-sars-cov-2.js
 }
 
 main "$@"

--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,7 @@ build-auspice() {
 generate-data() {
     echo "Running scripts to generate data at start time"
     node scripts/collect-strains-sars-cov-2.js
+    node scripts/collect-exclusions-sars-cov-2.js
 }
 
 main "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8532,11 +8532,11 @@
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
     "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.1.tgz",
+      "integrity": "sha512-mw/p92EyOzl2MhauKodw54Rx5ZK4624rNfgNaBguFZkHzyUG9WsDzFF5/yQVEJinbJDdP4jEfMN+uBquiGnaLg==",
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
@@ -8545,6 +8545,21 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
         "p-limit": "^1.1.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        }
       }
     },
     "p-map": {
@@ -8564,9 +8579,9 @@
       }
     },
     "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pako": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "make-fetch-happen": "^7.1.1",
     "marked": "^0.7.0",
     "node-fetch": "^2.6.0",
+    "p-limit": "^3.0.1",
     "passport": "^0.4.0",
     "passport-oauth2": "^1.5.0",
     "query-string": "^4.2.3",

--- a/scripts/collect-exclusions-sars-cov-2.js
+++ b/scripts/collect-exclusions-sars-cov-2.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+const fetch = require("node-fetch");
+const fs = require('fs');
+
+(async () => {
+  let exclude = await fetch("https://raw.githubusercontent.com/nextstrain/ncov/master/config/exclude.txt");
+  exclude = await exclude.text();
+  exclude = exclude.split("\n")
+    .reduce(
+      (state, currentLine) => {
+        /* The text file has no schema for associating comments explaining why a sequence is excluded
+        to the strains themselves. It's mostly obvious to humans, but hard to code.
+        The approach employed here is a heuristic based on what's been added so far (~800 lines).
+        A "reason" is a commented line with more than one word (so that we ignore a commented sample name)
+        and this reason is associated with the next block of text that's _not_ interrupted by a new line.
+        That is, a new line resets any assoication between a "reason" and subsequent sample names. */
+        if (currentLine === '') {
+          state.currentReason = '';
+          return state;
+        }
+        if (currentLine.startsWith('#')) {
+          const uncommented = currentLine.replace(/^#\s*/, '');
+          if ((uncommented.match(/\s+/g)||[]).length>0 && !state.currentReason) {
+            state.currentReason = uncommented;
+          }
+          // else it looks like a commented strain name, or a subsequent comment in a block -- do nothing!
+          return state;
+        }
+        if (!currentLine.match(/\s+/g)) {
+          state.excludeMap[currentLine] = state.currentReason || 'unknown reason';
+          return state;
+        }
+        console.log("Unparsed exclude.txt line: ", currentLine);
+        return state;
+      },
+      {excludeMap: {}, currentReason: ''}
+    );
+  if (!fs.existsSync("./data")) fs.mkdirSync("./data");
+  fs.writeFileSync("./data/ncov-excluded-strains.json", JSON.stringify(exclude.excludeMap, null, 0));
+})();

--- a/scripts/collect-exclusions-sars-cov-2.js
+++ b/scripts/collect-exclusions-sars-cov-2.js
@@ -4,6 +4,7 @@ const fetch = require("node-fetch");
 const fs = require('fs');
 
 (async () => {
+  console.log(`Fetching the SARS-CoV-2 exclude-list...`);
   let exclude = await fetch("https://raw.githubusercontent.com/nextstrain/ncov/master/config/exclude.txt");
   exclude = await exclude.text();
   exclude = exclude.split("\n")

--- a/scripts/collect-strains-sars-cov-2.js
+++ b/scripts/collect-strains-sars-cov-2.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+const AWS = require("aws-sdk");
+const fetch = require("node-fetch");
+const fs = require('fs');
+
+const collectStrainNames = (name, json) => {
+  const strains = [];
+  const recurse = (node) => {
+    if (node.children) {
+      for (let i=0; i<node.children.length; i++) recurse(node.children[i]);
+    } else {
+      strains.push(node.name);
+    }
+  };
+  try {
+    recurse(json.tree);
+  } catch (err) {
+    console.log(`Error collecting strain names for ${name}`);
+    return [];
+  }
+  return strains;
+};
+
+(async () => {
+  const S3 = new AWS.S3();
+  const BUCKET = `nextstrain-staging`;
+  const NEXTSTRAIN_URL_PREFIX = `https://nextstrain.org/staging/`;
+  let s3Objects;
+  try {
+    s3Objects = await S3.listObjectsV2({Bucket: BUCKET}).promise();
+  } catch (err) {
+    console.log("Error listing objects via the S3 API -- were credentials correctly set?");
+    console.log(err.message);
+    process.exit(2);
+  }
+  if (s3Objects.isTruncated) console.log("WARNING: S3 listing is truncated. Results will be incomplete.");
+  s3Objects = s3Objects.Contents
+    .filter((s3obj) => {
+      if (!s3obj.Key.endsWith(".json")) return false;
+      if (s3obj.Key.endsWith("_meta.json") || s3obj.Key.endsWith("_tree.json")) return false;
+      if (s3obj.Key.endsWith("_frequencies.json")) return false;
+      if (s3obj.Key.endsWith("_tip-frequencies.json")) return false;
+      if (s3obj.Key.endsWith("_sequences.json")) return false;
+      if (s3obj.Key.endsWith("_entropy.json")) return false;
+      if (s3obj.Key.endsWith("_root-sequence.json")) return false;
+      return true;
+    })
+    .filter((s3obj) => {
+      return s3obj.Key.startsWith("ncov_");
+    }); // .filter((_, i) => i<10);
+  s3Objects = await Promise.all(s3Objects.map(async (s3obj) => {
+    const dataset = await fetch(`https://${BUCKET}.s3.amazonaws.com/${s3obj.Key}`).then((res) => res.json());
+    s3obj.strains = collectStrainNames(s3obj.Key, dataset);
+    console.log(s3obj.Key, s3obj.strains.length);
+    return s3obj;
+  }));
+  s3Objects = s3Objects.sort((a, b) => b.LastModified-a.LastModified);
+  const {datasets, strainMap} = s3Objects.reduce((acc, s3obj, idx) => {
+    acc.datasets.push({
+      lastModified: s3obj.LastModified.toISOString().split("T")[0],
+      filename: s3obj.Key,
+      nGenomesInDataset: s3obj.strains.length,
+      url: `${NEXTSTRAIN_URL_PREFIX}${s3obj.Key.replace('.json', '').replace('_', '/')}`
+    });
+    s3obj.strains.forEach((name) => {
+      if (acc.strainMap[name]) acc.strainMap[name].push(idx);
+      else acc.strainMap[name] = [idx];
+    });
+    return acc;
+  }, {datasets: [], strainMap: {}});
+  if (!fs.existsSync("./data")) fs.mkdirSync("./data");
+  fs.writeFileSync("./data/ncov-strains-to-datasets.json", JSON.stringify({datasets, strainMap}, null, 0));
+})();
+

--- a/scripts/collect-strains-sars-cov-2.js
+++ b/scripts/collect-strains-sars-cov-2.js
@@ -24,15 +24,16 @@ const collectStrainNames = (name, json) => {
 
 (async () => {
   const S3 = new AWS.S3();
-  const BUCKET = `nextstrain-staging`;
-  const NEXTSTRAIN_URL_PREFIX = `https://nextstrain.org/staging/`;
+  const BUCKET = `nextstrain-data`;
+  const NEXTSTRAIN_URL_PREFIX = `https://nextstrain.org/`;
+  console.log(`Collecting datasets from ${BUCKET} to link sample names -> datasets...`);
   let s3Objects;
   try {
     s3Objects = await S3.listObjectsV2({Bucket: BUCKET}).promise();
   } catch (err) {
     console.log("Error listing objects via the S3 API -- were credentials correctly set?");
     console.log(err.message);
-    process.exit(2);
+    process.exit(0); // exit zero so the build script doesn't fail causing the site to not be deployed.
   }
   if (s3Objects.isTruncated) console.log("WARNING: S3 listing is truncated. Results will be incomplete.");
   s3Objects = s3Objects.Contents
@@ -69,7 +70,8 @@ const collectStrainNames = (name, json) => {
     });
     return acc;
   }, {datasets: [], strainMap: {}});
+  const dateUpdated = (new Date()).toISOString().split("T")[0];
   if (!fs.existsSync("./data")) fs.mkdirSync("./data");
-  fs.writeFileSync("./data/ncov-strains-to-datasets.json", JSON.stringify({datasets, strainMap}, null, 0));
+  fs.writeFileSync("./data/ncov-strains-to-datasets.json", JSON.stringify({datasets, strainMap, dateUpdated}, null, 0));
 })();
 

--- a/static-site/gatsby-node.js
+++ b/static-site/gatsby-node.js
@@ -199,6 +199,12 @@ exports.createPages = ({graphql, actions}) => {
           component: path.resolve("src/pages/ncov-sit-reps.jsx")
         });
 
+        // Create page listing all sequences and which datasets they're included in
+        createPage({
+          path: "/ncov-sequence-to-dataset",
+          component: path.resolve("src/pages/ncov-sequence-to-dataset.jsx")
+        });
+
       })
     );
   });

--- a/static-site/gatsby-node.js
+++ b/static-site/gatsby-node.js
@@ -201,8 +201,8 @@ exports.createPages = ({graphql, actions}) => {
 
         // Create page listing all sequences and which datasets they're included in
         createPage({
-          path: "/ncov-sequence-to-dataset",
-          component: path.resolve("src/pages/ncov-sequence-to-dataset.jsx")
+          path: "/sars-cov-2-sequence-search",
+          component: path.resolve("src/pages/sars-cov-2-sequence-search.jsx")
         });
 
       })

--- a/static-site/package-lock.json
+++ b/static-site/package-lock.json
@@ -1015,6 +1015,87 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "requires": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "@emotion/core": {
+      "version": "10.0.28",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.28.tgz",
+      "integrity": "sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "requires": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "requires": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      }
+    },
+    "@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -3009,6 +3090,23 @@
       "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
       "requires": {
         "object.assign": "^4.1.0"
+      }
+    },
+    "babel-plugin-emotion": {
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
       }
     },
     "babel-plugin-extract-import-names": {
@@ -8428,6 +8526,11 @@
         "pkg-dir": "^3.0.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -13739,6 +13842,11 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -17317,6 +17425,14 @@
         "camelcase": "^5.0.0"
       }
     },
+    "react-input-autosize": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
+      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -17353,6 +17469,21 @@
         "prop-types": "^15.5.10"
       }
     },
+    "react-select": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.1.0.tgz",
+      "integrity": "sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/cache": "^10.0.9",
+        "@emotion/core": "^10.0.9",
+        "@emotion/css": "^10.0.9",
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.0",
+        "react-input-autosize": "^2.2.2",
+        "react-transition-group": "^4.3.0"
+      }
+    },
     "react-share": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/react-share/-/react-share-1.19.1.tgz",
@@ -17370,6 +17501,28 @@
       "integrity": "sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==",
       "requires": {
         "shallowequal": "^1.0.1"
+      }
+    },
+    "react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "dom-helpers": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.4.tgz",
+          "integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
+          "requires": {
+            "@babel/runtime": "^7.8.7",
+            "csstype": "^2.6.7"
+          }
+        }
       }
     },
     "react-tweet-embed": {

--- a/static-site/package.json
+++ b/static-site/package.json
@@ -63,6 +63,7 @@
     "react-helmet": "^5.2.1",
     "react-icons": "^3.10.0",
     "react-scrollable-anchor": "^0.6.1",
+    "react-select": "^3.1.0",
     "react-share": "^1.15.1",
     "react-tweet-embed": "^1.1.0",
     "react-twitter-widgets": "^1.4.0",

--- a/static-site/src/pages/ncov-sequence-to-dataset.jsx
+++ b/static-site/src/pages/ncov-sequence-to-dataset.jsx
@@ -1,0 +1,140 @@
+import React from "react";
+import Helmet from "react-helmet";
+import Select, {createFilter} from 'react-select';
+import styled from 'styled-components';
+import {FaFile} from "react-icons/fa";
+import config from "../../data/SiteConfig";
+import NavBar from '../components/nav-bar';
+import MainLayout from "../components/layout";
+import UserDataWrapper from "../layouts/userDataWrapper";
+import { SmallSpacer, MediumSpacer, HugeSpacer, FlexCenter } from "../layouts/generalComponents";
+import * as splashStyles from "../components/splash/styles";
+import Footer from "../components/Footer";
+import {datasets, strainMap} from "../../../data/ncov-strains-to-datasets.json";
+
+
+/**
+ * See https://github.com/JedWatson/react-select/issues/3128 for ways to speed up <Select>
+ */
+
+const selectableStrains = Object.keys(strainMap).map((s) => ({value: strainMap[s], label: s})); // .filter((_, i) => i<10);
+
+class SequencesToDatasets extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {selected: []};
+    this.onSelectChange = this.onSelectChange.bind(this);
+  }
+  onSelectChange(inputValue, { action }) {
+    // see https://react-select.com/advanced
+    // console.log(inputValue, action);
+    switch (action) {
+      case 'select-option': // fallthrough
+      case 'remove-value':
+        this.setState({ selected: inputValue });
+        break;
+      case 'clear':
+        this.setState({ selected: [] });
+        break;
+      default:
+        console.error("Unhandled <Select> event", action);
+    }
+  }
+
+  render() {
+    return (
+      <MainLayout>
+        <div className="index-container">
+          <Helmet title={config.siteTitle} />
+          <main>
+
+            <UserDataWrapper>
+              <NavBar location={this.props.location} />
+            </UserDataWrapper>
+
+            <splashStyles.Container className="container">
+              <HugeSpacer />
+              <splashStyles.H2>
+                Search nCoV datasets by sample name
+              </splashStyles.H2>
+              <SmallSpacer />
+              <FlexCenter>
+                <splashStyles.CenteredFocusParagraph theme={{niceFontSize: "14px"}}>
+                  This is a prototype of how we can find which datasets a particular sample appears in.
+                  Limitations: currently it scans the datasets in the staging bucket and the scan is only done
+                  when the server starts up.
+                </splashStyles.CenteredFocusParagraph>
+              </FlexCenter>
+              <div className="row">
+                <MediumSpacer />
+                <div className="col-md-1"/>
+                <div className="col-md-10">
+                  <HugeSpacer/>
+                  <Select
+                    options={selectableStrains}
+                    openMenuOnClick={false}
+                    filterOption={createFilter({ignoreAccents: false})}
+                    isClearable
+                    isMulti
+                    onChange={this.onSelectChange}
+                  />
+                  <HugeSpacer/>
+                  <DatasetsWithSequence selected={this.state.selected}/>
+                </div>
+              </div>
+
+              <Footer />
+
+            </splashStyles.Container>
+          </main>
+        </div>
+      </MainLayout>
+    );
+  }
+}
+
+const Ul = styled.ul`
+  font-size: 16px;
+  line-height: 1.7;
+  list-style: none;
+`;
+
+function DatasetsWithSequence({selected}) {
+  if (!selected || !selected.length) return null;
+  if (selected.length === 1) {
+    return (
+      <div>
+        <h3>{`Sample "${selected[0].label}" appears in ${selected[0].value.length} datasets`}</h3>
+        <Ul>
+          {selected[0].value.map((datasetIdx) => {
+            const d = datasets[datasetIdx];
+            return (
+              <li key={d.filename}><a href={d.url}><FaFile />{" "+d.filename.replace(".json", "").replace("_", " / ")}</a>{` (last modified ${d.lastModified})`}</li>
+            );
+          })}
+        </Ul>
+      </div>
+    );
+  }
+  // else we want to find datsets which have all strains
+  const datasetIndicies = selected.map((s) => s.value);
+  const intersectedIndicies = datasetIndicies.reduce((a, b) => a.filter(c => b.includes(c)));
+  return (
+    <div>
+      <h3>{`The ${selected.length} samples appear (together) in ${intersectedIndicies.length} datasets`}</h3>
+      <h4>{selected.map((s) => s.label).join(", ")}</h4>
+      <Ul>
+        {intersectedIndicies.map((datasetIdx) => {
+          const d = datasets[datasetIdx];
+          return (
+            <li key={d.filename}><a href={d.url}><FaFile />{" "+d.filename.replace(".json", "").replace("_", " / ")}</a>{` (last modified ${d.lastModified})`}</li>
+          );
+        })}
+      </Ul>
+    </div>
+  );
+}
+
+
+export default SequencesToDatasets;
+

--- a/static-site/src/pages/sars-cov-2-sequence-search.jsx
+++ b/static-site/src/pages/sars-cov-2-sequence-search.jsx
@@ -19,10 +19,10 @@ import Footer from "../components/Footer";
 those which are either included in a dataset or included in the exclude list. (Or both!).
 In the future this could be a file fetch / GraphQL logic and part of the react component.
 There are plenty of improvements, but this is the simplest to begin with */
-let [selectableStrains, datasets, nSamplesInDatasets, nSamplesInExcludeList, nDatasets] = [[], [], 0, 0, 0];
+let [selectableStrains, datasets, nSamplesInDatasets, nSamplesInExcludeList, nDatasets, dateUpdated] = [[], [], 0, 0, 0, "unknown"];
 try {
   let strainMap;
-  ({datasets, strainMap} = require("../../../data/ncov-strains-to-datasets.json")); // eslint-disable-line
+  ({datasets, strainMap, dateUpdated} = require("../../../data/ncov-strains-to-datasets.json")); // eslint-disable-line
   nDatasets = datasets.length;
   nSamplesInDatasets = Object.keys(strainMap).length;
   const excludeMap = require("../../../data/ncov-excluded-strains.json"); // eslint-disable-line
@@ -41,6 +41,18 @@ try {
 } catch (err) {
   console.error("Error fetching / parsing data.", err.message);
 }
+
+
+const Ul = styled.ul`
+  font-size: 16px;
+  line-height: 1.7;
+  list-style: none;
+`;
+
+const Excluded = styled.div`
+  font-size: 18px;
+  color: red;
+`;
 
 class SequencesToDatasets extends React.Component {
   constructor(props) {
@@ -78,7 +90,7 @@ class SequencesToDatasets extends React.Component {
             <splashStyles.Container className="container">
               <HugeSpacer />
               <splashStyles.H2>
-                Search nCoV datasets by sample name
+                Search SARS-CoV-2 datasets by sample name
               </splashStyles.H2>
               <SmallSpacer />
               <FlexCenter>
@@ -88,16 +100,20 @@ class SequencesToDatasets extends React.Component {
                   will be shown. Additionally, if we have deliberately excluded a sample from the analysis we will attempt
                   to show the reason here.
                   <br/><br/>
-                  Current Limitations: Looking at datasets on the staging server. Data only regenerated when the server restarts.
-                  <br/><br/>
-                  Current database: {nSamplesInDatasets} samples, from {nDatasets} datasets on the staging bucket.
+                  Current database: {nSamplesInDatasets} samples, from {nDatasets} datasets on the core nextstrain bucket.
+                  <br/>
                   Additionally, {nSamplesInExcludeList} samples from our manually curated exclusion list are included.
+                  <br/>
+                  Data updated: {dateUpdated}
                 </splashStyles.CenteredFocusParagraph>
               </FlexCenter>
               <div className="row">
                 <MediumSpacer />
                 <div className="col-md-1"/>
                 <div className="col-md-10">
+                  {(nSamplesInDatasets===0 || nSamplesInExcludeList===0) && (
+                    <Excluded>There appears to have been a problem fetching the data for this page. Results, if any, may be incorrect!</Excluded>
+                  )}
                   <HugeSpacer/>
                   <Select
                     options={selectableStrains}
@@ -122,17 +138,6 @@ class SequencesToDatasets extends React.Component {
     );
   }
 }
-
-const Ul = styled.ul`
-  font-size: 16px;
-  line-height: 1.7;
-  list-style: none;
-`;
-
-const Excluded = styled.div`
-  font-size: 18px;
-  color: red;
-`;
 
 function InfoAboutSequence({selected}) {
   if (!selected || !selected.length) return null;


### PR DESCRIPTION
This introduces functionality which we've talked about previously but was sorely needed by me today! It works, but there are plenty of optimisations and improvements we could make. Consider this a Friday afternoon project (which is what it was). 

During `npm run build` we scan all the nCoV datasets (currently looking at the staging bucket) and generate a git-ignored JSON file mapping the sample names to which dataset they appear in.

A new page /ncov-sequence-to-dataset provides a search box For a single sample name, you'll get a chronological list of datasets which it appears in. For multiple samples, you'll get a list of datasets where they all appear together.

Limitations:
* React Select is slow with this many items
* The JSON file is only regenerated when the server restarts (when `npm run build` is run)
* Currently looking at the staging bucket only
* Styling needs improvement

Needs some more testing but works for the ones I was looking at so far. 


![image](https://user-images.githubusercontent.com/8350992/85112703-29748100-b26a-11ea-8f8f-a3b741fd501d.png)
![image](https://user-images.githubusercontent.com/8350992/85112747-385b3380-b26a-11ea-83c1-bf935fcb282e.png)
![image](https://user-images.githubusercontent.com/8350992/85112918-88d29100-b26a-11ea-815b-fb2b2d70334d.png)


