### PR TITLE
Sars-cov-2 builds yaml clean up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3659,6 +3659,16 @@
             "path-exists": "^4.0.0"
           }
         },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -13115,12 +13125,18 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        }
       }
     },
     "jsbn": {
@@ -18442,6 +18458,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-1.0.0.tgz",
           "integrity": "sha1-XmqI5wcP9ZCINurRkWlUjDD5C80="
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "heroku-ssl-redirect": "0.0.4",
     "ioredis": "^4.14.1",
     "iso-639-1": "^2.1.0",
+    "js-yaml": "^4.0.0",
     "make-fetch-happen": "^7.1.1",
     "marked": "^0.7.0",
     "node-fetch": "^2.6.0",

--- a/scripts/check-sars-cov-2-builds-yaml.js
+++ b/scripts/check-sars-cov-2-builds-yaml.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-prototype-builtins */
+
+const fs = require('fs');
+const yaml = require('js-yaml');
+const argparse = require('argparse');
+
+const parser = new argparse.ArgumentParser({
+  addHelp: true,
+  description: `A tool to perform basic sanity checking on the YAML file behind SARS-CoV-2 builds`
+});
+parser.addArgument('--precision', {action: "store", defaultValue: 0.1, type: Number, metavar: "NAME", help: "minimum (decimal degree) lat/long separation of points"});
+main(parser.parseArgs());
+
+
+function main(args) {
+  const blocks = getYaml();
+  ensureBlocksAreValid(blocks);
+  ensureGeoParentsDefined(blocks);
+  const builds = blocks.filter((block) => blockDefinesBuild(block));
+  compareLatLongOverlaps(builds, args.precision);
+  summarise(blocks, builds);
+}
+
+
+function getYaml() {
+  let allSARSCoV2Builds;
+  const buildsFilename = "./static-site/content/allSARS-CoV-2Builds.yaml";
+  try {
+    allSARSCoV2Builds = yaml.safeLoad(fs.readFileSync(buildsFilename, 'utf8'));
+  } catch (e) {
+    console.log(`There was an error reading ${buildsFilename}. Please ensure it exists and it is valid YAML.`);
+    console.log(e);
+    process.exit(2);
+  }
+  if (!allSARSCoV2Builds.builds) {
+    console.log(`The builds YAML was missing a top-level entry for "builds".`);
+    process.exit(2);
+  }
+  return allSARSCoV2Builds.builds;
+}
+
+function blockDefinesBuild(block) {
+  return block.geo && block.name && block.url && block.coords;
+}
+
+function ensureGeoParentsDefined(blocks) {
+  const geosWithGeoParents = blocks.filter((block) => block.hasOwnProperty("parentGeo")).map((block) => block.geo);
+  blocks.filter((block) => blockDefinesBuild(block)).forEach((block) => {
+    if (!geosWithGeoParents.includes(block.geo)) {
+      console.log(`Build for ${block.name} with geo "${block.geo}" doesn't have a corresponding block linking to a "parentGeo"`);
+    }
+  });
+}
+
+function ensureBlocksAreValid(blocks) {
+  blocks.forEach((block) => {
+    if (!block.geo || !block.name) {
+      console.log("Invalid block:", block);
+    }
+    if (block.coords) {
+      if (
+        !Array.isArray(block.coords) || block.coords.length!==2 ||
+        !(block.coords[0] >= -180 && block.coords[0] <= 180) || !(block.coords[1] >= -90 && block.coords[1] <= 90)
+      ) {
+        console.log(`Invalid coords for build name "${block.name}"`);
+      }
+    }
+  });
+}
+
+/**
+ * Here we treat the world as a 2-d flat surface for simplicity and ensure that the straight-line distance
+ * between 2 points is greater than the supplied `precision`. Units are decimal degrees.
+ */
+function compareLatLongOverlaps(builds, precision) {
+  const p2 = precision**2;
+  for (let i=0; i<builds.length-1; i++) {
+    const ll1 = builds[i].coords;
+    for (let j=i+1; j<builds.length; j++) {
+      const ll2 = builds[j].coords;
+      const sld2 = Math.abs(ll1[0]-ll2[0])**2 + Math.abs(ll1[1]-ll2[1])**2;
+      if (sld2 < p2) {
+        console.log(`Lat-longs for builds "${builds[i].name}" & "${builds[j].name}" are too close`);
+      }
+    }
+  }
+}
+
+function summarise(blocks, builds) {
+  console.log(`${blocks.length} blocks in YAML, defining ${builds.length} builds`);
+}

--- a/static-site/content/allSARS-CoV-2Builds.yaml
+++ b/static-site/content/allSARS-CoV-2Builds.yaml
@@ -1,9 +1,20 @@
+# This file defines the SARS-CoV-2 builds displayed on nextstrain.org/sars-cov-2/
+# (both as points on the map, and in the expandable tables).
+
+# Documentation on how to modify this YAML in order to add a build is forthcoming.
+# For now, please see https://github.com/nextstrain/docs.nextstrain.org/pull/42.
+# This message will be updated with the docs URL when that PR is merged.
+
 builds:
+
+  # The following section of heading entries, which don't themselves define a build,
+  # are used to organise the rendered table into appropriate hierarchies. They are not
+  # used for the <Map>
   - name: Global
     geo: global
     parentGeo: null
 
-  - name: South America
+  - name: South America`
     geo: south-america
     parentGeo: null
 
@@ -214,6 +225,10 @@ builds:
   - name: Middle East
     geo: middle-east
     parentGeo: null
+
+  # Entries below this comment define builds. They should have a URL pointing to the analysis
+  # visualisation as well as a name and coords for rendering on the map. The `geo` value should
+  # map to a non-build (stub) entry defined above.
 
   - url: https://nextstrain.org/ncov/global
     name: Global

--- a/static-site/content/allSARS-CoV-2Builds.yaml
+++ b/static-site/content/allSARS-CoV-2Builds.yaml
@@ -1,14 +1,11 @@
 builds:
-  - url: null
-    name: Global
+  - name: Global
     geo: global
     parentGeo: null
-    org: null
 
   - url: https://nextstrain.org/ncov/global
     name: Global
     geo: global
-    region: global
     level: region
     coords:
       - -30
@@ -17,16 +14,13 @@ builds:
       name: Nextstrain Team
       url: null
 
-  - url: null
-    name: South America
+  - name: South America
     geo: south-america
     parentGeo: null
-    org: null
 
   - url: https://nextstrain.org/ncov/south-america?f_region=South%20America
     name: South America
     geo: south-america
-    region: South America
     level: region
     coords:
       - -58.470721
@@ -35,16 +29,13 @@ builds:
       name: Nextstrain Team
       url: null
 
-  - url: null
-    name: Europe
+  - name: Europe
     geo: europe
     parentGeo: null
-    org: null
 
   - url: https://nextstrain.org/ncov/europe?f_region=Europe
     name: Europe
     geo: europe
-    region: Europe
     level: region
     coords:
       - 11.74
@@ -56,7 +47,6 @@ builds:
   - url: https://nextstrain.org/groups/neherlab/ncov/europe?f_region=Europe&p=grid
     name: Europe
     geo: europe
-    region: Europe
     level: region
     coords:
       - 10.799454
@@ -65,16 +55,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Africa
+  - name: Africa
     geo: africa
     parentGeo: null
-    org: null
 
   - url: https://nextstrain.org/ncov/africa?f_region=Africa
     name: Africa
     geo: africa
-    region: Africa
     level: region
     coords:
       - 21.824559
@@ -83,16 +70,13 @@ builds:
       name: Nextstrain Team
       url: null
 
-  - url: null
-    name: Asia
+  - name: Asia
     geo: asia
     parentGeo: null
-    org: null
 
   - url: https://nextstrain.org/ncov/asia?f_region=Asia
     name: Asia
     geo: asia
-    region: Asia
     level: region
     coords:
       - 86.654576
@@ -102,16 +86,13 @@ builds:
       name: Nextstrain Team
       url: null
 
-  - url: null
-    name: Oceania
+  - name: Oceania
     geo: oceania
     parentGeo: null
-    org: null
 
   - url: https://nextstrain.org/ncov/oceania?f_region=Oceania
     name: Oceania
     geo: oceania
-    region: Oceania
     level: region
     coords:
       - 152.008576
@@ -121,16 +102,13 @@ builds:
       name: Nextstrain Team
       url: null
 
-  - url: null
-    name: North America
+  - name: North America
     geo: north-america
     parentGeo: null
-    org: null
 
   - url: https://nextstrain.org/ncov/north-america?f_region=North%20America
     name: North America
     geo: north-america
-    region: North America
     level: region
     coords:
       - -107.738017
@@ -139,22 +117,17 @@ builds:
       name: Nextstrain Team
       url: null
 
-  - url: null
-    name: Canada
+  - name: Canada
     geo: canada
     parentGeo: north-america
-    org: null
 
-  - url: null
-    name: Quebec
+  - name: Quebec
     geo: quebec
     parentGeo: canada
-    org: null
 
   - url: https://covseq.ca/
     name: CoVSeQ
     geo: quebec
-    region: North America
     level: division
     coords:
       - -73.5491
@@ -163,16 +136,13 @@ builds:
       name: CoVSeQ Partnership
       url: https://covseq.ca/about
 
-  - url: null
-    name: USA
+  - name: USA
     geo: usa
     parentGeo: north-america
-    org: null
 
   - url: https://nextstrain.org/community/SESchmedes/sarscov2-southeast-usa/southeast
     name: South-East Region
     geo: usa
-    region: North America
     level: country
     coords:
       - -80.0
@@ -184,7 +154,6 @@ builds:
   - url: https://nextstrain.org/community/emmahodcroft/south-usa-sarscov2/south-central
     name: South-Central Region
     geo: usa
-    region: North America
     level: country
     coords:
       - -95.0
@@ -193,16 +162,13 @@ builds:
       name: Hodcroft et al.
       url: https://github.com/emmahodcroft/south-usa-sarscov2/
 
-  - url: null
-    name: California
+  - name: California
     geo: california
     parentGeo: usa
-    org: null
 
   - url: https://nextstrain.org/community/czbiohub/covidtracker/ca
     name: California
     geo: california
-    region: North America
     level: division
     coords:
       - -118.0
@@ -214,7 +180,6 @@ builds:
   - url: https://nextstrain.org/community/andersen-lab/HCoV-19-Genomics-Nextstrain/hCoV-19/usa/california
     name: California
     geo: california
-    region: North America
     level: division
     coords:
       - -121.0
@@ -226,7 +191,6 @@ builds:
   - url: https://nextstrain.org/community/andersen-lab/HCoV-19-Genomics-Nextstrain/hCoV-19/usa/sandiego
     name: San Diego
     geo: california
-    region: North America
     level: location
     coords:
       - -118.143358
@@ -235,16 +199,13 @@ builds:
       name: SEARCH, San Diego
       url: https://searchcovid.info/
 
-  - url: null
-    name: Connecticut
+  - name: Connecticut
     geo: connecticut
     parentGeo: usa
-    org: null
 
   - url: https://nextstrain.org/community/grubaughlab/CT-SARS-CoV-2/current
     name: Connecticut
     geo: connecticut
-    region: North America
     level: division
     coords:
       - -72.669773
@@ -253,16 +214,13 @@ builds:
       name: Grubaugh Lab
       url: http://grubaughlab.com
 
-  - url: null
-    name: Florida
+  - name: Florida
     geo: florida
     parentGeo: usa
-    org: null
 
   - url: https://nextstrain.org/community/SESchmedes/sarscov2-florida/florida
     name: Florida
     geo: florida
-    region: North America
     level: division
     coords:
       - -81.5158
@@ -271,16 +229,13 @@ builds:
       name: FL-BPHL
       url: http://www.floridahealth.gov/programs-and-services/public-health-laboratories/index.html
 
-  - url: null
-    name: Louisiana
+  - name: Louisiana
     geo: louisiana
     parentGeo: usa
-    org: null
 
   - url: https://nextstrain.org/community/emmahodcroft/south-usa-sarscov2/louisiana
     name: Louisiana
     geo: louisiana
-    region: North America
     level: division
     coords:
       - -91.9623
@@ -289,16 +244,13 @@ builds:
       name: LCSC
       url: https://github.com/emmahodcroft/south-usa-sarscov2/
 
-  - url: null
-    name: Massachusetts
+  - name: Massachusetts
     parentGeo: usa
     geo: massachusetts
-    org: null
 
   - url: https://auspice.broadinstitute.org/sars-cov-2/boston/genbank
     name: Boston GenBank
     geo: massachusetts
-    region: North America
     level: location
     coords:
       - -71.18
@@ -310,7 +262,6 @@ builds:
   - url: https://auspice.broadinstitute.org/sars-cov-2/boston/gisaid-4k
     name: Boston GISAID (4k)
     geo: massachusetts
-    region: North America
     level: location
     coords:
       - -71
@@ -319,16 +270,13 @@ builds:
       name: Broad Institute
       url: https://auspice.broadinstitute.org
 
-  - url: null
-    name: Texas
+  - name: Texas
     geo: texas
     parentGeo: usa
-    org: null
 
   - url: https://nextstrain.org/community/emmahodcroft/south-usa-sarscov2/texas?f_country=USA&p=grid
     name: Texas
     geo: texas
-    region: North America
     level: division
     coords:
       - -99.188758
@@ -337,16 +285,13 @@ builds:
       name: Hodcroft et al.
       url: https://github.com/emmahodcroft/south-usa-sarscov2/
 
-  - url: null
-    name: Washington
+  - name: Washington
     geo: washington
     parentGeo: usa
-    org: null
 
   - url: https://nextstrain.org/groups/blab/ncov/wa/4m
     name: Washington
     geo: washington
-    region: North America
     level: division
     coords:
       - -120.644869
@@ -355,16 +300,13 @@ builds:
       name: Bedford Lab
       url: https://bedford.io/
 
-  - url: null
-    name: Wisconsin
+  - name: Wisconsin
     geo: wisconsin
     parentGeo: usa
-    org: null
 
   - url: https://go.wisc.edu/r7374f
     name: Wisconsin
     geo: wisconsin
-    region: North America
     level: division
     coords:
       - -89.527762
@@ -373,16 +315,13 @@ builds:
       name: WISC
       url: https://openresearch.labkey.com/Coven/project-begin.view?
 
-  - url: null
-    name: Austria
+  - name: Austria
     geo: austria
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/community/bergthalerlab/SARSCoV2/NextstrainAustria
     name: Austria
     geo: austria
-    region: Europe
     level: country
     coords:
       - 14.5
@@ -394,7 +333,6 @@ builds:
   - url: https://nextstrain.org/groups/neherlab/ncov/austria?c=clade_membership&f_country=Austria&p=grid&r=division
     name: Austria
     geo: austria
-    region: Europe
     level: country
     coords:
       - 14.5
@@ -403,16 +341,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Spain
+  - name: Spain
     geo: spain
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/nextspain/ncov19-Spain
     name: Spain
     geo: spain
-    region: Europe
     level: country
     coords:
       - -3.7492
@@ -424,7 +359,6 @@ builds:
   - url: https://nextstrain.org/groups/neherlab/ncov/spain?c=clade_membership&f_country=Spain&p=grid&r=division
     name: Spain
     geo: spain
-    region: Europe
     level: country
     coords:
       - -3.65
@@ -433,16 +367,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Switzerland
+  - name: Switzerland
     geo: switzerland
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/swiss/ncov/switzerland
     name: Switzerland
     geo: switzerland
-    region: Europe
     level: country
     coords:
       - 8.2275
@@ -451,16 +382,13 @@ builds:
       name: nextstrain.org/groups/swiss
       url: https://nextstrain.org/groups/swiss/
 
-  - url: null
-    name: Portugal
+  - name: Portugal
     geo: portugal
     parentGeo: europe
-    org: null
 
   - url: https://insaflu.insa.pt/covid19/
     name: Portugal
     geo: portugal
-    region: Europe
     level: country
     coords:
       - -8.1
@@ -472,7 +400,6 @@ builds:
   - url: https://nextstrain.org/groups/neherlab/ncov/portugal?c=clade_membership&f_country=Portugal&p=grid&r=division
     name: Portugal
     geo: portugal
-    region: Europe
     level: country
     coords:
       - -8.174701
@@ -481,16 +408,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Belarus
+  - name: Belarus
     geo: belarus
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/belarus?c=clade_membership&f_country=Belarus&p=grid&r=division
     name: Belarus
     geo: belarus
-    region: Europe
     level: country
     coords:
       - 28.247691
@@ -499,16 +423,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Belgium
+  - name: Belgium
     geo: belgium
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/belgium?c=clade_membership&f_country=Belgium&p=grid&r=division
     name: Belgium
     geo: belgium
-    region: Europe
     level: country
     coords:
       - 4.3517
@@ -520,7 +441,6 @@ builds:
   - url: https://nextstrain.org/community/GuyBaele/sars-cov-2-belgium?c=clade_membership&f_country=Belgium
     name: Belgium
     geo: belgium
-    region: Europe
     level: country
     coords:
       - 4.7005
@@ -533,7 +453,6 @@ builds:
     name: Bosnia and Herzegovina
     geo: bosnia_and_herzegovina
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/bosnia-and-herzegovina?c=clade_membership&f_country=Bosnia and Herzegovin&p=grid&r=division
     name: Bosnia and Herzegovina
@@ -548,16 +467,13 @@ builds:
       url: https://neherlab.org
 
 
-  - url: null
-    name: Bulgaria
+  - name: Bulgaria
     geo: bulgaria
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/bulgaria?c=clade_membership&f_country=Bulgaria&p=grid&r=division
     name: Bulgaria
     geo: bulgaria
-    region: Europe
     level: country
     coords:
       - 25.193668
@@ -566,16 +482,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Croatia
+  - name: Croatia
     geo: croatia
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/croatia?c=clade_membership&f_country=Croatia&p=grid&r=division
     name: Croatia
     geo: croatia
-    region: Europe
     level: country
     coords:
       - 16
@@ -584,16 +497,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Czech Republic
+  - name: Czech Republic
     geo: czech_republic
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/czech-republic?c=clade_membership&f_country=Czech Republic&p=grid&r=division
     name: Czech Republic
     geo: czech_republic
-    region: Europe
     level: country
     coords:
       - 15.473
@@ -602,16 +512,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Denmark
+  - name: Denmark
     geo: denmark
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/denmark?c=clade_membership&f_country=Denmark&p=grid&r=division
     name: Denmark
     geo: denmark
-    region: Europe
     level: country
     coords:
       - 9.5018
@@ -620,16 +527,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Estonia
+  - name: Estonia
     geo: estonia
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/estonia?c=clade_membership&f_country=Estonia&p=grid&r=division
     name: Estonia
     geo: estonia
-    region: Europe
     level: country
     coords:
       - 25.808524
@@ -638,16 +542,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Finland
+  - name: Finland
     geo: finland
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/finland?c=clade_membership&f_country=Finland&p=grid&r=division
     name: Finland
     geo: finland
-    region: Europe
     level: country
     coords:
       - 26.186437
@@ -656,16 +557,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: France
+  - name: France
     geo: france
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/france?c=clade_membership&f_country=France&p=grid&r=division
     name: France
     geo: france
-    region: Europe
     level: country
     coords:
       - 2.2137
@@ -674,16 +572,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Germany
+  - name: Germany
     geo: germany
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/germany?c=clade_membership&f_country=Germany&p=grid&r=division
     name: Germany
     geo: germany
-    region: Europe
     level: country
     coords:
       - 10.4515
@@ -692,16 +587,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Greece
+  - name: Greece
     geo: greece
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/greece?c=clade_membership&f_country=Greece&p=grid&r=division
     name: Greece
     geo: greece
-    region: Europe
     level: country
     coords:
       - 22.0
@@ -710,16 +602,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Hungary
+  - name: Hungary
     geo: hungary
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/hungary?c=clade_membership&f_country=Hungary&p=grid&r=division
     name: Hungary
     geo: hungary
-    region: Europe
     level: country
     coords:
       - 20.0
@@ -728,16 +617,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Iceland
+  - name: Iceland
     geo: iceland
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/iceland?c=clade_membership&f_country=Iceland&p=grid&r=division
     name: Iceland
     geo: iceland
-    region: Europe
     level: country
     coords:
       - -18.4826
@@ -746,16 +632,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Ireland
+  - name: Ireland
     geo: ireland
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/ireland?c=clade_membership&f_country=Ireland&p=grid&r=division
     name: Ireland
     geo: ireland
-    region: Europe
     level: country
     coords:
       - -7.979
@@ -764,16 +647,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Israel
+  - name: Israel
     geo: israel
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/israel?c=clade_membership&f_country=Israel&p=grid&r=division
     name: Israel
     geo: israel
-    region: Europe
     level: country
     coords:
       - 34.903129
@@ -782,16 +662,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Italy
+  - name: Italy
     geo: italy
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/italy?c=clade_membership&f_country=Italy&p=grid&r=division
     name: Italy
     geo: italy
-    region: Europe
     level: country
     coords:
       - 12.183629
@@ -800,16 +677,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Latvia
+  - name: Latvia
     geo: latvia
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/latvia?c=clade_membership&f_country=Latvia&p=grid&r=division
     name: Latvia
     geo: latvia
-    region: Europe
     level: country
     coords:
       - 25.441386
@@ -818,16 +692,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Lithuania
+  - name: Lithuania
     geo: lithuania
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/lithuania?c=clade_membership&f_country=Lithuania&p=grid&r=division
     name: Lithuania
     geo: lithuania
-    region: Europe
     level: country
     coords:
       - 23.945328
@@ -836,16 +707,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Luxembourg
+  - name: Luxembourg
     geo: luxembourg
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/luxembourg?c=clade_membership&f_country=Luxembourg&p=grid&r=division
     name: Luxembourg
     geo: luxembourg
-    region: Europe
     level: country
     coords:
       - 6.119486
@@ -854,16 +722,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Netherlands
+  - name: Netherlands
     geo: netherlands
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/netherlands?c=clade_membership&f_country=Netherlands&p=grid&r=division
     name: Netherlands
     geo: netherlands
-    region: Europe
     level: country
     coords:
       - 5.2913
@@ -872,16 +737,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Norway
+  - name: Norway
     geo: norway
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/norway?c=clade_membership&f_country=Norway&p=grid&r=division
     name: Norway
     geo: norway
-    region: Europe
     level: country
     coords:
       - 8.73701
@@ -890,16 +752,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Poland
+  - name: Poland
     geo: poland
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/poland?c=clade_membership&f_country=Poland&p=grid&r=division
     name: Poland
     geo: poland
-    region: Europe
     level: country
     coords:
       - 19.0258159
@@ -908,16 +767,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Romania
+  - name: Romania
     geo: romania
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/romania?c=clade_membership&f_country=Romania&p=grid&r=division
     name: Romania
     geo: romania
-    region: Europe
     level: country
     coords:
       - 24.9668
@@ -926,16 +782,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Russia
+  - name: Russia
     geo: russia
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/russia?c=clade_membership&f_country=Russia&p=grid&r=division
     name: Russia
     geo: russia
-    region: Europe
     level: country
     coords:
       - 97.7453061
@@ -944,16 +797,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Serbia
+  - name: Serbia
     geo: serbia
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/serbia?c=clade_membership&f_country=Serbia&p=grid&r=division
     name: Serbia
     geo: serbia
-    region: Europe
     level: country
     coords:
       - 20.848918
@@ -962,16 +812,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Slovakia
+  - name: Slovakia
     geo: slovakia
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/slovakia?c=clade_membership&f_country=Slovakia&p=grid&r=division
     name: Slovakia
     geo: slovakia
-    region: Europe
     level: country
     coords:
       - 19.5
@@ -980,16 +827,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Slovenia
+  - name: Slovenia
     geo: slovenia
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/slovenia?c=clade_membership&f_country=Slovenia&p=grid&r=division
     name: Slovenia
     geo: slovenia
-    region: Europe
     level: country
     coords:
       - 14.4808369
@@ -998,16 +842,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: Sweden
+  - name: Sweden
     geo: sweden
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/sweden?c=clade_membership&f_country=Sweden&p=grid&r=division
     name: Sweden
     geo: sweden
-    region: Europe
     level: country
     coords:
       - 14.5208584
@@ -1016,16 +857,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: United Kingdom
+  - name: United Kingdom
     geo: united_kingdom
     parentGeo: europe
-    org: null
 
   - url: https://nextstrain.org/groups/neherlab/ncov/united-kingdom?c=clade_membership&f_country=United Kingdom&p=grid&r=division
     name: United Kingdom
     geo: united_kingdom
-    region: Europe
     level: country
     coords:
       - -2.088739
@@ -1034,16 +872,13 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - url: null
-    name: India
+  - name: India
     geo: india
     parentGeo: asia
-    org: null
 
   - url: https://nextstrain.org/community/banijolly/Phylovis/COVID-India
     name: India
     geo: india
-    region: Asia
     level: country
     coords:
       - 78.723951
@@ -1052,16 +887,13 @@ builds:
       name: Vinod Scaria Lab
       url: http://vinodscaria.rnabiology.org/
 
-  - url: null
-    name: Middle East
+  - name: Middle East
     geo: middle-east
     parentGeo: null
-    org: null
 
   - url: https://nextstrain.org/community/banijolly/Phylovis/COVID-Middle-East
     name: Middle East
     geo: middle-east
-    region: Middle East
     level: region
     coords:
       - 50.0

--- a/static-site/content/allSARS-CoV-2Builds.yaml
+++ b/static-site/content/allSARS-CoV-2Builds.yaml
@@ -3,6 +3,218 @@ builds:
     geo: global
     parentGeo: null
 
+  - name: South America
+    geo: south-america
+    parentGeo: null
+
+  - name: Europe
+    geo: europe
+    parentGeo: null
+
+  - name: Oceania
+    geo: oceania
+    parentGeo: null
+
+  - name: Africa
+    geo: africa
+    parentGeo: null
+
+  - name: Asia
+    geo: asia
+    parentGeo: null
+
+  - name: North America
+    geo: north-america
+    parentGeo: null
+
+  - name: Canada
+    geo: canada
+    parentGeo: north-america
+
+  - name: Quebec
+    geo: quebec
+    parentGeo: canada
+
+  - name: USA
+    geo: usa
+    parentGeo: north-america
+
+  - name: California
+    geo: california
+    parentGeo: usa
+
+  - name: Connecticut
+    geo: connecticut
+    parentGeo: usa
+
+  - name: Florida
+    geo: florida
+    parentGeo: usa
+
+  - name: Louisiana
+    geo: louisiana
+    parentGeo: usa
+
+  - name: Massachusetts
+    parentGeo: usa
+    geo: massachusetts
+
+  - name: Texas
+    geo: texas
+    parentGeo: usa
+
+  - name: Washington
+    geo: washington
+    parentGeo: usa
+
+  - name: Wisconsin
+    geo: wisconsin
+    parentGeo: usa
+
+  - name: Austria
+    geo: austria
+    parentGeo: europe
+
+  - name: Spain
+    geo: spain
+    parentGeo: europe
+
+  - name: Switzerland
+    geo: switzerland
+    parentGeo: europe
+
+  - name: Portugal
+    geo: portugal
+    parentGeo: europe
+
+  - name: Belarus
+    geo: belarus
+    parentGeo: europe
+
+  - name: Belgium
+    geo: belgium
+    parentGeo: europe
+
+  - name: Bosnia and Herzegovina
+    geo: bosnia_and_herzegovina
+    parentGeo: europe
+
+  - name: Bulgaria
+    geo: bulgaria
+    parentGeo: europe
+
+  - name: Croatia
+    geo: croatia
+    parentGeo: europe
+
+  - name: Czech Republic
+    geo: czech_republic
+    parentGeo: europe
+
+  - name: Denmark
+    geo: denmark
+    parentGeo: europe
+
+  - name: Estonia
+    geo: estonia
+    parentGeo: europe
+
+  - name: Finland
+    geo: finland
+    parentGeo: europe
+
+  - name: France
+    geo: france
+    parentGeo: europe
+
+  - name: Germany
+    geo: germany
+    parentGeo: europe
+
+  - name: Greece
+    geo: greece
+    parentGeo: europe
+
+  - name: Hungary
+    geo: hungary
+    parentGeo: europe
+
+  - name: Iceland
+    geo: iceland
+    parentGeo: europe
+
+  - name: Ireland
+    geo: ireland
+    parentGeo: europe
+
+  - name: Israel
+    geo: israel
+    parentGeo: europe
+
+  - name: Italy
+    geo: italy
+    parentGeo: europe
+
+  - name: Latvia
+    geo: latvia
+    parentGeo: europe
+
+  - name: Lithuania
+    geo: lithuania
+    parentGeo: europe
+
+  - name: Luxembourg
+    geo: luxembourg
+    parentGeo: europe
+
+  - name: Netherlands
+    geo: netherlands
+    parentGeo: europe
+
+  - name: Norway
+    geo: norway
+    parentGeo: europe
+
+  - name: Poland
+    geo: poland
+    parentGeo: europe
+
+  - name: Romania
+    geo: romania
+    parentGeo: europe
+
+  - name: Russia
+    geo: russia
+    parentGeo: europe
+
+  - name: Serbia
+    geo: serbia
+    parentGeo: europe
+
+  - name: Slovakia
+    geo: slovakia
+    parentGeo: europe
+
+  - name: Slovenia
+    geo: slovenia
+    parentGeo: europe
+
+  - name: Sweden
+    geo: sweden
+    parentGeo: europe
+
+  - name: United Kingdom
+    geo: united_kingdom
+    parentGeo: europe
+
+  - name: India
+    geo: india
+    parentGeo: asia
+
+  - name: Middle East
+    geo: middle-east
+    parentGeo: null
+
   - url: https://nextstrain.org/ncov/global
     name: Global
     geo: global
@@ -14,10 +226,6 @@ builds:
       name: Nextstrain Team
       url: null
 
-  - name: South America
-    geo: south-america
-    parentGeo: null
-
   - url: https://nextstrain.org/ncov/south-america?f_region=South%20America
     name: South America
     geo: south-america
@@ -28,10 +236,6 @@ builds:
     org:
       name: Nextstrain Team
       url: null
-
-  - name: Europe
-    geo: europe
-    parentGeo: null
 
   - url: https://nextstrain.org/ncov/europe?f_region=Europe
     name: Europe
@@ -55,10 +259,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Africa
-    geo: africa
-    parentGeo: null
-
   - url: https://nextstrain.org/ncov/africa?f_region=Africa
     name: Africa
     geo: africa
@@ -70,10 +270,6 @@ builds:
       name: Nextstrain Team
       url: null
 
-  - name: Asia
-    geo: asia
-    parentGeo: null
-
   - url: https://nextstrain.org/ncov/asia?f_region=Asia
     name: Asia
     geo: asia
@@ -81,14 +277,9 @@ builds:
     coords:
       - 86.654576
       - 30.451098
-    parentGeo: null
     org:
       name: Nextstrain Team
       url: null
-
-  - name: Oceania
-    geo: oceania
-    parentGeo: null
 
   - url: https://nextstrain.org/ncov/oceania?f_region=Oceania
     name: Oceania
@@ -97,14 +288,9 @@ builds:
     coords:
       - 152.008576
       - -25.0562891
-    parentGeo: null
     org:
       name: Nextstrain Team
       url: null
-
-  - name: North America
-    geo: north-america
-    parentGeo: null
 
   - url: https://nextstrain.org/ncov/north-america?f_region=North%20America
     name: North America
@@ -117,14 +303,6 @@ builds:
       name: Nextstrain Team
       url: null
 
-  - name: Canada
-    geo: canada
-    parentGeo: north-america
-
-  - name: Quebec
-    geo: quebec
-    parentGeo: canada
-
   - url: https://covseq.ca/
     name: CoVSeQ
     geo: quebec
@@ -135,10 +313,6 @@ builds:
     org:
       name: CoVSeQ Partnership
       url: https://covseq.ca/about
-
-  - name: USA
-    geo: usa
-    parentGeo: north-america
 
   - url: https://nextstrain.org/community/SESchmedes/sarscov2-southeast-usa/southeast
     name: South-East Region
@@ -161,10 +335,6 @@ builds:
     org:
       name: Hodcroft et al.
       url: https://github.com/emmahodcroft/south-usa-sarscov2/
-
-  - name: California
-    geo: california
-    parentGeo: usa
 
   - url: https://nextstrain.org/community/czbiohub/covidtracker/ca
     name: California
@@ -199,10 +369,6 @@ builds:
       name: SEARCH, San Diego
       url: https://searchcovid.info/
 
-  - name: Connecticut
-    geo: connecticut
-    parentGeo: usa
-
   - url: https://nextstrain.org/community/grubaughlab/CT-SARS-CoV-2/current
     name: Connecticut
     geo: connecticut
@@ -213,10 +379,6 @@ builds:
     org:
       name: Grubaugh Lab
       url: http://grubaughlab.com
-
-  - name: Florida
-    geo: florida
-    parentGeo: usa
 
   - url: https://nextstrain.org/community/SESchmedes/sarscov2-florida/florida
     name: Florida
@@ -229,10 +391,6 @@ builds:
       name: FL-BPHL
       url: http://www.floridahealth.gov/programs-and-services/public-health-laboratories/index.html
 
-  - name: Louisiana
-    geo: louisiana
-    parentGeo: usa
-
   - url: https://nextstrain.org/community/emmahodcroft/south-usa-sarscov2/louisiana
     name: Louisiana
     geo: louisiana
@@ -243,10 +401,6 @@ builds:
     org:
       name: LCSC
       url: https://github.com/emmahodcroft/south-usa-sarscov2/
-
-  - name: Massachusetts
-    parentGeo: usa
-    geo: massachusetts
 
   - url: https://auspice.broadinstitute.org/sars-cov-2/boston/genbank
     name: Boston GenBank
@@ -270,10 +424,6 @@ builds:
       name: Broad Institute
       url: https://auspice.broadinstitute.org
 
-  - name: Texas
-    geo: texas
-    parentGeo: usa
-
   - url: https://nextstrain.org/community/emmahodcroft/south-usa-sarscov2/texas?f_country=USA&p=grid
     name: Texas
     geo: texas
@@ -284,10 +434,6 @@ builds:
     org:
       name: Hodcroft et al.
       url: https://github.com/emmahodcroft/south-usa-sarscov2/
-
-  - name: Washington
-    geo: washington
-    parentGeo: usa
 
   - url: https://nextstrain.org/groups/blab/ncov/wa/4m
     name: Washington
@@ -300,10 +446,6 @@ builds:
       name: Bedford Lab
       url: https://bedford.io/
 
-  - name: Wisconsin
-    geo: wisconsin
-    parentGeo: usa
-
   - url: https://go.wisc.edu/r7374f
     name: Wisconsin
     geo: wisconsin
@@ -314,10 +456,6 @@ builds:
     org:
       name: WISC
       url: https://openresearch.labkey.com/Coven/project-begin.view?
-
-  - name: Austria
-    geo: austria
-    parentGeo: europe
 
   - url: https://nextstrain.org/community/bergthalerlab/SARSCoV2/NextstrainAustria
     name: Austria
@@ -341,10 +479,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Spain
-    geo: spain
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/nextspain/ncov19-Spain
     name: Spain
     geo: spain
@@ -367,10 +501,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Switzerland
-    geo: switzerland
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/swiss/ncov/switzerland
     name: Switzerland
     geo: switzerland
@@ -381,10 +511,6 @@ builds:
     org:
       name: nextstrain.org/groups/swiss
       url: https://nextstrain.org/groups/swiss/
-
-  - name: Portugal
-    geo: portugal
-    parentGeo: europe
 
   - url: https://insaflu.insa.pt/covid19/
     name: Portugal
@@ -408,10 +534,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Belarus
-    geo: belarus
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/belarus?c=clade_membership&f_country=Belarus&p=grid&r=division
     name: Belarus
     geo: belarus
@@ -422,10 +544,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Belgium
-    geo: belgium
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/belgium?c=clade_membership&f_country=Belgium&p=grid&r=division
     name: Belgium
@@ -449,11 +567,6 @@ builds:
       name: Baele Lab
       url: https://rega.kuleuven.be/cev/ecv
 
-  - url: null
-    name: Bosnia and Herzegovina
-    geo: bosnia_and_herzegovina
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/bosnia-and-herzegovina?c=clade_membership&f_country=Bosnia and Herzegovin&p=grid&r=division
     name: Bosnia and Herzegovina
     geo: bosnia_and_herzegovina
@@ -467,10 +580,6 @@ builds:
       url: https://neherlab.org
 
 
-  - name: Bulgaria
-    geo: bulgaria
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/bulgaria?c=clade_membership&f_country=Bulgaria&p=grid&r=division
     name: Bulgaria
     geo: bulgaria
@@ -481,10 +590,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Croatia
-    geo: croatia
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/croatia?c=clade_membership&f_country=Croatia&p=grid&r=division
     name: Croatia
@@ -497,10 +602,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Czech Republic
-    geo: czech_republic
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/czech-republic?c=clade_membership&f_country=Czech Republic&p=grid&r=division
     name: Czech Republic
     geo: czech_republic
@@ -511,10 +612,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Denmark
-    geo: denmark
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/denmark?c=clade_membership&f_country=Denmark&p=grid&r=division
     name: Denmark
@@ -527,10 +624,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Estonia
-    geo: estonia
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/estonia?c=clade_membership&f_country=Estonia&p=grid&r=division
     name: Estonia
     geo: estonia
@@ -541,10 +634,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Finland
-    geo: finland
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/finland?c=clade_membership&f_country=Finland&p=grid&r=division
     name: Finland
@@ -557,10 +646,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: France
-    geo: france
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/france?c=clade_membership&f_country=France&p=grid&r=division
     name: France
     geo: france
@@ -571,10 +656,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Germany
-    geo: germany
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/germany?c=clade_membership&f_country=Germany&p=grid&r=division
     name: Germany
@@ -587,10 +668,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Greece
-    geo: greece
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/greece?c=clade_membership&f_country=Greece&p=grid&r=division
     name: Greece
     geo: greece
@@ -601,10 +678,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Hungary
-    geo: hungary
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/hungary?c=clade_membership&f_country=Hungary&p=grid&r=division
     name: Hungary
@@ -617,10 +690,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Iceland
-    geo: iceland
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/iceland?c=clade_membership&f_country=Iceland&p=grid&r=division
     name: Iceland
     geo: iceland
@@ -631,10 +700,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Ireland
-    geo: ireland
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/ireland?c=clade_membership&f_country=Ireland&p=grid&r=division
     name: Ireland
@@ -647,10 +712,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Israel
-    geo: israel
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/israel?c=clade_membership&f_country=Israel&p=grid&r=division
     name: Israel
     geo: israel
@@ -661,10 +722,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Italy
-    geo: italy
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/italy?c=clade_membership&f_country=Italy&p=grid&r=division
     name: Italy
@@ -677,10 +734,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Latvia
-    geo: latvia
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/latvia?c=clade_membership&f_country=Latvia&p=grid&r=division
     name: Latvia
     geo: latvia
@@ -691,10 +744,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Lithuania
-    geo: lithuania
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/lithuania?c=clade_membership&f_country=Lithuania&p=grid&r=division
     name: Lithuania
@@ -707,10 +756,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Luxembourg
-    geo: luxembourg
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/luxembourg?c=clade_membership&f_country=Luxembourg&p=grid&r=division
     name: Luxembourg
     geo: luxembourg
@@ -721,10 +766,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Netherlands
-    geo: netherlands
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/netherlands?c=clade_membership&f_country=Netherlands&p=grid&r=division
     name: Netherlands
@@ -737,10 +778,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Norway
-    geo: norway
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/norway?c=clade_membership&f_country=Norway&p=grid&r=division
     name: Norway
     geo: norway
@@ -751,10 +788,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Poland
-    geo: poland
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/poland?c=clade_membership&f_country=Poland&p=grid&r=division
     name: Poland
@@ -767,10 +800,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Romania
-    geo: romania
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/romania?c=clade_membership&f_country=Romania&p=grid&r=division
     name: Romania
     geo: romania
@@ -781,10 +810,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Russia
-    geo: russia
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/russia?c=clade_membership&f_country=Russia&p=grid&r=division
     name: Russia
@@ -797,10 +822,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Serbia
-    geo: serbia
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/serbia?c=clade_membership&f_country=Serbia&p=grid&r=division
     name: Serbia
     geo: serbia
@@ -811,10 +832,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Slovakia
-    geo: slovakia
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/slovakia?c=clade_membership&f_country=Slovakia&p=grid&r=division
     name: Slovakia
@@ -827,10 +844,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: Slovenia
-    geo: slovenia
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/slovenia?c=clade_membership&f_country=Slovenia&p=grid&r=division
     name: Slovenia
     geo: slovenia
@@ -841,10 +854,6 @@ builds:
     org:
       name: neherlab
       url: https://neherlab.org
-
-  - name: Sweden
-    geo: sweden
-    parentGeo: europe
 
   - url: https://nextstrain.org/groups/neherlab/ncov/sweden?c=clade_membership&f_country=Sweden&p=grid&r=division
     name: Sweden
@@ -857,10 +866,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: United Kingdom
-    geo: united_kingdom
-    parentGeo: europe
-
   - url: https://nextstrain.org/groups/neherlab/ncov/united-kingdom?c=clade_membership&f_country=United Kingdom&p=grid&r=division
     name: United Kingdom
     geo: united_kingdom
@@ -872,10 +877,6 @@ builds:
       name: neherlab
       url: https://neherlab.org
 
-  - name: India
-    geo: india
-    parentGeo: asia
-
   - url: https://nextstrain.org/community/banijolly/Phylovis/COVID-India
     name: India
     geo: india
@@ -886,10 +887,6 @@ builds:
     org:
       name: Vinod Scaria Lab
       url: http://vinodscaria.rnabiology.org/
-
-  - name: Middle East
-    geo: middle-east
-    parentGeo: null
 
   - url: https://nextstrain.org/community/banijolly/Phylovis/COVID-Middle-East
     name: Middle East

--- a/static-site/src/components/sars-cov-2/build-map.jsx
+++ b/static-site/src/components/sars-cov-2/build-map.jsx
@@ -230,7 +230,7 @@ class BuildMap extends React.Component {
     const center = mapDefaults.center;
     const zoom = mapDefaults.zoomOverall;
     // We don't map the stub builds that are used to define the hierarchy
-    const buildsToMap = this.props.builds.filter((build) => build.url !== null && build.coords !== undefined && build.name !== "Global");
+    const buildsToMap = this.props.builds.filter((build) => build.url !== undefined && build.coords !== undefined && build.name !== "Global");
     // Nextstrain builds go separate from clustered community builds on the map
     const nextstrainBuilds = remove(buildsToMap, (b) => b.org && b.org.name === "Nextstrain Team");
 

--- a/static-site/src/components/sars-cov-2/builds.jsx
+++ b/static-site/src/components/sars-cov-2/builds.jsx
@@ -10,20 +10,17 @@ import BuildMap from "./build-map";
 
 /*
 * This is a page to display all builds for SARS-CoV-2 in one place.
-* TODO:
-* - abstract 15px left margin
-* - tweak yaml design for builds list as necessary
 */
 
 const buildComponent = (build) => (
   <splashStyles.SitRepTitle >
-    {build.url === null ? build.name : <div>
+    {build.url === undefined ? build.name : <div>
       <a href={build.url}>
         <FaChartArea />
         {` ${build.name} `}
       </a>
       (
-      {build.org.url === null ? build.org.name : <a href={build.org.url}>{build.org.name}</a>
+      {build.org.url === undefined ? build.org.name : <a href={build.org.url}>{build.org.name}</a>
       }
       )
     </div>}
@@ -43,9 +40,9 @@ class Index extends React.Component {
 
   subBuilds(header, expanded=false, fontSize=20) {
     const children = allSARSCoV2Builds.builds
-      .filter((b) => b.geo === header.geo && b.url !== null);
+      .filter((b) => b.geo === header.geo && b.url);
     const subHeaders = allSARSCoV2Builds.builds
-      .filter((b) => b.parentGeo === header.geo && b.url === null);
+      .filter((b) => b.parentGeo === header.geo && b.url === undefined);
     return (
       <div key={header.name}>
         <Collapsible
@@ -78,7 +75,7 @@ class Index extends React.Component {
   }
 
   buildTree() {
-    const headers = allSARSCoV2Builds.builds.filter((b) => b.url === null);
+    const headers = allSARSCoV2Builds.builds.filter((b) => b.url === undefined);
     const roots = headers.filter((b) => b.parentGeo === null);
     return roots.map((root) => this.subBuilds(root));
   }


### PR DESCRIPTION
Removing some unnecessary `null` fields in this yaml listing of sars-cov-2 builds and adjusting the code to allow them to be undefined instead. Also moves all the hierarchy defining builds to the top for easier reading (I think, though can revert this if others disagree).