### PR TITLE
Refactor secondTreeOptions

### DIFF
--- a/src/getAvailable.js
+++ b/src/getAvailable.js
@@ -24,17 +24,10 @@ const getAvailable = async (req, res) => {
     utils.verbose(`No narratives available for ${source.name}`);
   }
 
-  // XXX TODO: This is bad and should go away by refactoring second tree
-  // enumeration into our source classes, potentially as part of the
-  // availableDatasets() method.
-  //   -trs, 3 Oct 2019
-  const secondTreeOptions = (dataset) =>
-    (global.availableDatasets.secondTreeOptions[source.name] || {})[dataset] || [];
-
   return res.json({
     datasets: datasets.map((path) => ({
       request: joinPartsIntoPrefix({source, prefixParts: [path]}),
-      secondTreeOptions: secondTreeOptions(path),
+      secondTreeOptions: source.secondTreeOptions(path),
       buildUrl: source.name === "community"
         ? `https://github.com/${source.repo}`
         : null

--- a/src/sources.js
+++ b/src/sources.js
@@ -37,6 +37,12 @@ class Source {
   narrative(pathParts) {
     return new Narrative(this, pathParts);
   }
+
+  // The computation of these globals should move here.
+  secondTreeOptions(path) {
+    return (global.availableDatasets.secondTreeOptions[this.name] || {})[path] || [];
+  }
+
   availableDatasets() {
     return [];
   }


### PR DESCRIPTION
### Description of proposed changes    
Refactor the computation of second tree options data by moving it into
the getAvailableDatasets() method of the Source classes.

Note that it still uses globally computed data for now. While stopping
or centralizing the usage of global variables is a desirable direction
to take this codebase, this commit is just moving the functionality to a
place it's more expected.
