### PR TITLE
Add public canada nCoV builds

### DIFF
--- a/static-site/content/allSARS-CoV-2Builds.yaml
+++ b/static-site/content/allSARS-CoV-2Builds.yaml
@@ -332,6 +332,28 @@ builds:
       name: CoVSeQ Partnership
       url: https://covseq.ca/about
 
+  - url: http://auspice.finlaymagui.re/ncov/north-america/canada?f_country=Canada
+    name: Maguire et. al.,
+    geo: canada
+    level: country
+    coords:
+      - -106.3468
+      - 56.1304
+    org:
+      name: Maguire et. al., (for work with ONCoV/CanCOGeN)
+      url: https://finlaymagui.re
+
+  - url: http://auspice.finlaymagui.re/ncov/north-america/canada/ontario?f_division=Ontario
+    name: Maguire et. al.,
+    geo: ontario
+    level: division
+    coords:
+      - -85.3232
+      - 51.2538
+    org:
+      name: Maguire et. al., (for work with ONCoV/CanCOGeN)
+      url: https://finlaymagui.re
+
   - url: https://nextstrain.org/community/SESchmedes/sarscov2-southeast-usa/southeast
     name: South-East Region
     geo: usa

--- a/static-site/content/allSARS-CoV-2Builds.yaml
+++ b/static-site/content/allSARS-CoV-2Builds.yaml
@@ -45,6 +45,10 @@ builds:
     geo: quebec
     parentGeo: canada
 
+  - name: Ontario
+    geo: ontario
+    parentGeo: canada
+
   - name: USA
     geo: usa
     parentGeo: north-america
@@ -333,25 +337,25 @@ builds:
       url: https://covseq.ca/about
 
   - url: http://auspice.finlaymagui.re/ncov/north-america/canada?f_country=Canada
-    name: Maguire et. al.,
+    name: Canada
     geo: canada
     level: country
     coords:
       - -106.3468
       - 56.1304
     org:
-      name: Maguire et. al., (for work with ONCoV/CanCOGeN)
+      name: Maguire et. al., for work with ONCoV/CanCOGeN
       url: https://finlaymagui.re
 
   - url: http://auspice.finlaymagui.re/ncov/north-america/canada/ontario?f_division=Ontario
-    name: Maguire et. al.,
+    name: Ontario, Canada
     geo: ontario
     level: division
     coords:
       - -85.3232
       - 51.2538
     org:
-      name: Maguire et. al., (for work with ONCoV/CanCOGeN)
+      name: Maguire et. al., for work with ONCoV/CanCOGeN
       url: https://finlaymagui.re
 
   - url: https://nextstrain.org/community/SESchmedes/sarscov2-southeast-usa/southeast


### PR DESCRIPTION
This is PR #258 with slight change to the build names so that they are clearer when hovering on the map and the addition of ontario as a heirachy block in the YAML which is necessary for inclusion in the table.

Awesome to see another auspice server being run!

