### PR TITLE
Allow pages to define and inject dataset-related components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,6 +37,7 @@ rules:
   react/jsx-filename-extension: [1, { "extensions": [".js", ".jsx"] }]
   react/jsx-first-prop-new-line: off
   react/no-did-mount-set-state: off
+  react/require-default-props: off
   react/no-did-update-set-state: off
   react/prop-types: off # possibly reinstate
   react/sort-comp: off # possibly reinstate

--- a/static-site/src/components/Datasets/dataset-select.jsx
+++ b/static-site/src/components/Datasets/dataset-select.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import "react-select/dist/react-select.css";
 import "react-virtualized-select/styles.css";
 import { get, sortBy } from 'lodash';
@@ -8,13 +9,21 @@ import { FilterDisplay } from "./filter-display";
 import { collectAvailableFilteringOptions, computeFilterValues } from "./filter-helpers";
 
 /**
- * <FilterData> is a (keyboard)-typing based search box intended to
- * allow users to filter samples. The filtering rules are not implemented
- * in this component, but are useful to spell out: we take the union of
- * entries within each category and then take the intersection of those unions.
+ * <DatasetSelect> is intended to render datasets [0] and expose a filtering UI to dynamically
+ * restrict the visible datasets.
+ *
+ * PROPS:
+ * @prop {string | undefined} urlDefinedFilterPath slash-separated keywords which will be applied as filters
+ * @prop {string | undefined} intendedUri Intended URI. Browser address will be replaced with this.
+ * @prop {Array} datasets Available datasets. Array of Objects.
+ * @prop {boolean} noDates Note: will be replaced in a subsequent commit
+ *
+ * @returns React Component
+ *
+ * [0] Currently only datasets are rendered, but in the future narratives and other assets
+ *     may be displayed
  */
 class DatasetSelect extends React.Component {
-
   constructor(props) {
     super(props);
     this.state = {
@@ -82,5 +91,12 @@ class DatasetSelect extends React.Component {
     );
   }
 }
+
+DatasetSelect.propTypes = {
+  urlDefinedFilterPath: PropTypes.string,
+  intendedUri: PropTypes.string,
+  noDates: PropTypes.bool,
+  datasets: PropTypes.array.isRequired
+};
 
 export default DatasetSelect;

--- a/static-site/src/components/Datasets/filter-display.jsx
+++ b/static-site/src/components/Datasets/filter-display.jsx
@@ -5,6 +5,7 @@
 import { sum } from "lodash";
 import React from "react";
 import { Tooltip, FilterBadge} from "./filterBadge";
+import { CenteredContainer } from "./styles";
 
 
 const Intersect = ({id}) => (
@@ -31,7 +32,7 @@ export const FilterDisplay = ({filters, applyFilter}) => {
   if (!sum(filtersByCategory.map((c) => c.badges.length))) return null;
 
   return (
-    <>
+    <CenteredContainer>
       {"Filtered to "}
       {filtersByCategory.map((filterCategory, idx) => {
         const multipleFilterBadges = filterCategory.badges.length > 1;
@@ -68,7 +69,7 @@ export const FilterDisplay = ({filters, applyFilter}) => {
         );
       })}
       {". "}
-    </>
+    </CenteredContainer>
   );
 };
 

--- a/static-site/src/components/Datasets/filter-selection.jsx
+++ b/static-site/src/components/Datasets/filter-selection.jsx
@@ -10,13 +10,9 @@ import { FaInfoCircle } from "react-icons/fa";
 import Select from "react-virtualized-select";
 import * as splashStyles from "../splash/styles";
 import { collectAvailableFilteringOptions } from "./filter-helpers";
+import { CenteredContainer } from "./styles";
 
 const DEBOUNCE_TIME = 200;
-
-const Container = styled.div`
-  margin-bottom: 0px;
-  font-size: 14px;
-`;
 
 const StyledTooltip = styled(ReactTooltip)`
   max-width: 30vh;
@@ -32,7 +28,7 @@ export const FilterSelect = ({datasets, applyFilter}) => {
   const options = collectAvailableFilteringOptions(datasets);
 
   return (
-    <Container>
+    <CenteredContainer>
       <splashStyles.H3 left>
         {`Filter datasets `}
         <>
@@ -64,7 +60,7 @@ export const FilterSelect = ({datasets, applyFilter}) => {
         valueKey="label"
         onChange={(sel) => applyFilter("add", sel.value[0], [sel.value[1]])}
       />
-    </Container>
+    </CenteredContainer>
   );
 };
 

--- a/static-site/src/components/Datasets/filter-selection.jsx
+++ b/static-site/src/components/Datasets/filter-selection.jsx
@@ -27,7 +27,7 @@ const StyledTooltip = styled(ReactTooltip)`
   pointer-events: auto !important;
 `;
 
-export const DatasetFilteringSelection = ({datasets, applyFilter}) => {
+export const FilterSelect = ({datasets, applyFilter}) => {
 
   const options = collectAvailableFilteringOptions(datasets);
 

--- a/static-site/src/components/Datasets/filter-selection.jsx
+++ b/static-site/src/components/Datasets/filter-selection.jsx
@@ -9,7 +9,6 @@ import ReactTooltip from 'react-tooltip';
 import { FaInfoCircle } from "react-icons/fa";
 import Select from "react-virtualized-select";
 import * as splashStyles from "../splash/styles";
-import { collectAvailableFilteringOptions } from "./filter-helpers";
 import { CenteredContainer } from "./styles";
 
 const DEBOUNCE_TIME = 200;
@@ -23,9 +22,7 @@ const StyledTooltip = styled(ReactTooltip)`
   pointer-events: auto !important;
 `;
 
-export const FilterSelect = ({datasets, applyFilter}) => {
-
-  const options = collectAvailableFilteringOptions(datasets);
+export const FilterSelect = ({options, applyFilter}) => {
 
   return (
     <CenteredContainer>

--- a/static-site/src/components/Datasets/list-datasets.jsx
+++ b/static-site/src/components/Datasets/list-datasets.jsx
@@ -1,33 +1,17 @@
 import React from "react";
 import "react-select/dist/react-select.css";
 import "react-virtualized-select/styles.css";
-import { get } from 'lodash';
 import styled from 'styled-components';
-import { MdPerson } from "react-icons/md";
 import {Grid, Col, Row} from 'react-styled-flexboxgrid';
 import { CenteredContainer } from "./styles";
 
-const logoPNG = require("../../../static/logos/favicon.png");
-
-const StyledLinkContainer = styled.div`
-  a {
-    color: #444;
-    font-weight: ${(props) => props.bold ? 700 : "normal"};
-  }
-  a:hover,
-  a:focus {
-    color: #5097BA;
+const StyledLink = styled.a`
+  color: #444 !important;
+  font-weight: ${(props) => props.bold ? 500 : 300} !important;
+  &:hover,
+  &:focus {
+    color: #5097BA !important;
     text-decoration: underline;
-  }
-`;
-
-const StyledIconLinkContainer = styled.div`
-  svg {
-    color: #444;
-  }
-  svg:hover,
-  svg:focus {
-    color: #5097BA;
   }
 `;
 
@@ -37,77 +21,137 @@ const DatasetSelectionResultsContainer = styled.div`
   overflow-y: visible;
 `;
 
-const DatasetContainer = styled.div`
+const RowContainer = styled.div`
   font-family: ${(props) => props.theme.generalFont};
   font-weight: 900;
   font-size: 18px;
   padding: 10px 1px 10px 1px;
   line-height: 24px;
+  ${(props) => props.border && `border-bottom: 1px solid #CCC;`}
 `;
 
-const LogoContainer = styled.a`
+const LogoContainerLink = styled.a`
   padding: 1px 1px;
   margin-right: 5px;
   width: 24px;
   cursor: pointer;
 `;
 
-export const ListDatasets = ({datasets, showDates}) => {
+const LogoContainer = styled.span`
+  padding: 1px 1px;
+  margin-right: 5px;
+  width: 24px;
+`;
+
+const columnStyles = [
+  [{xs: 8, sm: 6, md: 7}], // column 1 rendered as a single <Col>
+  [{xs: false, sm: 3, md: 3}, {xs: 4, sm: false, style: {textAlign: 'right'}}], // column 2
+  [{xs: false, sm: 3, md: 2}]
+];
+
+const HeaderRow = ({columns}) => {
+  const names = columns.map((c) => c.name);
+  return (
+    <RowContainer>
+      <Row>
+        {/* column 1 (typically the dataset) - same rendering on main & mobile views */}
+        <Col {...columnStyles[0][0]} key={names[0]}>{names[0]}</Col>
+
+        {/* column 2: (typically the contributor) - both main & mobile views */}
+        <Col {...columnStyles[1][0]} key={names[1]}>{names[1]}</Col>
+        <Col {...columnStyles[1][1]} key={`${names[1]}-mobile`}>{names[1]}</Col>
+
+        {/* column 3: optional. Not rendered on small screens. */}
+        {names.length===3 && (
+          <Col {...columnStyles[2][0]} key={names[2]}>{names[2]}</Col>
+        )}
+      </Row>
+    </RowContainer>
+  );
+};
+
+const NormalRow = ({columns, dataset}) => {
+  const names = columns.map((c) => c.name);
+  return (
+    <RowContainer>
+      <Row>
+        {/* column 1 (typically the dataset) - same rendering on main & mobile views */}
+        <Col {...columnStyles[0][0]} key={names[0]}>
+          <Value dataset={dataset} columnInfo={columns[0]} firstColumn/>
+        </Col>
+
+        {/* column 2: (typically the contributor) - both main & mobile views */}
+        <Col {...columnStyles[1][0]} key={names[1]}>
+          <Value dataset={dataset} columnInfo={columns[1]}/>
+        </Col>
+        <Col {...columnStyles[1][1]} key={`${names[1]}-mobile`}>
+          <Value dataset={dataset} columnInfo={columns[1]} mobileView/>
+        </Col>
+
+        {/* column 3: optional. Not rendered on small screens. */}
+        {names.length===3 && (
+          <Col {...columnStyles[2][0]} key={names[2]}>
+            <Value dataset={dataset} columnInfo={columns[2]} mobileView/>
+          </Col>
+        )}
+      </Row>
+    </RowContainer>
+  );
+};
+
+/**
+ * Render the value for a particular cell in the table.
+ * May be a link and/or have a logo, depending on the data in `columnInfo`
+ */
+const Value = ({dataset, columnInfo, mobileView, firstColumn}) => {
+  const url = typeof columnInfo.url === "function" && columnInfo.url(dataset);
+  const value = mobileView && typeof columnInfo.valueMobile === "function" ?
+    columnInfo.valueMobile(dataset) :
+    columnInfo.value(dataset);
+  const logo = mobileView && typeof columnInfo.logoMobile === "function" ?
+    columnInfo.logoMobile(dataset) :
+    typeof columnInfo.logo === "function" ?
+      columnInfo.logo(dataset) :
+      undefined;
+  return (
+    <>
+      {(logo && url) ?
+        (<LogoContainerLink href={url}>{logo}</LogoContainerLink>) :
+        logo ?
+          (<LogoContainer>{logo}</LogoContainer>) :
+          null
+      }
+      {url ?
+        <StyledLink bold={firstColumn} href={url}>{value}</StyledLink> :
+        value
+      }
+    </>
+  );
+};
+
+
+/**
+ * React component to render a table showing the `datasets` as rows with
+ * the specified `columns`. Open to future expansion.
+ * Currently only 2 or 3 columns are supported.
+ * If 3 columns are supplied, the 3rd will not be shown on small screens.
+ * @prop {Array} columns Array of columns. Each entry is an object with following properties:
+ *       `name` {string} To be displayed in the header
+ *       `value` {function} return the value, given an individual entry from `datasets`
+ *       `valueMobile` {function | undefined} value to be used on small screens
+ *       `url` {function | undefined} render the value as a link to this URL
+ *       `logo` {function | undefined} if the function returns "nextstrain" then we render the Nextstrain logo.
+ * @returns React Component
+ */
+export const ListDatasets = ({datasets, columns}) => {
   return (
     <CenteredContainer>
       <Grid fluid>
-        <DatasetContainer key="Column labels" style={{borderBottom: "1px solid #CCC"}}>
-          <Row>
-            <Col xs={8} sm={6} md={7}>
-              Dataset
-            </Col>
-            <Col xs={false} sm={3} md={3}>
-              Contributor
-            </Col>
-            {showDates && <Col xs={false} sm={3} md={2}>
-              Uploaded date
-            </Col>}
-            <Col xs={4} sm={false} style={{textAlign: "right"}}>
-              Contributor
-            </Col>
-          </Row>
-        </DatasetContainer>
+        <HeaderRow columns={columns}/>
         <DatasetSelectionResultsContainer>
-          { datasets.map((dataset) => (
-            <DatasetContainer key={dataset.filename}>
-              <Row>
-                <Col xs={10} sm={6} md={7}>
-                  <StyledLinkContainer bold>
-                    <a href={dataset.url}>{dataset.filename.replace(/_/g, ' / ').replace('.json', '')}</a>
-                  </StyledLinkContainer>
-                </Col>
-                <Col xs={false} sm={3} md={3}>
-                  <span>
-                    {dataset.contributor.includes("Nextstrain") && <LogoContainer href="https://nextstrain.org">
-                      <img alt="nextstrain.org" className="logo" width="24px" src={logoPNG}/>
-                    </LogoContainer>}
-                    {dataset.contributorUrl === undefined ?
-                      dataset.contributor :
-                      <StyledLinkContainer>
-                        <a href={dataset.contributorUrl}>{dataset.contributor}</a>
-                      </StyledLinkContainer>}
-                  </span>
-                </Col>
-                {showDates && <Col xs={false} sm={3} md={2}>
-                  {dataset.date_uploaded}
-                </Col>}
-                <Col xs={2} sm={false} style={{textAlign: "right"}}>
-                  <LogoContainer href={dataset.contributor.includes("Nextstrain") ? "https://nextstrain.org" : get(dataset, "contributorUrl")}>
-                    {dataset.contributor.includes("Nextstrain") ?
-                      <img alt="nextstrain.org" className="logo" width="24px" src={logoPNG}/> :
-                      <StyledIconLinkContainer><MdPerson/></StyledIconLinkContainer>
-                    }
-                  </LogoContainer>
-                </Col>
-              </Row>
-            </DatasetContainer>
-          ))
-          }
+          {datasets.map((dataset) => (
+            <NormalRow dataset={dataset} columns={columns} key={columns[0].value(dataset)}/>
+          ))}
         </DatasetSelectionResultsContainer>
       </Grid>
     </CenteredContainer>

--- a/static-site/src/components/Datasets/list-datasets.jsx
+++ b/static-site/src/components/Datasets/list-datasets.jsx
@@ -5,6 +5,7 @@ import { get } from 'lodash';
 import styled from 'styled-components';
 import { MdPerson } from "react-icons/md";
 import {Grid, Col, Row} from 'react-styled-flexboxgrid';
+import { CenteredContainer } from "./styles";
 
 const logoPNG = require("../../../static/logos/favicon.png");
 
@@ -53,7 +54,7 @@ const LogoContainer = styled.a`
 
 export const ListDatasets = ({datasets, showDates}) => {
   return (
-    <>
+    <CenteredContainer>
       <Grid fluid>
         <DatasetContainer key="Column labels" style={{borderBottom: "1px solid #CCC"}}>
           <Row>
@@ -109,6 +110,6 @@ export const ListDatasets = ({datasets, showDates}) => {
           }
         </DatasetSelectionResultsContainer>
       </Grid>
-    </>
+    </CenteredContainer>
   );
 };

--- a/static-site/src/components/Datasets/styles.jsx
+++ b/static-site/src/components/Datasets/styles.jsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const CenteredContainer = styled.div`
+  margin: 0px auto 0px auto;
+  max-width: 800px;
+`;

--- a/static-site/src/pages/influenza-page.jsx
+++ b/static-site/src/pages/influenza-page.jsx
@@ -102,26 +102,17 @@ class Index extends React.Component {
               <ScrollableAnchor id={"datasets"}>
                 <div>
                   <HugeSpacer /><HugeSpacer />
-                  <splashStyles.H2 left>
+                  <splashStyles.H2>
                     Influenza datasets
                   </splashStyles.H2>
-                  <SmallSpacer />
-                  <splashStyles.FocusParagraph>
-                    This section is an index of Nextstrain datasets for flu, organized by type.
-                  </splashStyles.FocusParagraph>
-                  <div className="row">
-                    <MediumSpacer />
-                    <div className="col-md-1"/>
-                    <div className="col-md-10">
-                      {this.state.dataLoaded && (
-                        <DatasetSelect
-                          datasets={this.state.datasets}
-                          urlDefinedFilterPath={this.props["*"]}
-                          intendedUri={this.props.uri}
-                        />
-                      )}
-                    </div>
-                  </div>
+                  <HugeSpacer />
+                  {this.state.dataLoaded && (
+                    <DatasetSelect
+                      datasets={this.state.datasets}
+                      urlDefinedFilterPath={this.props["*"]}
+                      intendedUri={this.props.uri}
+                    />
+                  )}
                   { this.state.errorFetchingData && <splashStyles.CenteredFocusParagraph>
                               Something went wrong getting data.
                               Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>

--- a/static-site/src/pages/influenza-page.jsx
+++ b/static-site/src/pages/influenza-page.jsx
@@ -16,6 +16,8 @@ import Footer from "../components/Footer";
 import { PathogenPageIntroduction } from "../components/Datasets/pathogen-page-introduction";
 import DatasetSelect from "../components/Datasets/dataset-select";
 
+const nextstrainLogoPNG = require("../../static/logos/favicon.png");
+
 const title = "Influenza resources";
 const abstract = `The Nextstrain team maintains datasets and other tools for analyzing a variety of influenza viruses.
 We track the evolution of seasonal influenza viruses (A/H3N2, A/H1N1pdm, B/Victoria, and B/Yamagata)
@@ -51,6 +53,25 @@ const contents = [
     to: "/search/seasonal-flu",
     title: "Search seasonal flu datasets by strain name(s)",
     subtext: "Search all seasonal influenza nextstrain datasets, including historical ones, for particular strain name(s)",
+  }
+];
+
+const tableColumns = [
+  {
+    name: "Dataset",
+    value: (dataset) => dataset.filename.replace(/_/g, ' / ').replace('.json', ''),
+    url: (dataset) => dataset.url
+  },
+  {
+    name: "Contributor",
+    value: () => "Nextstrain",
+    valueMobile: () => "",
+    url: () => "https://nextstrain.org",
+    logo: () => (<img alt="nextstrain.org" className="logo" width="24px" src={nextstrainLogoPNG}/>)
+  },
+  {
+    name: "Uploaded Date",
+    value: (dataset) => dataset.date_uploaded
   }
 ];
 
@@ -109,6 +130,7 @@ class Index extends React.Component {
                   {this.state.dataLoaded && (
                     <DatasetSelect
                       datasets={this.state.datasets}
+                      columns={tableColumns}
                       urlDefinedFilterPath={this.props["*"]}
                       intendedUri={this.props.uri}
                     />

--- a/static-site/src/pages/sars-cov-2-page.jsx
+++ b/static-site/src/pages/sars-cov-2-page.jsx
@@ -160,26 +160,23 @@ class Index extends React.Component {
                     If you know of a dataset not listed here, please let us know!
                     Please note that inclusion on this list does not indicate an endorsement by the Nextstrain team.
                   </splashStyles.FocusParagraph>
-                  <div className="row">
-                    <MediumSpacer />
-                    <div className="col-md-1"/>
-                    <div className="col-md-10">
-                      {this.state.filterParsed && (
-                        <DatasetSelect
-                          datasets={this.state.filterList}
-                          noDates
-                          interface={[
-                            DatasetMap,
-                            "FilterSelect",
-                            "FilterDisplay",
-                            "ListDatasets"
-                          ]}
-                          urlDefinedFilterPath={this.props["*"]}
-                          intendedUri={this.props.uri}
-                        />
-                      )}
-                    </div>
-                  </div>
+
+                  <HugeSpacer/>
+                  {this.state.filterParsed && (
+                    <DatasetSelect
+                      datasets={this.state.filterList}
+                      noDates
+                      interface={[
+                        DatasetMap,
+                        "FilterSelect",
+                        "FilterDisplay",
+                        "ListDatasets"
+                      ]}
+                      urlDefinedFilterPath={this.props["*"]}
+                      intendedUri={this.props.uri}
+                    />
+                  )}
+
                 </div>
               </ScrollableAnchor>
 

--- a/static-site/src/pages/sars-cov-2-page.jsx
+++ b/static-site/src/pages/sars-cov-2-page.jsx
@@ -160,7 +160,6 @@ class Index extends React.Component {
                     If you know of a dataset not listed here, please let us know!
                     Please note that inclusion on this list does not indicate an endorsement by the Nextstrain team.
                   </splashStyles.FocusParagraph>
-                  <DatasetMap datasets={this.state.catalogueDatasets}/>
                   <div className="row">
                     <MediumSpacer />
                     <div className="col-md-1"/>
@@ -169,6 +168,12 @@ class Index extends React.Component {
                         <DatasetSelect
                           datasets={this.state.filterList}
                           noDates
+                          interface={[
+                            DatasetMap,
+                            "FilterSelect",
+                            "FilterDisplay",
+                            "ListDatasets"
+                          ]}
                           urlDefinedFilterPath={this.props["*"]}
                           intendedUri={this.props.uri}
                         />

--- a/static-site/src/pages/sars-cov-2-page.jsx
+++ b/static-site/src/pages/sars-cov-2-page.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Helmet from "react-helmet";
 import ScrollableAnchor, { configureAnchors } from "react-scrollable-anchor";
+import { MdPerson } from "react-icons/md";
 import { get } from 'lodash';
 import config from "../../data/SiteConfig";
 import NavBar from "../components/nav-bar";
@@ -20,6 +21,9 @@ import { SituationReportsByLanguage } from "../components/Datasets/situation-rep
 import { PathogenPageIntroduction } from "../components/Datasets/pathogen-page-introduction";
 import {parseNcovSitRepInfo} from "../../../auspice-client/customisations/languageSelector";
 import sarscov2Catalogue from "../../content/SARS-CoV-2-Datasets.yaml";
+
+const nextstrainLogoPNG = require("../../static/logos/favicon.png");
+
 
 const title = "Nextstrain SARS-CoV-2 resources";
 const abstract = `Around the world, people are sequencing and sharing SARS-CoV-2
@@ -104,6 +108,27 @@ const contents = [
   }
 ];
 
+const tableColumns = [
+  {
+    name: "Dataset",
+    value: (dataset) => dataset.filename.replace(/_/g, ' / ').replace('.json', ''),
+    url: (dataset) => dataset.url
+  },
+  {
+    name: "Contributor",
+    value: (dataset) => dataset.contributor,
+    valueMobile: () => "",
+    url: (dataset) => dataset.contributorUrl,
+    logo: (dataset) => dataset.contributor==="Nextstrain Team" ?
+      <img alt="nextstrain.org" className="logo" width="24px" src={nextstrainLogoPNG}/> :
+      undefined,
+    logoMobile: (dataset) => dataset.contributor==="Nextstrain Team" ?
+      <img alt="nextstrain.org" className="logo" width="24px" src={nextstrainLogoPNG}/> :
+      <MdPerson/>
+  }
+];
+
+
 class Index extends React.Component {
   constructor(props) {
     super(props);
@@ -165,7 +190,7 @@ class Index extends React.Component {
                   {this.state.filterParsed && (
                     <DatasetSelect
                       datasets={this.state.filterList}
-                      noDates
+                      columns={tableColumns}
                       interface={[
                         DatasetMap,
                         "FilterSelect",


### PR DESCRIPTION
This PR is based off commits 9733985, a8db4cb and 491682e (all by @eharkins, see PR #291). The main changes are due to the refactoring previously done in #299.

The `interface` prop passed to `<DatasetSelect>` (originally implemented in 9733985) has been generalised to take any number of (react) components as props, although this is only currently used by the geographic map in sars-cov-2.

