### PR TITLE
S3Source: return `group-logo.png` as avatar if found in S3 bucket

### DIFF
--- a/src/sources.js
+++ b/src/sources.js
@@ -326,7 +326,23 @@ class S3Source extends Source {
   async getInfo() {
     try {
       /* attempt to fetch customisable information from S3 bucket */
-      throw new Error();
+      const objects = await this._listObjects();
+      const objectKeys = objects.map((object) => object.Key);
+
+      let logoSrc;
+      if (objectKeys.includes("logo.png")) {
+        const logo = await S3.getObject({ Bucket: this.bucket, Key: "logo.png"}).promise();
+        logoSrc = "data:image/png;base64," + logo.Body.toString("base64");
+      }
+
+      return {
+        title: `"${this.name}" Nextstrain group`,
+        byline: `The available datasets and narratives in this group are listed below.`,
+        showDatasets: true,
+        showNarratives: true,
+        avatar: logoSrc
+      };
+
     } catch (err) {
       /* Appropriate fallback if no customised data is available */
       return {

--- a/src/sources.js
+++ b/src/sources.js
@@ -338,8 +338,8 @@ class S3Source extends Source {
       const objectKeys = objects.map((object) => object.Key);
 
       let logoSrc;
-      if (objectKeys.includes("logo.png")) {
-        const logo = await this.getAndDecompressObject("logo.png");
+      if (objectKeys.includes("group-logo.png")) {
+        const logo = await this.getAndDecompressObject("group-logo.png");
         logoSrc = "data:image/png;base64," + logo.toString("base64");
       }
 


### PR DESCRIPTION
### Description of proposed changes    
This will allow Nextstrain groups to customize their logo/avatar on
the groups splash page by uploading `logo.png` to their S3 bucket.

### Testing
I've added `logo.png` for SeattleFlu, which can be seen at `localhost:5000/groups/seattleflu`

### Thank you for contributing to Nextstrain!
