### PR TITLE
dataset-select mobile view contributor links;

### DIFF
--- a/static-site/src/components/build-pages/dataset-select.jsx
+++ b/static-site/src/components/build-pages/dataset-select.jsx
@@ -14,14 +14,24 @@ import * as splashStyles from "../splash/styles";
 const logoPNG = require("../../../static/logos/favicon.png");
 
 const StyledLinkContainer = styled.div`
-  a,svg {
+  a {
     color: #444;
     font-weight: ${(props) => props.bold ? 700 : "normal"};
   }
-  a,svg:hover,
-  a,svg:focus {
+  a:hover,
+  a:focus {
     color: #5097BA;
     text-decoration: underline;
+  }
+`;
+
+const StyledIconLinkContainer = styled.div`
+  svg {
+    color: #444;
+  }
+  svg:hover,
+  svg:focus {
+    color: #5097BA;
   }
 `;
 
@@ -121,7 +131,7 @@ const renderDatasets = (datasets, showDates) => {
                   <LogoContainer href={dataset.contributor.includes("Nextstrain") ? "https://nextstrain.org" : get(dataset, "contributorUrl")}>
                     {dataset.contributor.includes("Nextstrain") ?
                       <img alt="nextstrain.org" className="logo" width="24px" src={logoPNG}/> :
-                      <StyledLinkContainer><MdPerson/></StyledLinkContainer>
+                      <StyledIconLinkContainer><MdPerson/></StyledIconLinkContainer>
                     }
                   </LogoContainer>
                 </Col>

--- a/static-site/src/components/build-pages/dataset-select.jsx
+++ b/static-site/src/components/build-pages/dataset-select.jsx
@@ -6,6 +6,7 @@ import { debounce, get, sortBy } from 'lodash';
 import styled from 'styled-components';
 import ReactTooltip from 'react-tooltip';
 import { FaInfoCircle } from "react-icons/fa";
+import { MdPerson } from "react-icons/md";
 import {Grid, Col, Row} from 'react-styled-flexboxgrid';
 import { FilterBadge, Tooltip } from "./filterBadge";
 import * as splashStyles from "../splash/styles";
@@ -13,12 +14,12 @@ import * as splashStyles from "../splash/styles";
 const logoPNG = require("../../../static/logos/favicon.png");
 
 const StyledLinkContainer = styled.div`
-  a {
+  a,svg {
     color: #444;
     font-weight: ${(props) => props.bold ? 700 : "normal"};
   }
-  a:hover,
-  a:focus {
+  a,svg:hover,
+  a,svg:focus {
     color: #5097BA;
     text-decoration: underline;
   }
@@ -117,8 +118,11 @@ const renderDatasets = (datasets, showDates) => {
                   {dataset.date_uploaded}
                 </Col>}
                 <Col xs={2} sm={false} style={{textAlign: "right"}}>
-                  <LogoContainer href="https://nextstrain.org">
-                    <img alt="nextstrain.org" className="logo" width="24px" src={logoPNG}/>
+                  <LogoContainer href={dataset.contributor.includes("Nextstrain") ? "https://nextstrain.org" : get(dataset, "contributorUrl")}>
+                    {dataset.contributor.includes("Nextstrain") ?
+                      <img alt="nextstrain.org" className="logo" width="24px" src={logoPNG}/> :
+                      <StyledLinkContainer><MdPerson/></StyledLinkContainer>
+                    }
                   </LogoContainer>
                 </Col>
               </Row>


### PR DESCRIPTION
this was previously hardcoded to be a
nextstrain logo. I replace it here with a
person icon for non-Nextstrain contributors

will merge right away since its a 1 commit quick fix to #286 and people might be mad if they view /sars-cov-2 on mobile and it looks like we are crediting ourselves for their datasets.