### PR TITLE
Document required cores argument for snakemake and nextstrain build

### DIFF
--- a/static-site/content/docs/01-getting-started/02-quickstart.md
+++ b/static-site/content/docs/01-getting-started/02-quickstart.md
@@ -117,9 +117,9 @@ After unzipping the snapshot, you'll need to rename the resulting `zika-tutorial
 
 Nextstrain builds use the [Augur bioinformatics toolkit](/docs/bioinformatics) to subsample data, align sequences, build a phylogeny, estimate phylogeographic patterns, and save the results in a format suitable for [visualization with Auspice](/docs/interpretation).
 
-Run `nextstrain build zika-tutorial/` to run the build:
+Run `nextstrain build zika-tutorial/ --cores 1` to run the build:
 
-    $ nextstrain build zika-tutorial/
+    $ nextstrain build zika-tutorial/ --cores 1
     Building DAG of jobs...
     […a lot of output…]
 

--- a/static-site/content/docs/01-getting-started/02-quickstart.md
+++ b/static-site/content/docs/01-getting-started/02-quickstart.md
@@ -117,9 +117,9 @@ After unzipping the snapshot, you'll need to rename the resulting `zika-tutorial
 
 Nextstrain builds use the [Augur bioinformatics toolkit](/docs/bioinformatics) to subsample data, align sequences, build a phylogeny, estimate phylogeographic patterns, and save the results in a format suitable for [visualization with Auspice](/docs/interpretation).
 
-Run `nextstrain build zika-tutorial/ --cores 1` to run the build:
+Run `nextstrain build --cpus 1 zika-tutorial/` to run the build:
 
-    $ nextstrain build zika-tutorial/ --cores 1
+    $ nextstrain build --cpus 1 zika-tutorial/
     Building DAG of jobs...
     […a lot of output…]
 

--- a/static-site/content/docs/02-bioinformatics/02-what-is-a-build.md
+++ b/static-site/content/docs/02-bioinformatics/02-what-is-a-build.md
@@ -32,7 +32,7 @@ While it is possible to run a build by running each of the individual steps, we 
 [Snakemake](https://snakemake.readthedocs.io/en/stable/index.html) is "a tool to create reproducible and scalable data analyses... via a human-readable, Python-based language."
 
 > Snakemake is installed as part of the [conda environment](/docs/getting-started/local-installation#install-augur--auspice-with-conda-recommended) or the [docker container](/docs/getting-started/container-installation#install-docker).
-If you ever see a build which has a "Snakefile" then you can run this by typing `snakemake` or `nextstrain build .`, respectively.
+If you ever see a build which has a "Snakefile" then you can run this by typing `snakemake --cores 1` or `nextstrain build . --cores 1`, respectively.
 
 
 ### Next steps

--- a/static-site/content/docs/02-bioinformatics/02-what-is-a-build.md
+++ b/static-site/content/docs/02-bioinformatics/02-what-is-a-build.md
@@ -32,7 +32,7 @@ While it is possible to run a build by running each of the individual steps, we 
 [Snakemake](https://snakemake.readthedocs.io/en/stable/index.html) is "a tool to create reproducible and scalable data analyses... via a human-readable, Python-based language."
 
 > Snakemake is installed as part of the [conda environment](/docs/getting-started/local-installation#install-augur--auspice-with-conda-recommended) or the [docker container](/docs/getting-started/container-installation#install-docker).
-If you ever see a build which has a "Snakefile" then you can run this by typing `snakemake --cores 1` or `nextstrain build . --cores 1`, respectively.
+If you ever see a build which has a "Snakefile" then you can run this by typing `snakemake --cores 1` or `nextstrain build --cpus 1 .`, respectively.
 
 
 ### Next steps

--- a/static-site/content/docs/03-tutorials/01-zika.md
+++ b/static-site/content/docs/03-tutorials/01-zika.md
@@ -262,13 +262,13 @@ rm -rf results/ auspice/
 
 If you've installed Augur & Auspice, simply run
 ```
-snakemake
+snakemake --cores 1
 ```
 
 or, if you're using the Nextstrain CLI tool, run:
 
 ```
-nextstrain build .
+nextstrain build . --cores 1
 ```
 
 which will run the automated pathogen build.
@@ -277,7 +277,7 @@ View the results the same way you did before to confirm it produced the same Zik
 
 Note that automated builds will only re-run steps when the data changes.
 This means builds will pick up where they left off if they are restarted after being interrupted.
-If you want to force a re-run of the whole build, first remove any previous output with `snakemake clean` or `nextstrain build . clean`.
+If you want to force a re-run of the whole build, first remove any previous output with `snakemake --cores 1 clean` or `nextstrain build . --cores 1 clean`.
 
 ## Next steps
 

--- a/static-site/content/docs/03-tutorials/01-zika.md
+++ b/static-site/content/docs/03-tutorials/01-zika.md
@@ -268,7 +268,7 @@ snakemake --cores 1
 or, if you're using the Nextstrain CLI tool, run:
 
 ```
-nextstrain build . --cores 1
+nextstrain build --cpus 1 .
 ```
 
 which will run the automated pathogen build.
@@ -277,7 +277,7 @@ View the results the same way you did before to confirm it produced the same Zik
 
 Note that automated builds will only re-run steps when the data changes.
 This means builds will pick up where they left off if they are restarted after being interrupted.
-If you want to force a re-run of the whole build, first remove any previous output with `snakemake --cores 1 clean` or `nextstrain build . --cores 1 clean`.
+If you want to force a re-run of the whole build, first remove any previous output with `snakemake --cores 1 clean` or `nextstrain build --cpus 1 . clean`.
 
 ## Next steps
 


### PR DESCRIPTION
Adds the required --cores 1 argument to all calls to `snakemake` and `nextstrain build` in documentation. This is the first step toward [removing Snakemake as an augur dependency](https://github.com/nextstrain/augur/pull/557).
