### PR TITLE
Fixed typo in allSARS-CoV-2Builds.yaml

### DIFF
--- a/static-site/content/allSARS-CoV-2Builds.yaml
+++ b/static-site/content/allSARS-CoV-2Builds.yaml
@@ -14,7 +14,7 @@ builds:
     geo: global
     parentGeo: null
 
-  - name: South America`
+  - name: South America
     geo: south-america
     parentGeo: null
 


### PR DESCRIPTION
Deleted tickmark ` after South America name

Fixes https://github.com/nextstrain/nextstrain.org/issues/256