### PR TITLE
Fix links to discussion.nextstrain.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Current (master branch) travis status:[![Build Status](https://travis-ci.com/nex
 # Nextstrain.org
 
 Nextstrain is an open-source project to harness the scientific and public health potential of pathogen genome data. We provide a continually-updated view of publicly available data alongside powerful analytic and visualization tools for use by the community. Our goal is to aid epidemiological understanding and improve outbreak response.
-If you have any questions, or simply want to say hi, please give us a shout at hello@nextstrain.org or introduce yourself at [discussion.nextstrain.org](discussion.nextstrain.org).
+If you have any questions, or simply want to say hi, please give us a shout at hello@nextstrain.org or introduce yourself at [discussion.nextstrain.org](https://discussion.nextstrain.org).
 
 > We have received a number of generous offers to contribute front-end developer effort to nextstrain (and auspice) folowing our work on [SARS-CoV-2](https://nextstrain.org/ncov).
 We would be grateful for code contributions, as well as constructive criticism and advice.

--- a/static-site/content/docs/01-getting-started/01-introduction.md
+++ b/static-site/content/docs/01-getting-started/01-introduction.md
@@ -3,7 +3,7 @@ title: "Nextstrain: analysis and visualization of pathogen sequence data"
 ---
 
 Nextstrain is an open-source project to harness the scientific and public health potential of pathogen genome data. We provide a continually-updated view of publicly available data with powerful analytics and visualizations showing pathogen evolution and epidemic spread. Our goal is to aid epidemiological understanding and improve outbreak response.
-If you have any questions, or simply want to say hi, please give us a shout at [hello@nextstrain.org](mailto:hello@nextstrain.org) or introduce yourself at discussion.nextstrain.org.
+If you have any questions, or simply want to say hi, please give us a shout at [hello@nextstrain.org](mailto:hello@nextstrain.org) or introduce yourself at [discussion.nextstrain.org](https://discussion.nextstrain.org).
 
 
 **These docs describe using the components behind nextstrain to run your own analysis, which you can choose to share through nextstrain.org.**
@@ -80,7 +80,7 @@ Additionally, we have open-sourced all the tools we use, and hope to create a co
 ### Contact us
 
 We are keen to keep expanding the scope of Nextstrain and empowering other researchers to better analyze and understand their data.
-Please [get in touch with us](mailto:hello@nextstrain.org) if you have questions or comments, or create a post at [discussion.nextstrain.org](discussion.nextstrain.org).
+Please [get in touch with us](mailto:hello@nextstrain.org) if you have questions or comments, or create a post at [discussion.nextstrain.org](https://discussion.nextstrain.org).
 
 ---
 ### Publication

--- a/static-site/content/docs/01-getting-started/02-quickstart.md
+++ b/static-site/content/docs/01-getting-started/02-quickstart.md
@@ -4,7 +4,7 @@ title: Quickstart
 
 This guide uses the [Nextstrain command-line interface (CLI) tool [GitHub]](https://github.com/nextstrain/cli) to help you get started running and viewing the pathogen builds you see on nextstrain.org.
 It assumes you are comfortable using the command line and installing software on your computer.
-If you need help when following this guide, please reach out by [emailing us](mailto:hello@nextstrain.org?subject=Quickstart%20help), or create a post at [discussion.nextstrain.org](discussion.nextstrain.org).
+If you need help when following this guide, please reach out by [emailing us](mailto:hello@nextstrain.org?subject=Quickstart%20help), or create a post at [discussion.nextstrain.org](https://discussion.nextstrain.org).
 
 When you're done following this guide, you will have built a local version of [our example Zika analysis](https://github.com/nextstrain/zika-tutorial) and viewed the results on your computer.
 You'll have a basic understanding of how to run builds for other pathogens and a foundation for understanding the Nextstrain ecosystem in more depth.

--- a/static-site/content/docs/01-getting-started/05-container-installation.md
+++ b/static-site/content/docs/01-getting-started/05-container-installation.md
@@ -93,7 +93,7 @@ All good!
 
 If the final message doesn't indicate success (as with "All good!" in the
 example above), something may be wrong with your Docker installation.
-Please get in touch with us [via email](mailto:hello@nextstrain.org) or create a post at [discussion.nextstrain.org](discussion.nextstrain.org) if this is the case!
+Please get in touch with us [via email](mailto:hello@nextstrain.org) or create a post at [discussion.nextstrain.org](https://discussion.nextstrain.org) if this is the case!
 
 ---
 ## Usage

--- a/static-site/content/help/01-general/01-about-nextstrain.md
+++ b/static-site/content/help/01-general/01-about-nextstrain.md
@@ -3,7 +3,7 @@ title: "Nextstrain: analysis and visualization of pathogen sequence data"
 ---
 
 Nextstrain is an open-source project to harness the scientific and public health potential of pathogen genome data. We provide a continually-updated view of publicly available data with powerful analytics and visualizations showing pathogen evolution and epidemic spread. Our goal is to aid epidemiological understanding and improve outbreak response.
-If you have any questions, or simply want to say hi, please give us a shout at [hello@nextstrain.org](mailto:hello@nextstrain.org) or introduce yourself at discussion.nextstrain.org.
+If you have any questions, or simply want to say hi, please give us a shout at [hello@nextstrain.org](mailto:hello@nextstrain.org) or introduce yourself at [discussion.nextstrain.org](https://discussion.nextstrain.org).
 
 
 #### Table of Contents:
@@ -48,7 +48,7 @@ Additionally, we have open-sourced all the tools we use, and hope to create a co
 ### Contact us
 
 We are keen to keep expanding the scope of Nextstrain and empowering other researchers to better analyze and understand their data.
-Please [get in touch with us](mailto:hello@nextstrain.org) if you have questions or comments, or create a post at [discussion.nextstrain.org](discussion.nextstrain.org).
+Please [get in touch with us](mailto:hello@nextstrain.org) if you have questions or comments, or create a post at [discussion.nextstrain.org](https://discussion.nextstrain.org).
 
 ---
 ### Publication


### PR DESCRIPTION
These have to be absolute links because they are not relative to nextstrain.org/.
