### PR TITLE
Error handling

### DIFF
--- a/src/exceptions.js
+++ b/src/exceptions.js
@@ -7,6 +7,12 @@ class NextstrainError extends Error {
   }
 }
 
+class ResourceNotFoundError extends NextstrainError {
+  constructor(msg = "The requested URLs do not exist", ...rest) {
+    super(msg, ...rest);
+  }
+}
+
 /* Thrown when a valid Source object is asked to create a new Dataset object
  * without a dataset path.
  */
@@ -28,5 +34,6 @@ class InvalidSourceImplementation extends NextstrainError {
 
 module.exports = {
   InvalidSourceImplementation,
+  ResourceNotFoundError,
   NoDatasetPathError
 };

--- a/src/getDataset.js
+++ b/src/getDataset.js
@@ -92,7 +92,7 @@ const requestMainDataset = async (res, fetchUrls) => {
 const getDataset = async (req, res) => {
   const query = queryString.parse(req.url.split('?')[1]);
   if (!query.prefix) {
-    return helpers.handleError(res, `getDataset request must define a prefix`);
+    return helpers.handle500Error(res, `getDataset request must define a prefix`);
   }
 
   /*
@@ -122,7 +122,7 @@ const getDataset = async (req, res) => {
       utils.verbose(err.message);
       return res.status(204).end();
     }
-    return helpers.handleError(res, `Couldn't parse the url "${query.prefix}"`, err.message);
+    return helpers.handle500Error(res, `Couldn't parse the url "${query.prefix}"`, err.message);
   }
 
   const {source, dataset, fetchUrls, auspiceDisplayUrl} = datasetInfo;
@@ -148,7 +148,7 @@ const getDataset = async (req, res) => {
     try {
       await requestCertainFileType(res, req, fetchUrls.additional, query);
     } catch (err) {
-      return helpers.handleError(res, `Couldn't fetch JSON: ${fetchUrls.additional}`, err.message);
+      return helpers.handle500Error(res, `Couldn't fetch JSON: ${fetchUrls.additional}`, err.message);
     }
   } else {
     try {
@@ -158,7 +158,7 @@ const getDataset = async (req, res) => {
         utils.verbose("Request is valid, but no dataset available. Returning 204.");
         return res.status(204).end();
       }
-      return helpers.handleError(res, `Couldn't fetch JSONs`, err.message);
+      return helpers.handle500Error(res, `Couldn't fetch JSONs`, err.message);
     }
   }
   return undefined;

--- a/src/getDataset.js
+++ b/src/getDataset.js
@@ -1,4 +1,6 @@
 const queryString = require("query-string");
+const assert = require('assert').strict;
+
 const utils = require("./utils");
 const helpers = require("./getDatasetHelpers");
 const {NoDatasetPathError} = require("./exceptions");
@@ -91,8 +93,10 @@ const requestMainDataset = async (res, fetchUrls) => {
  */
 const getDataset = async (req, res) => {
   const query = queryString.parse(req.url.split('?')[1]);
-  if (!query.prefix) {
-    return helpers.handle500Error(res, `getDataset request must define a prefix`);
+  try {
+    assert(query.prefix);
+  } catch {
+    return res.status(400).send('getDataset request must define a prefix');
   }
 
   /*
@@ -122,7 +126,7 @@ const getDataset = async (req, res) => {
       utils.verbose(err.message);
       return res.status(204).end();
     }
-    return helpers.handle500Error(res, `Couldn't parse the url "${query.prefix}"`, err.message);
+    return res.status(400).send(`Couldn't parse the url "${query.prefix}"`);
   }
 
   const {source, dataset, fetchUrls, auspiceDisplayUrl} = datasetInfo;

--- a/src/getDatasetHelpers.js
+++ b/src/getDatasetHelpers.js
@@ -24,9 +24,6 @@ const unauthorized = (req, res) => {
  * roundtrip losslessly.
  */
 const splitPrefixIntoParts = (prefix) => {
-  /* This could be const, but use let to signal to the reader that we use
-   * modifying methods like shift() and splice().
-   */
   const prefixParts = prefix
     .replace(/^\//, '')
     .replace(/\/$/, '')

--- a/src/getDatasetHelpers.js
+++ b/src/getDatasetHelpers.js
@@ -1,7 +1,7 @@
 const utils = require("./utils");
 const sources = require("./sources");
 
-const handleError = (res, clientMsg, serverMsg="") => {
+const handle500Error = (res, clientMsg, serverMsg="") => {
   utils.warn(`${clientMsg} -- ${serverMsg}`);
   return res.status(500).type("text/plain").send(clientMsg);
 };
@@ -230,7 +230,7 @@ const parsePrefix = (prefix, otherQueries) => {
 module.exports = {
   splitPrefixIntoParts,
   joinPartsIntoPrefix,
-  handleError,
+  handle500Error,
   unauthorized,
   parsePrefix
 };

--- a/src/getNarrative.js
+++ b/src/getNarrative.js
@@ -6,10 +6,10 @@ const getNarrative = async (req, res) => {
   const query = req.query;
   const prefix = query.prefix;
   if (!prefix) {
-    return helpers.handleError(res, "No prefix in getNarrative URL query");
+    return helpers.handle500Error(res, "No prefix in getNarrative URL query");
   }
   if (!query.type || !["markdown", "md"].includes(query.type.toLowerCase())) {
-    return helpers.handleError(res, "The nextstrain.org server only serves getNarrative requests in markdown format. Please specify `?type=md`");
+    return helpers.handle500Error(res, "The nextstrain.org server only serves getNarrative requests in markdown format. Please specify `?type=md`");
   }
 
   /*
@@ -49,7 +49,7 @@ const getNarrative = async (req, res) => {
     res.set("Content-Type", "text/markdown");
     return response.body.pipe(res);
   } catch (err) {
-    return helpers.handleError(res, `Narratives couldn't be served -- ${err.message}`);
+    return helpers.handle500Error(res, `Narratives couldn't be served -- ${err.message}`);
   }
 };
 

--- a/src/getNarrative.js
+++ b/src/getNarrative.js
@@ -1,15 +1,24 @@
 const fetch = require('node-fetch');
+const assert = require('assert').strict;
+
 const utils = require("./utils");
 const helpers = require("./getDatasetHelpers");
 
 const getNarrative = async (req, res) => {
   const query = req.query;
   const prefix = query.prefix;
-  if (!prefix) {
-    return helpers.handle500Error(res, "No prefix in getNarrative URL query");
+
+  try {
+    assert(prefix);
+  } catch {
+    return res.status(400).send("No prefix in getNarrative URL query");
   }
-  if (!query.type || !["markdown", "md"].includes(query.type.toLowerCase())) {
-    return helpers.handle500Error(res, "The nextstrain.org server only serves getNarrative requests in markdown format. Please specify `?type=md`");
+
+  try {
+    assert(query.type);
+    assert(["markdown", "md"].includes(query.type.toLowerCase()));
+  } catch {
+    return res.status(400).send("The nextstrain.org server only serves getNarrative requests in markdown format. Please specify `?type=md`");
   }
 
   /*

--- a/src/getNarrative.js
+++ b/src/getNarrative.js
@@ -52,7 +52,9 @@ const getNarrative = async (req, res) => {
   try {
     utils.log(`Fetching narrative ${fetchURL} and streaming to client for parsing`);
     const response = await fetch(fetchURL);
-    if (!(response.status === 200 || response.status === 304)) {
+    if (response.status === 404) {
+      return res.status(404).send("The requested URL does not exist.");
+    } else if (!(response.status === 200 || response.status === 304)) {
       throw new Error(`Failed to fetch ${fetchURL}: ${response.status} ${response.statusText}`);
     }
     res.set("Content-Type", "text/markdown");

--- a/src/getSourceInfo.js
+++ b/src/getSourceInfo.js
@@ -1,4 +1,6 @@
 const queryString = require("query-string");
+const assert = require('assert').strict;
+
 const helpers = require("./getDatasetHelpers");
 
 /**
@@ -6,9 +8,12 @@ const helpers = require("./getDatasetHelpers");
  */
 const getSourceInfo = async (req, res) => {
   const query = queryString.parse(req.url.split('?')[1]);
-  if (!query.prefix) {
-    throw new Error("No prefix defined");
+  try {
+    assert(query.prefix);
+  } catch {
+    return res.status(400).send("No prefix defined");
   }
+
   const {source} = helpers.splitPrefixIntoParts(query.prefix);
 
   // Authorization

--- a/src/getSourceInfo.js
+++ b/src/getSourceInfo.js
@@ -20,7 +20,7 @@ const getSourceInfo = async (req, res) => {
   try {
     sourceInfo = await source.getInfo();
   } catch (err) {
-    return helpers.handleError(res, `No source info available`, err.message);
+    return helpers.handle500Error(res, `No source info available`, err.message);
   }
   return res.json(sourceInfo);
 };

--- a/src/getSourceInfo.js
+++ b/src/getSourceInfo.js
@@ -25,7 +25,7 @@ const getSourceInfo = async (req, res) => {
   try {
     sourceInfo = await source.getInfo();
   } catch (err) {
-    return helpers.handle500Error(res, `No source info available`, err.message);
+    return helpers.handle500Error(res, 'Error processing source info', err.message);
   }
   return res.json(sourceInfo);
 };

--- a/src/getSourceInfo.js
+++ b/src/getSourceInfo.js
@@ -15,15 +15,15 @@ const getSourceInfo = async (req, res) => {
     return res.status(400).send("No prefix defined");
   }
 
-  const {source} = helpers.splitPrefixIntoParts(query.prefix);
-
-  // Authorization
-  if (!source.visibleToUser(req.user)) {
-    return helpers.unauthorized(req, res);
-  }
-
   let sourceInfo;
   try {
+    const {source} = helpers.splitPrefixIntoParts(query.prefix);
+
+    // Authorization
+    if (!source.visibleToUser(req.user)) {
+      return helpers.unauthorized(req, res);
+    }
+
     sourceInfo = await source.getInfo();
   } catch (err) {
     if (err instanceof ResourceNotFoundError) {

--- a/src/getSourceInfo.js
+++ b/src/getSourceInfo.js
@@ -2,6 +2,7 @@ const queryString = require("query-string");
 const assert = require('assert').strict;
 
 const helpers = require("./getDatasetHelpers");
+const {ResourceNotFoundError} = require("./exceptions");
 
 /**
  * Prototype implementation.
@@ -25,6 +26,10 @@ const getSourceInfo = async (req, res) => {
   try {
     sourceInfo = await source.getInfo();
   } catch (err) {
+    if (err instanceof ResourceNotFoundError) {
+      return res.status(404).send("The requested URL does not exist");
+    }
+
     return helpers.handle500Error(res, 'Error processing source info', err.message);
   }
   return res.json(sourceInfo);

--- a/src/sources.js
+++ b/src/sources.js
@@ -4,7 +4,7 @@ const zlib = require("zlib");
 const yamlFront = require("yaml-front-matter");
 const {fetch} = require("./fetch");
 const queryString = require("query-string");
-const {NoDatasetPathError, InvalidSourceImplementation} = require("./exceptions");
+const {ResourceNotFoundError, NoDatasetPathError, InvalidSourceImplementation} = require("./exceptions");
 const utils = require("./utils");
 
 const S3 = new AWS.S3();
@@ -136,7 +136,8 @@ class CoreSource extends Source {
     const qs = queryString.stringify({ref: this.branch});
     const response = await fetch(`https://api.github.com/repos/${this.repo}/contents?${qs}`);
 
-    if (response.status !== 200 && response.status !== 304) {
+    if (response.status === 404) throw new ResourceNotFoundError();
+    else if (response.status !== 200 && response.status !== 304) {
       utils.warn(`Error fetching available narratives from GitHub for source ${this.name}`, await utils.responseDetails(response));
       return [];
     }
@@ -206,7 +207,8 @@ class CommunitySource extends Source {
     const qs = queryString.stringify({ref: this.branch});
     const response = await fetch(`https://api.github.com/repos/${this.repo}/contents/auspice?${qs}`);
 
-    if (response.status !== 200 && response.status !== 304) {
+    if (response.status === 404) throw new ResourceNotFoundError();
+    else if (response.status !== 200 && response.status !== 304) {
       utils.warn(`Error fetching available datasets from GitHub for source ${this.name}`, await utils.responseDetails(response));
       return [];
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,9 @@ const fs = require('fs');
 const chalk = require('chalk');
 const fetch = require('node-fetch');
 
+const { ResourceNotFoundError } = require('./exceptions');
+
+
 const getGitHash = () => {
   /* https://stackoverflow.com/questions/34518389/get-hash-of-most-recent-git-commit-in-node */
   try {
@@ -35,7 +38,9 @@ const fetchJSON = (pathToFetch) => {
   verbose(`Fetching ${pathToFetch}`);
   const p = fetch(pathToFetch)
     .then((res) => {
-      if (res.status !== 200) throw new Error(res.statusText);
+      if (res.status === 404) throw new ResourceNotFoundError();
+      else if (res.status !== 200) throw new Error(res.statusText);
+
       try {
         const header = res.headers[Object.getOwnPropertySymbols(res.headers)[0]] || res.headers._headers;
         verbose(`Got type ${header["content-type"]} with encoding ${header["content-encoding"] || "none"}`);

--- a/test/smoke-test/auspice_client_requests.json
+++ b/test/smoke-test/auspice_client_requests.json
@@ -36,6 +36,11 @@
     "expectStatusCode": 200
   },
   {
+    "name": "Check that getAvailable API call for a non-existent community source 404s",
+    "url": "/charon/getAvailable?prefix=/community/jameshadfield/doesntexist",
+    "expectStatusCode": 404
+  },
+  {
     "name": "Check that getDataset works for a community build (Auspice v2 JSON)",
     "url": "/charon/getDataset?prefix=/community/jameshadfield/scratch/placentalia",
     "expectStatusCode": 200,
@@ -88,6 +93,22 @@
     "responseIsJson": true
   },
   {
+    "name": "Fetch dataset with a malformed API call",
+    "url": "/charon/getDataset",
+    "expectStatusCode": 400
+  },
+  {
+    "name": "Fetch dataset which doesn't exist",
+    "url": "/charon/getDataset?prefix=/ncov/XXXX-XX-XX",
+    "expectStatusCode": 404
+  },
+  {
+    "name": "Check getDataset API for non-existing a sidecar file tip-frequencies which doesn't exist",
+    "__comment": "Auspice only makes such a request if the dataset JSON indicates that the frequency panel is to be displayed",
+    "url": "/charon/getDataset?prefix=/ncov/2020-01-23&type=tip-frequencies",
+    "expectStatusCode": 404
+  },
+  {
     "name": "Fetch sidecar file using /fetch URLs (root-sequence JSON from S3 staging bucket)",
     "url": "/charon/getDataset?prefix=/fetch/staging.nextstrain.org/flu_seasonal_h3n2_ha_2y.json&type=root-sequence",
     "expectStatusCode": 200,
@@ -97,5 +118,26 @@
     "name": "Fetch narrative using /fetch URLs (from nextstrain/narratives GitHub repo)",
     "url": "/charon/getNarrative?prefix=/fetch/narratives/raw.githubusercontent.com/nextstrain/narratives/master/intro-to-narratives.md&type=md",
     "expectStatusCode": 200
+  },
+  {
+    "name": "Fetch (core) narrative",
+    "url": "/charon/getNarrative?prefix=/narratives/ncov/sit-rep/2020-05-15&type=md",
+    "expectStatusCode": 200,
+    "responseIsJson": false
+  },
+  {
+    "name": "Fetch narrative without specifying a type (invalid request)",
+    "url": "/charon/getNarrative?prefix=/narratives/ncov/sit-rep/2020-05-15",
+    "expectStatusCode": 400
+  },
+  {
+    "name": "Fetch narrative which doesn't exist",
+    "url": "/charon/getNarrative?prefix=/narratives/ncov/sit-rep/XXXX-XX-XX&type=md",
+    "expectStatusCode": 404
+  },
+  {
+    "name": "Attempt to access a private Nextstrain Group when not logged in",
+    "url": "/charon/getAvailable?prefix=/groups/blab-private",
+    "expectStatusCode": 404
   }
 ]

--- a/test/smoke-test/auspice_client_requests.json
+++ b/test/smoke-test/auspice_client_requests.json
@@ -71,10 +71,9 @@
     "responseIsJson": true
   },
   {
-    "name": "Check getDatset API for a dataset which doesn't exist returns 500 (Internal Server Error)",
-    "__comment": "There are open issues to differentiate dataset errors vs datasets which don't exist",
+    "name": "Check getDatset API for a dataset which doesn't exist returns 404",
     "url": "/charon/getDataset?prefix=/ncov/doesntExist",
-    "expectStatusCode": 500
+    "expectStatusCode": 404
   },
   {
     "name": "Check getDataset API for sidecar file tip-frequencies",

--- a/test/smoke-test/auspice_client_requests.json
+++ b/test/smoke-test/auspice_client_requests.json
@@ -139,5 +139,10 @@
     "name": "Attempt to access a private Nextstrain Group when not logged in",
     "url": "/charon/getAvailable?prefix=/groups/blab-private",
     "expectStatusCode": 404
+  },
+  {
+    "name": "Fetch from a group which doesn't exist",
+    "url": "/charon/getSourceInfo?prefix=/groups/doesntexist",
+    "expectStatusCode": 500
   }
 ]


### PR DESCRIPTION
### Description of proposed changes    
Change the error handling for client errors.

Previously, we were treating incorrectly typed (or non-parseable) URLs as 500 errors, when in my opinion, we should be returning a response of a 400 error, indicating that the request was bad because the query was malformed. 

~This branch is currently based off of #227 to minimize the differences shown here between it and the master branch.~