### PR TITLE
Update build ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - "10"
   - "12"
 install:
-  - npm install
+  - npm ci
 script:
   - npm run build
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: node_js
 sudo: false
 dist: bionic
 node_js:
-  - "10"
-  - "12"
+  - "13.6"
 install:
   - npm ci
 script:

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ This repository provides the tools you need to [build nextstrain.org locally](#b
 ### Install prerequisites
 Install the node dependencies by running
 ```
-npm install
+npm ci
 ```
 from this directory (the "nextstrain.org" directory).
+
+> Using `npm ci` instead of `npm install` ensures your dependency tree matches those in `package-lock.json`.
 
 
 ### Build locally mirroring the deployed (live) website
@@ -54,7 +56,7 @@ The auspice customisations specific to nextstrain.org are found in `./auspice-cl
 Please see [the auspice documentation](https://nextstrain.github.io/auspice/customise-client/introduction) for more information on customising auspice.
 
 ### Testing locally
-Make sure you've installed dependencies with `npm install` first (and activated your conda environment if using one).
+Make sure you've installed dependencies with `npm ci` first (and activated your conda environment if using one).
 
 If you have AWS credentials make sure they are set as environment variables (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).
 These are not necessary, but some functionality will be missing if these aren't available.

--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ main() {
 build-static() {
     echo "Building the static site (./static-site/public/)"
     cd static-site
-    npm install # this needs python 2
+    npm ci
     npm run build # build using gatsby. Can take a few minutes.
     cd ..
 }

--- a/static-site/package.json
+++ b/static-site/package.json
@@ -11,8 +11,8 @@
   "license": "MIT",
   "main": "n/a",
   "engines": {
-    "node": "9.6.x",
-    "npm": "5.6.x"
+    "node": "13.6.x",
+    "npm": "6.13.x"
   },
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
1. We use npm to install project dependencies in two places: the root level and within the `static-site` directory (via `build.sh` or `npm run build`). Moving to `npm ci` allows (a) developers to all be working from the same deterministic set of dependencies and (b) the automatic deploys (heroku, travis) to use the same dependencies as us.

2. This updates travisCI to use the version specified in package.json, which heroku will run. This results in a CI which better matches our actual deploy environment.
Also changed the `engines` declaration of the static-site to match the root level declaration (I don't believe anything was / is using the static-site engines declaration, but it should match the root level as we are running both from the same environment).