### PR TITLE
Adds WA build to map

### DIFF
--- a/static-site/content/allSARS-CoV-2Builds.yaml
+++ b/static-site/content/allSARS-CoV-2Builds.yaml
@@ -337,23 +337,23 @@ builds:
       name: Hodcroft et al.
       url: https://github.com/emmahodcroft/south-usa-sarscov2/
 
-    - url: null
-      name: Washington
-      geo: washington
-      parentGeo: usa
-      org: null
+  - url: null
+    name: Washington
+    geo: washington
+    parentGeo: usa
+    org: null
 
-    - url: https://nextstrain.org/groups/blab/ncov/wa/4m
-      name: Washington
-      geo: washington
-      region: North America
-      level: division
-      coords:
-        - -119.950361
-        - 47.183945
-      org:
-        name: Bedford Lab
-        url: https://bedford.io/
+  - url: https://nextstrain.org/groups/blab/ncov/wa/4m
+    name: Washington
+    geo: washington
+    region: North America
+    level: division
+    coords:
+      - -120.644869
+      - 46.988611
+    org:
+      name: Bedford Lab
+      url: https://bedford.io/
 
   - url: null
     name: Wisconsin

--- a/static-site/content/allSARS-CoV-2Builds.yaml
+++ b/static-site/content/allSARS-CoV-2Builds.yaml
@@ -10,7 +10,7 @@ builds:
     geo: global
     region: global
     level: region
-    coords: 
+    coords:
       - -30
       - 10
     org:
@@ -336,6 +336,24 @@ builds:
     org:
       name: Hodcroft et al.
       url: https://github.com/emmahodcroft/south-usa-sarscov2/
+
+    - url: null
+      name: Washington
+      geo: washington
+      parentGeo: usa
+      org: null
+
+    - url: https://nextstrain.org/groups/blab/ncov/wa/4m
+      name: Washington
+      geo: washington
+      region: North America
+      level: division
+      coords:
+        - -119.950361
+        - 47.183945
+      org:
+        name: Bedford Lab
+        url: https://bedford.io/
 
   - url: null
     name: Wisconsin


### PR DESCRIPTION
This PR adds the [Washington State SARS-Cov-2 build](https://nextstrain.org/groups/blab/ncov/wa/4m) to the global map.
