### PR TITLE
Add BE build to map

### DIFF
--- a/static-site/content/allSARS-CoV-2Builds.yaml
+++ b/static-site/content/allSARS-CoV-2Builds.yaml
@@ -517,7 +517,7 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: https://nextstrain.org/community/GuyBaele/sars-cov-2-belgium?f_country=Belgium
+  - url: https://nextstrain.org/community/GuyBaele/sars-cov-2-belgium?c=clade_membership&f_country=Belgium
     name: Belgium
     geo: belgium
     region: Europe

--- a/static-site/content/allSARS-CoV-2Builds.yaml
+++ b/static-site/content/allSARS-CoV-2Builds.yaml
@@ -511,11 +511,23 @@ builds:
     region: Europe
     level: country
     coords:
-      - 4.677726
-      - 50.707735
+      - 4.3517
+      - 50.8503
     org:
       name: neherlab
       url: https://neherlab.org
+
+  - url: https://nextstrain.org/community/GuyBaele/sars-cov-2-belgium?f_country=Belgium
+    name: Belgium
+    geo: belgium
+    region: Europe
+    level: country
+    coords:
+      - 4.7005
+      - 50.8798
+    org:
+      name: Baele Lab
+      url: https://rega.kuleuven.be/cev/ecv
 
   - url: null
     name: Bosnia and Herzegovin


### PR DESCRIPTION
This PR adds the Baele Lab's Belgium-focused build to the map.

In addition to adding the new build (centered Leuven), coordinates for the Neher Lab's currently existing build have been shifted slightly to Brussels center so that the two builds can be differentiated on the map.
