### PR TITLE
Update sars-cov-2 search regularly

### DIFF
--- a/.github/workflows/update-search.yml
+++ b/.github/workflows/update-search.yml
@@ -1,10 +1,6 @@
 name: 'update nextstrain.org/search from latest datasets in s3'
 
 on:
-  push:
-    branches:
-      - update-search
-
   schedule:
     # * is a special character in YAML so you have to quote this string
     # "At 01:00 UTC on every day-of-week from Tuesday through Saturday. 
@@ -15,10 +11,6 @@ on:
     # so this update will lag behind that by ~9 hours. It can also be
     # triggered from the command line at any time with a respository_dispatch (below)."
     - cron:  '0 1 * * TUE-SAT'
-
-  # Manually triggered using `./bin/trigger update-search`
-  repository_dispatch:
-    types: update-search
 
 jobs:
   update-search:

--- a/.github/workflows/update-search.yml
+++ b/.github/workflows/update-search.yml
@@ -1,6 +1,10 @@
 name: 'update nextstrain.org/search from latest datasets in s3'
 
 on:
+  push:
+    branches:
+      - update-search
+
   schedule:
     # * is a special character in YAML so you have to quote this string
     # "At 01:00 UTC on every day-of-week from Tuesday through Saturday. 

--- a/.github/workflows/update-search.yml
+++ b/.github/workflows/update-search.yml
@@ -33,6 +33,7 @@ jobs:
         npm ci
         python3 -m pip install --upgrade pip setuptools
         python3 -m pip install nextstrain-cli
+        PATH="$HOME/.local/bin:$PATH"
         ./scripts/collect-search-results.js --pathogen sars-cov-2
         nextstrain remote upload s3://nextstrain-data ./data/search_sars-cov-2.json
       env:

--- a/.github/workflows/update-search.yml
+++ b/.github/workflows/update-search.yml
@@ -21,20 +21,18 @@ on:
     types: update-search
 
 jobs:
-  ingest:
+  update-search:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
         node-version: 14
-    - name: install dependencies
+    - name: update sars-cov-2 search
       run: |
         npm ci
         python3 -m pip install --upgrade pip setuptools
         python3 -m pip install nextstrain-cli
-    - name: update sars-cov-2 search
-      run: |
         ./scripts/collect-search-results.js --pathogen sars-cov-2
         nextstrain remote upload s3://nextstrain-data ./data/search_sars-cov-2.json
       env:

--- a/.github/workflows/update-search.yml
+++ b/.github/workflows/update-search.yml
@@ -1,0 +1,39 @@
+name: 'update nextstrain.org/search from latest datasets in s3'
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # "At 01:00 UTC on every day-of-week from Tuesday through Saturday. 
+    # This works out to 17:00 Monday-Friday Pacific Time, i.e. the time
+    # by which the ncov build has usually been published to s3 when it
+    # is being run by folks in Seattle. When it is being run by folks
+    # in Switzerland, ncov build data is usually published by 16:00 UTC,
+    # so this update will lag behind that by ~9 hours. It can also be
+    # triggered from the command line at any time with a respository_dispatch (below)."
+    - cron:  '0 1 * * TUE-SAT'
+
+  # Manually triggered using `./bin/trigger update-search`
+  repository_dispatch:
+    types: update-search
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 14
+    - name: install dependencies
+      run: |
+        npm ci
+        python3 -m pip install --upgrade pip setuptools
+        python3 -m pip install nextstrain-cli
+    - name: update sars-cov-2 search
+      run: |
+        ./scripts/collect-search-results.js --pathogen sars-cov-2
+        nextstrain remote upload s3://nextstrain-data ./data/search_sars-cov-2.json
+      env:
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This is a Github action which runs `scripts/collect-search-results.js` and uploads this data to s3 in order to update https://nextstrain.org/search/sars-cov-2. It is scheduled to happen every weekday as close as possible to the time by which we have usually published new sars-cov-2 (ncov) builds to s3; as I wrote in a comment in the workflow itself, the timing of this is imperfect for sars-cov-2 (ncov) builds because they are run in different time zones on alternating days. More jobs in this workflow or separate ones with separate timelines can be added for other pathogens we want to maintain search pages for. If we want to make this 'smarter' we can use something like aws lambdas which could automatically run upon updating of certain files in an s3 bucket, but that doesn't seem to be such a huge improvement over this to necessitate the time it would take (at least for me with my lack of lambdas experience).
 
### Description of proposed changes    
What is the goal of this pull request? What does this pull request change?

### Related issue(s)  
[Slack thread](https://bedfordlab.slack.com/archives/C7SDVPBLZ/p1605660746030400)
#187 
#192 
#196 
#182 

### Testing
I will trigger this manually now to test that it works and also monitor it to see that the cron schedule is as desired (I think it will apply even though it's in a branch since I didn't say anything about which branch it runs on, but I need to check the default there.

### Thank you for contributing to Nextstrain!
