### PR TITLE
Allow community builds to be stored using git-lfs

### DIFF
--- a/src/sources.js
+++ b/src/sources.js
@@ -181,7 +181,7 @@ class CommunitySource extends Source {
 
   static get _name() { return "community"; }
   get repo() { return `${this.owner}/${this.repoName}`; }
-  get baseUrl() { return `https://raw.githubusercontent.com/${this.repo}/${this.branch}/`; }
+  get baseUrl() { return `https://github.com/${this.repo}/raw/${this.branch}/`; }
 
   get repoNameWithBranch() {
     return this.branch === "master"


### PR DESCRIPTION
The API we were using to access the datasets behind nextstrain community didn't work if the file was stored using git-lfs (the response was a 200 with the contents of the git-lfs pointer). We now switch to a different GitHub API call which allows us to access both "normal" github files and those stored with git-lfs.

Underneath, this new API returns a 302 redirect to one of two different APIs. If the file is "normal", the redirect is to the previous API we were using (raw.githubusercontent.com), if it's git-lfs then it redirects the request to the media.githubusercontent.com API.

URLs to test: 
* https://nextstrain-s-git-lfs-co-izv8nx.herokuapp.com/community/czbiohub/covidtracker/ca (git-lfs)
* https://nextstrain-s-git-lfs-co-izv8nx.herokuapp.com/community/emmahodcroft/south-usa-sarscov2/louisiana ("normal" git object)
