### PR TITLE
[build-map] cluster community builds on the map;

### DIFF
--- a/static-site/content/allSARS-CoV-2Builds.yaml
+++ b/static-site/content/allSARS-CoV-2Builds.yaml
@@ -205,7 +205,7 @@ builds:
     region: North America
     level: division
     coords:
-      - -119.64
+      - -118.0
       - 36.357039
     org:
       name: CZ BioHub
@@ -217,8 +217,8 @@ builds:
     region: North America
     level: division
     coords:
-      - -119.690182
-      - 36.357039
+      - -121.0
+      - 37.357039
     org:
       name: SEARCH, San Diego
       url: https://searchcovid.info/
@@ -229,8 +229,8 @@ builds:
     region: North America
     level: location
     coords:
-      - -117.143358
-      - 32.733024
+      - -118.143358
+      - 33.733024
     org:
       name: SEARCH, San Diego
       url: https://searchcovid.info/
@@ -301,8 +301,8 @@ builds:
     region: North America
     level: location
     coords:
-      - -71.0589
-      - 42.3601
+      - -71.18
+      - 42.45
     org:
       name: Broad Institute
       url: https://auspice.broadinstitute.org
@@ -313,8 +313,8 @@ builds:
     region: North America
     level: location
     coords:
-      - -71.3
-      - 42.3601
+      - -71
+      - 42.25
     org:
       name: Broad Institute
       url: https://auspice.broadinstitute.org
@@ -367,8 +367,8 @@ builds:
     region: Europe
     level: country
     coords:
-      - 14.5501
-      - 47.5162
+      - 14.5
+      - 47
     org:
       name: Bergthaler Lab
       url: https://cemm.at/en/research/groups/andreas-bergthaler-group/
@@ -380,7 +380,7 @@ builds:
     level: country
     coords:
       - 14.5
-      - 47.5162
+      - 48
     org:
       name: neherlab
       url: https://neherlab.org
@@ -398,7 +398,7 @@ builds:
     level: country
     coords:
       - -3.7492
-      - 40.4637
+      - 41
     org:
       name: FISABIO Sequencing and Bioinformatics Service
       url: http://www.fisabio-ngs.com/en/
@@ -410,7 +410,7 @@ builds:
     level: country
     coords:
       - -3.65
-      - 40.4637
+      - 39
     org:
       name: neherlab
       url: https://neherlab.org
@@ -446,7 +446,7 @@ builds:
     level: country
     coords:
       - -8.1
-      - 39.54046
+      - 38
     org:
       name: INSA / NIH Portugal
       url: http://www.insa.pt/
@@ -458,7 +458,7 @@ builds:
     level: country
     coords:
       - -8.174701
-      - 39.54046
+      - 40
     org:
       name: neherlab
       url: https://neherlab.org
@@ -548,8 +548,8 @@ builds:
     region: Europe
     level: country
     coords:
-      - 15.2
-      - 45.1
+      - 16
+      - 45.4
     org:
       name: neherlab
       url: https://neherlab.org

--- a/static-site/content/allSARS-CoV-2Builds.yaml
+++ b/static-site/content/allSARS-CoV-2Builds.yaml
@@ -47,8 +47,8 @@ builds:
     region: Europe
     level: region
     coords:
-      - 10.799454
-      - 49.646237
+      - 11.74
+      - 39.646237
     org:
       name: Nextstrain Team
       url: null
@@ -133,7 +133,7 @@ builds:
     region: North America
     level: region
     coords:
-      - -97.738017
+      - -107.738017
       - 28.2367447
     org:
       name: Nextstrain Team
@@ -205,7 +205,7 @@ builds:
     region: North America
     level: division
     coords:
-      - -119.690182
+      - -119.64
       - 36.357039
     org:
       name: CZ BioHub
@@ -301,8 +301,8 @@ builds:
     region: North America
     level: location
     coords:
-      - -71.998513
-      - 42.340741
+      - -71.0589
+      - 42.3601
     org:
       name: Broad Institute
       url: https://auspice.broadinstitute.org
@@ -313,8 +313,8 @@ builds:
     region: North America
     level: location
     coords:
-      - -71.998513
-      - 42.340741
+      - -71.3
+      - 42.3601
     org:
       name: Broad Institute
       url: https://auspice.broadinstitute.org
@@ -379,7 +379,7 @@ builds:
     region: Europe
     level: country
     coords:
-      - 14.5501
+      - 14.5
       - 47.5162
     org:
       name: neherlab
@@ -409,7 +409,7 @@ builds:
     region: Europe
     level: country
     coords:
-      - -3.7492
+      - -3.65
       - 40.4637
     org:
       name: neherlab
@@ -445,7 +445,7 @@ builds:
     region: Europe
     level: country
     coords:
-      - -8.174701
+      - -8.1
       - 39.54046
     org:
       name: INSA / NIH Portugal

--- a/static-site/src/components/sars-cov-2/build-map.jsx
+++ b/static-site/src/components/sars-cov-2/build-map.jsx
@@ -249,7 +249,7 @@ class BuildMap extends React.Component {
             <ZoomControl zoomDiff={1.0} style={{top: "auto", bottom: "15px", right: "10px"}}/>
             {Legend(legendEntries)}
             {/* Clustering of community builds according to https://github.com/alex3165/react-mapbox-gl/blob/master/docs/API.md#cluster */}
-            <Cluster ClusterMarkerFactory={this.ClusterMarker} zoomOnClick zoomOnClickPadding={100} maxZoom={5} radius={30}>
+            <Cluster ClusterMarkerFactory={this.ClusterMarker} zoomOnClick zoomOnClickPadding={200} maxZoom={5} radius={30}>
               {buildsToMap.map((build, index) => this.MapMarker(build, index))}
             </Cluster>
             {/* Tooltips for cluster markers: */}

--- a/static-site/src/components/sars-cov-2/build-map.jsx
+++ b/static-site/src/components/sars-cov-2/build-map.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import ReactMapboxGl, { ZoomControl, Marker } from "react-mapbox-gl";
+import ReactMapboxGl, { ZoomControl, Marker, Cluster } from "react-mapbox-gl";
 import styled from 'styled-components';
 import ReactTooltip from 'react-tooltip';
-import { sortBy } from "lodash";
+import { remove } from "lodash";
 import { FaInfoCircle } from "react-icons/fa";
 
 const MapMarkerContainer = styled.div`
@@ -102,18 +102,27 @@ const Map = ReactMapboxGl({
   scrollZoom: false
 });
 
-const circle = (size, fill) => (
-  <svg height={size+2} width={size+2}>
-    <circle cx={(size+2)/2} cy={(size+2)/2} r={size/2} stroke="white" strokeWidth="1" fill={fill} />
-  </svg>
-);
+const circle = (size, fill, text) => {
+  const sizeAdjusted = size+2;
+  const radius = size/2;
+  const width = sizeAdjusted/2;
+  const fontSize = `${width/12}em`;
+  return (<svg height={sizeAdjusted} width={sizeAdjusted}>
+    <circle cx={width} cy={width} r={radius} stroke="white" strokeWidth="1" fill={fill}/>
+    {text &&
+      <text x={width} y={width+1} fill="white" fontSize={fontSize} textAnchor="middle" alignmentBaseline="middle">
+        {text}
+      </text>}
+  </svg>);
+};
 
 const nextstrainBuild = circle(16, "#5DA8A3");
+const communityBuildColor = "#529AB6";
 const communityBuilds = {
-  region: circle(15, "#529AB6"),
-  country: circle(12, "#529AB6"),
-  division: circle(8, "#529AB6"),
-  location: circle(6, "#529AB6")
+  region: circle(15, communityBuildColor),
+  country: circle(12, communityBuildColor),
+  division: circle(8, communityBuildColor),
+  location: circle(6, communityBuildColor)
 };
 const communityBuildInfo = (level) =>
   `A ${level}-level build maintained by a group in the scientific community.
@@ -180,43 +189,50 @@ class BuildMap extends React.Component {
     this.setState({zoomToIndex: null});
   }
 
-  MapMarker = (build, index) => {
+  ClusterMarker = (coordinates, pointCount, getLeaves) => {
+    const size = pointCount < 10 ? 20 : pointCount < 50 ? 30 : 40;
+    return (
+      <Marker
+        key={coordinates.toString()}
+        coordinates={coordinates}
+      >
+        <MapMarkerContainer data-tip data-for={"cluster-tooltip"}>
+          {circle(size, communityBuildColor, pointCount)}
+        </MapMarkerContainer>
+      </Marker>);
+  };
+
+  MapMarker = (build) => {
     const isNextstrainBuild = build.org.name === "Nextstrain Team";
-    return (<div key={index}>
+    return (
       <Marker
         coordinates={build.coords}
         anchor="bottom"
+        key={build.coords.toString()}
       >
-        <MapMarkerContainer data-tip data-for={build.url} data-delay-hide="500">
-          <a href={build.url}>
+        <MapMarkerContainer>
+          <a href={build.url} data-tip data-for={build.url} build={build}>
             {isNextstrainBuild ? nextstrainBuild : communityBuilds[build.level]}
           </a>
         </MapMarkerContainer>
-      </Marker>
-      <StyledTooltip type="light" id={build.url} effect="solid" data-delay-hide={500}>
+      </Marker>);
+  }
+
+  MapMarkerTooltip = (build) => {
+    return (
+      <StyledTooltip type="light" id={build.url} effect="solid">
         {`${build.name} (${build.org.name})`}
         <div style={{fontStyle: "italic"}}>Click to view</div>
-      </StyledTooltip>
-    </div>
-    );
+      </StyledTooltip>);
   }
 
   render() {
-    let center, zoom;
-    const buildsToMap = sortBy(
-      // We don't map the stub builds that are used to define the hierarchy
-      this.props.builds.filter((build) => build.url !== null && build.coords !== undefined && build.name !== "Global"),
-      // Nextstrain builds are last so they show up on top
-      (b) => b.org && b.org.name === "Nextstrain Team");
-    if (this.state.zoomToIndex !== null) {
-      /* map focused on one pin */
-      center = buildsToMap[this.state.zoomToIndex].coords;
-      zoom = buildsToMap[this.state.zoomToIndex].zoom || mapDefaults.zoomPin;
-    } else {
-      /* "overall" view */
-      zoom = mapDefaults.zoomOverall;
-      center = mapDefaults.center;
-    }
+    const center = mapDefaults.center;
+    const zoom = mapDefaults.zoomOverall;
+    // We don't map the stub builds that are used to define the hierarchy
+    const buildsToMap = this.props.builds.filter((build) => build.url !== null && build.coords !== undefined && build.name !== "Global");
+    // Nextstrain builds go separate from clustered community builds on the map
+    const nextstrainBuilds = remove(buildsToMap, (b) => b.org && b.org.name === "Nextstrain Team");
 
     return (
       <Flex>
@@ -227,11 +243,23 @@ class BuildMap extends React.Component {
             center={center}
             zoom={[zoom]}
             maxBounds={mapDefaults.maxBounds}
-            // onDragEnd={() => this.onMapMove()}
+            onZoomEnd={ReactTooltip.rebuild}
+            onDragEnd={ReactTooltip.rebuild}
           >
             <ZoomControl zoomDiff={1.0} style={{top: "auto", bottom: "15px", right: "10px"}}/>
             {Legend(legendEntries)}
-            {buildsToMap.map((build, index) => this.MapMarker(build, index))}
+            {/* Clustering of community builds according to https://github.com/alex3165/react-mapbox-gl/blob/master/docs/API.md#cluster */}
+            <Cluster ClusterMarkerFactory={this.ClusterMarker} zoomOnClick zoomOnClickPadding={100} maxZoom={5} radius={30}>
+              {buildsToMap.map((build, index) => this.MapMarker(build, index))}
+            </Cluster>
+            {/* Tooltips for cluster markers: */}
+            <StyledTooltip type="light" id={"cluster-tooltip"} effect="solid">
+              <div style={{fontStyle: "italic"}}>Click to zoom on this cluster of builds</div>
+            </StyledTooltip>
+            {/* Nextstrain builds: */}
+            {nextstrainBuilds.map((build) => this.MapMarker(build))}
+            {/* Tooltips for map markers: */}
+            {[...nextstrainBuilds, ...buildsToMap].map((build) => this.MapMarkerTooltip(build))}
           </Map>
         </MapContainer>
       </Flex>

--- a/static-site/src/components/sars-cov-2/build-map.jsx
+++ b/static-site/src/components/sars-cov-2/build-map.jsx
@@ -108,9 +108,9 @@ const circle = (size, fill, text) => {
   const width = sizeAdjusted/2;
   const fontSize = `${width/12}em`;
   return (<svg height={sizeAdjusted} width={sizeAdjusted}>
-    <circle cx={width} cy={width} r={radius} stroke="white" strokeWidth="1" fill={fill}/>
+    <circle cx={width} cy={width} r={radius*1.1} stroke="white" strokeWidth="1" fill={fill}/>
     {text &&
-      <text x={width} y={width+1} fill="white" fontSize={fontSize} textAnchor="middle" dominantBaseline="middle">
+      <text x={width} y={width*1.1} fill="white" fontSize={fontSize} textAnchor="middle" dominantBaseline="middle">
         {text}
       </text>}
   </svg>);

--- a/static-site/src/components/sars-cov-2/build-map.jsx
+++ b/static-site/src/components/sars-cov-2/build-map.jsx
@@ -110,7 +110,7 @@ const circle = (size, fill, text) => {
   return (<svg height={sizeAdjusted} width={sizeAdjusted}>
     <circle cx={width} cy={width} r={radius} stroke="white" strokeWidth="1" fill={fill}/>
     {text &&
-      <text x={width} y={width+1} fill="white" fontSize={fontSize} textAnchor="middle" alignmentBaseline="middle">
+      <text x={width} y={width+1} fill="white" fontSize={fontSize} textAnchor="middle" dominantBaseline="middle">
         {text}
       </text>}
   </svg>);

--- a/static-site/src/components/sars-cov-2/build-map.jsx
+++ b/static-site/src/components/sars-cov-2/build-map.jsx
@@ -116,13 +116,13 @@ const circle = (size, fill, text) => {
   </svg>);
 };
 
-const nextstrainBuild = circle(16, "#5DA8A3");
-const communityBuildColor = "#529AB6";
+
+const nextstrainBuild = circle(17, "#4C90C0");
 const communityBuilds = {
-  region: circle(15, communityBuildColor),
-  country: circle(12, communityBuildColor),
-  division: circle(8, communityBuildColor),
-  location: circle(6, communityBuildColor)
+  region: circle(14, "#75B681"),
+  country: circle(12, "#B2BD4D"),
+  division: circle(10, "#E1A03A"),
+  location: circle(8, "#E04929")
 };
 const communityBuildInfo = (level) =>
   `A ${level}-level build maintained by a group in the scientific community.
@@ -197,7 +197,7 @@ class BuildMap extends React.Component {
         coordinates={coordinates}
       >
         <MapMarkerContainer data-tip data-for={"cluster-tooltip"}>
-          {circle(size, communityBuildColor, pointCount)}
+          {circle(size, "grey", pointCount)}
         </MapMarkerContainer>
       </Marker>);
   };

--- a/static-site/src/components/sars-cov-2/build-map.jsx
+++ b/static-site/src/components/sars-cov-2/build-map.jsx
@@ -189,7 +189,7 @@ class BuildMap extends React.Component {
     this.setState({zoomToIndex: null});
   }
 
-  ClusterMarker = (coordinates, pointCount, getLeaves) => {
+  ClusterMarker = (coordinates, pointCount) => {
     const size = pointCount < 10 ? 20 : pointCount < 50 ? 30 : 40;
     return (
       <Marker
@@ -220,7 +220,7 @@ class BuildMap extends React.Component {
 
   MapMarkerTooltip = (build) => {
     return (
-      <StyledTooltip type="light" id={build.url} effect="solid">
+      <StyledTooltip type="light" key={build.url} id={build.url} effect="solid">
         {`${build.name} (${build.org.name})`}
         <div style={{fontStyle: "italic"}}>Click to view</div>
       </StyledTooltip>);


### PR DESCRIPTION
This uses a react-mapbox-gl component to cluster builds on the map. Only community builds are clustered in this way. Clicking a cluster will zoom to the bounds of the builds it contains. Cluster tooltips don't show the contents of the
cluster (this is possible, just adds complexity to implementation). Important to note that clusters will never separate if two markers (builds) have the same coordinates. Since programmatically adding small differences to identical coordinates is non-trivial, we do this manually in the yaml file for now. We should add a console warning so that this doesn't happen by mistake.

### Description of proposed changes    
What is the goal of this pull request? What does this pull request change?

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #  
Related to #  

### Testing
What steps should be taken to test the changes you've proposed?  
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  

### Thank you for contributing to Nextstrain!
