### PR TITLE
flexible column prop for dataset-select listing

### DIFF
--- a/static-site/src/components/Datasets/dataset-select.jsx
+++ b/static-site/src/components/Datasets/dataset-select.jsx
@@ -83,58 +83,83 @@ const LogoContainer = styled.a`
   cursor: pointer;
 `;
 
-const renderDatasets = (datasets, showDates) => {
+const datasetListingColumn = {
+  dataset: {
+    colHeader: (
+      <Col xs={8} sm={6} md={7}>
+       Dataset
+      </Col>),
+    colEntry: (dataset) => (
+      <Col xs={10} sm={6} md={7}>
+        <StyledLinkContainer bold>
+          <a href={dataset.url}>{dataset.filename.replace(/_/g, ' / ').replace('.json', '')}</a>
+        </StyledLinkContainer>
+      </Col>
+    )
+  },
+  contributor: {
+    colHeader: (
+      <>
+        <Col xs={false} sm={3} md={3}>
+          Contributor
+        </Col>
+        <Col xs={4} sm={false} style={{textAlign: "right"}}>
+          Contributor
+        </Col>
+      </>),
+    colEntry: (dataset) => (
+      <>
+        <Col xs={false} sm={3} md={3}>
+          <span>
+            {dataset.contributor.includes("Nextstrain") && <LogoContainer href="https://nextstrain.org">
+              <img alt="nextstrain.org" className="logo" width="24px" src={logoPNG}/>
+            </LogoContainer>}
+            {dataset.contributorUrl === undefined ?
+              dataset.contributor :
+              <StyledLinkContainer>
+                <a href={dataset.contributorUrl}>{dataset.contributor}</a>
+              </StyledLinkContainer>}
+          </span>
+        </Col>
+        <Col xs={2} sm={false} style={{textAlign: "right"}}>
+          <LogoContainer href={dataset.contributor.includes("Nextstrain") ? "https://nextstrain.org" : get(dataset, "contributorUrl")}>
+            {dataset.contributor.includes("Nextstrain") ?
+              <img alt="nextstrain.org" className="logo" width="24px" src={logoPNG}/> :
+              <StyledIconLinkContainer><MdPerson/></StyledIconLinkContainer>
+            }
+          </LogoContainer>
+        </Col>
+      </>
+    )
+  },
+  uploadedDate: {
+    colHeader: (
+      <Col xs={false} sm={3} md={2}>
+        Uploaded date
+      </Col>),
+    colEntry: (dataset) => (
+      <Col xs={false} sm={3} md={2}>
+        {dataset.date_uploaded}
+      </Col>
+    )
+  }
+
+};
+
+const renderDatasets = (datasets, columns) => {
   return (
     <>
       <Grid fluid>
         <DatasetContainer key="Column labels" style={{borderBottom: "1px solid #CCC"}}>
           <Row>
-            <Col xs={8} sm={6} md={7}>
-              Dataset
-            </Col>
-            <Col xs={false} sm={3} md={3}>
-              Contributor
-            </Col>
-            {showDates && <Col xs={false} sm={3} md={2}>
-              Uploaded date
-            </Col>}
-            <Col xs={4} sm={false} style={{textAlign: "right"}}>
-              Contributor
-            </Col>
+            {columns.map((colName) => datasetListingColumn[colName].colHeader)}
           </Row>
         </DatasetContainer>
         <DatasetSelectionResultsContainer>
           { datasets.map((dataset) => (
             <DatasetContainer key={dataset.filename}>
               <Row>
-                <Col xs={10} sm={6} md={7}>
-                  <StyledLinkContainer bold>
-                    <a href={dataset.url}>{dataset.filename.replace(/_/g, ' / ').replace('.json', '')}</a>
-                  </StyledLinkContainer>
-                </Col>
-                <Col xs={false} sm={3} md={3}>
-                  <span>
-                    {dataset.contributor.includes("Nextstrain") && <LogoContainer href="https://nextstrain.org">
-                      <img alt="nextstrain.org" className="logo" width="24px" src={logoPNG}/>
-                    </LogoContainer>}
-                    {dataset.contributorUrl === undefined ?
-                      dataset.contributor :
-                      <StyledLinkContainer>
-                        <a href={dataset.contributorUrl}>{dataset.contributor}</a>
-                      </StyledLinkContainer>}
-                  </span>
-                </Col>
-                {showDates && <Col xs={false} sm={3} md={2}>
-                  {dataset.date_uploaded}
-                </Col>}
-                <Col xs={2} sm={false} style={{textAlign: "right"}}>
-                  <LogoContainer href={dataset.contributor.includes("Nextstrain") ? "https://nextstrain.org" : get(dataset, "contributorUrl")}>
-                    {dataset.contributor.includes("Nextstrain") ?
-                      <img alt="nextstrain.org" className="logo" width="24px" src={logoPNG}/> :
-                      <StyledIconLinkContainer><MdPerson/></StyledIconLinkContainer>
-                    }
-                  </LogoContainer>
-                </Col>
+                {columns.map((colName) => datasetListingColumn[colName].colEntry(dataset))}
               </Row>
             </DatasetContainer>
           ))
@@ -391,7 +416,7 @@ class DatasetSelect extends React.Component {
           ) : null}
         </div>
 
-        {renderDatasets(filteredDatasets, !this.props.noDates)}
+        {renderDatasets(filteredDatasets, this.props.columns)}
 
       </>
     );

--- a/static-site/src/pages/influenza.jsx
+++ b/static-site/src/pages/influenza.jsx
@@ -115,7 +115,7 @@ class Index extends React.Component {
                     <div className="col-md-1"/>
                     <div className="col-md-10">
                       {this.state.dataLoaded &&
-                      <DatasetSelect datasets={this.state.datasets} />}
+                      <DatasetSelect datasets={this.state.datasets} columns={["dataset", "contributor", "uploadedDate"]}/>}
                     </div>
                   </div>
                   { this.state.errorFetchingData && <splashStyles.CenteredFocusParagraph>

--- a/static-site/src/pages/sars-cov-2.jsx
+++ b/static-site/src/pages/sars-cov-2.jsx
@@ -165,7 +165,7 @@ class Index extends React.Component {
                     <MediumSpacer />
                     <div className="col-md-1"/>
                     <div className="col-md-10">
-                      {this.state.filterParsed && <DatasetSelect datasets={this.state.filterList} noDates/>}
+                      {this.state.filterParsed && <DatasetSelect datasets={this.state.filterList} columns={["dataset", "contributor"]}/>}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
This doesn't change how things are rendering right now but creates a more flexible react pattern that will allow us to change how things render more easily in the future if we want. 

This allows you to specify the columns you would like to display when rendering datasets below the filter bar in the scrollable table. They render in the order you pass them. You must choose from the options in the object: "datasetListingColumn" in the dataset-select component. There's no error handling for if you choose one that isn't there since the options you choose are static / baked into the code and not determined dynamically.