### PR TITLE
Add the GCC build to the global map

### DIFF
--- a/static-site/content/allSARS-CoV-2Builds.yaml
+++ b/static-site/content/allSARS-CoV-2Builds.yaml
@@ -236,6 +236,10 @@ builds:
   - name: Middle East
     geo: middle-east
     parentGeo: null
+    
+  - name: GCC
+    geo: gcc
+    parentGeo: asia
 
   # Entries below this comment define builds. They should have a URL pointing to the analysis
   # visualisation as well as a name and coords for rendering on the map. The `geo` value should
@@ -968,3 +972,15 @@ builds:
     org:
       name: Vinod Scaria Lab
       url: http://vinodscaria.rnabiology.org/
+
+  - url: https://nextstrain.org/community/alghoribi-lab/ncov/gcc
+    name: GCC
+    geo: gcc
+    level: region
+    coords:
+      - 24.7857025
+      - 49.4726344
+    org:
+      name: Alghoribi Lab (MNGHA - KAIMRC)
+      url: https://kaimrc.med.sa
+      


### PR DESCRIPTION
This PR adds the [GCC](https://nextstrain.org/community/alghoribi-lab/ncov/gcc) build to the global map.
