### PR TITLE
WIP: list all datasets at path "/all"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14647,6 +14647,11 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "ndjson-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ndjson-parse/-/ndjson-parse-1.0.4.tgz",
+      "integrity": "sha512-xwglvz2dMbxvX4NAVKnww8xEJ4kp4+CKVseQQdtkA79yI3abPqyBYqk6A6HvNci5oS0cUsSHheMEV1c+9MWlEw=="
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "js-yaml": "^4.0.0",
     "make-fetch-happen": "^7.1.1",
     "marked": "^0.7.0",
+    "ndjson-parse": "^1.0.4",
     "node-fetch": "^2.6.0",
     "p-limit": "^3.0.1",
     "passport": "^0.4.0",

--- a/scripts/tmp-collect-all.js
+++ b/scripts/tmp-collect-all.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+const AWS = require("aws-sdk");
+const limit = require('p-limit')(20);
+const fs = require('fs');
+const path = require('path');
+const ndjsonParser = require('ndjson-parse');
+const sources = require("../src/sources.js");
+
+// this script is proof-of-principle quality
+main();
+
+
+async function main() {
+  const datasets = [];
+
+  const core = await collectFromBucket({
+    BUCKET: `nextstrain-data`,
+    fileToUrl: (filename) => `https://nextstrain.org/${filename.replace('.json', '').replace(/_/g, '/')}`,
+    inclusionTest: () => true
+  });
+  core.forEach((obj) => datasets.push({
+    filename: obj.filename,
+    date_uploaded: obj.date_uploaded,
+    url: obj.url,
+    contributor: "Nextstrain",
+    source: "Core"
+  }));
+
+  const staging = await collectFromBucket({
+    BUCKET: `nextstrain-staging`,
+    fileToUrl: (filename) => `https://nextstrain.org/staging/${filename.replace('.json', '').replace(/_/g, '/')}`,
+    inclusionTest: () => true
+  });
+  staging.forEach((obj) => datasets.push({
+    filename: obj.filename,
+    date_uploaded: obj.date_uploaded,
+    url: obj.url,
+    contributor: "Nextstrain",
+    source: "Staging"
+  }));
+
+  // PUBLIC GROUPS:
+  for (const [sourceName, Source] of sources) {
+    if (Source.isGroup() && Source.visibleToUser()) { // both static methods
+      const source = new Source();
+      const data = await collectFromBucket({ // eslint-disable-line no-await-in-loop
+        BUCKET: source.bucket,
+        fileToUrl: (filename) => `https://nextstrain.org/groups/${sourceName}/${filename.replace('.json', '').replace(/_/g, '/')}`,
+        inclusionTest: () => true
+      });
+      data.forEach((obj) => datasets.push({
+        filename: obj.filename,
+        date_uploaded: obj.date_uploaded,
+        url: obj.url,
+        contributor: sourceName,
+        source: `Public Group`
+      }));
+    }
+  }
+
+  // following assumes your directory structure is the same as mine!
+  const communityNdJson = fs.readFileSync("../community-search/community.ndjson", {encoding: "utf-8"});
+  const communityJson = ndjsonParser(communityNdJson);
+  communityJson
+    .filter((obj) => obj.valid)
+    .forEach((obj) => datasets.push({
+      filename: obj.url.replace("https://nextstrain.org/community/", "").replace(/\//g, '_'),
+      date_uploaded: "unknown",
+      url: obj.url,
+      contributor: obj.repo.owner,
+      source: `Community`
+    }));
+
+  // restrict to unique URLs
+  const seen = new Set();
+  const uniqueDatasets = datasets.filter((f) => {
+    if (seen.has(f.url)) return false;
+    seen.add(f.url);
+    return true;
+  });
+
+  // console.log(datasets);
+
+  if (!fs.existsSync("./data")) fs.mkdirSync("./data");
+  const outputFilename = path.join("./data/", "tmp-all-datasets.json");
+  console.log("Writing search data to file ", `${outputFilename}`);
+  fs.writeFileSync(outputFilename, JSON.stringify(uniqueDatasets, null, 1));
+
+  console.log("\n\nNext step: upload outputs to the S3 bucket via the following command");
+  console.log(`\t\`nextstrain remote upload s3://nextstrain-staging/james/ data/tmp-all-datasets.json\``);
+}
+
+
+/* following duplicated from "collect-datasets.js" */
+async function collectFromBucket({BUCKET, fileToUrl, inclusionTest}) {
+  const S3 = new AWS.S3();
+  console.log(`Collecting datasets from ${BUCKET} to retrieve metadata...`);
+  let s3Objects;
+  try {
+    s3Objects = await S3.listObjectsV2({Bucket: BUCKET}).promise();
+  } catch (err) {
+    console.log("Error listing objects via the S3 API -- were credentials correctly set?");
+    console.log(err.message);
+    process.exit(0); // exit zero so the build script doesn't fail causing the site to not be deployed.
+  }
+  if (s3Objects.isTruncated) console.log("WARNING: S3 listing is truncated. Results will be incomplete.");
+  s3Objects = s3Objects.Contents
+    .filter((s3obj) => filenameLooksLikeDataset(s3obj.Key))
+    .filter((s3obj) => inclusionTest(s3obj.Key)) // eslint-disable-line semi
+    // .filter((_, i) => i<2);
+  const dataObjects = await Promise.all(s3Objects.map(async (s3obj) => limit(async () => {
+    // surface these properties for getDatasetMetadata
+    s3obj.filename = s3obj.Key;
+    s3obj.url = fileToUrl(s3obj.Key);
+    s3obj.date_uploaded = s3obj.LastModified.toISOString().split("T")[0];
+    return s3obj;
+  })));
+  return dataObjects;
+}
+
+/* following duplicated from "collect-datasets.js" */
+function filenameLooksLikeDataset(filename) {
+  if (!filename.endsWith(".json")) return false;
+  if (filename.endsWith("_meta.json") || filename.endsWith("_tree.json")) return false;
+  if (filename.endsWith("_frequencies.json")) return false;
+  if (filename.endsWith("_tip-frequencies.json")) return false;
+  if (filename.endsWith("_aa-mutation-frequencies.json")) return false;
+  if (filename.endsWith("_sequences.json")) return false;
+  if (filename.endsWith("_entropy.json")) return false;
+  if (filename.endsWith("_root-sequence.json")) return false;
+  return true;
+}

--- a/static-site/gatsby-node.js
+++ b/static-site/gatsby-node.js
@@ -212,6 +212,13 @@ exports.createPages = ({graphql, actions}) => {
           component: path.resolve("src/pages/influenza-page.jsx")
         });
 
+        // proof-of-principle. Names may change.
+        createPage({
+          path: "/all",
+          matchPath: "/all/*",
+          component: path.resolve("src/pages/all-datasets.jsx")
+        });
+
         // search pages
         createPage({
           path: `/search`,

--- a/static-site/src/components/Datasets/list-datasets.jsx
+++ b/static-site/src/components/Datasets/list-datasets.jsx
@@ -150,7 +150,7 @@ export const ListDatasets = ({datasets, columns}) => {
         <HeaderRow columns={columns}/>
         <DatasetSelectionResultsContainer>
           {datasets.map((dataset) => (
-            <NormalRow dataset={dataset} columns={columns} key={columns[0].value(dataset)}/>
+            <NormalRow dataset={dataset} columns={columns} key={columns[0].url(dataset)}/>
           ))}
         </DatasetSelectionResultsContainer>
       </Grid>

--- a/static-site/src/pages/all-datasets.jsx
+++ b/static-site/src/pages/all-datasets.jsx
@@ -1,0 +1,106 @@
+import React from "react";
+import Helmet from "react-helmet";
+import { MdPerson } from "react-icons/md";
+import config from "../../data/SiteConfig";
+import NavBar from "../components/nav-bar";
+import MainLayout from "../components/layout";
+import UserDataWrapper from "../layouts/userDataWrapper";
+import { SmallSpacer, HugeSpacer, FlexCenter } from "../layouts/generalComponents";
+import * as splashStyles from "../components/splash/styles";
+import Footer from "../components/Footer";
+import { fetchAndParseDatasetsJSON } from "./influenza-page";
+import DatasetSelect from "../components/Datasets/dataset-select";
+
+const nextstrainLogoPNG = require("../../static/logos/favicon.png");
+
+const title = "Proof of principle: All known Nextstrain datasets";
+const abstract = `A listing of all datasets currently available on (a) Nextstrain Core,
+(b) Nextstrain Staging, (c) all Public Nextstrain Groups and (d) community datasets.
+Narratives are not yet considered.`;
+const tableColumns = [
+  {
+    name: "Dataset",
+    value: (dataset) => dataset.filename.replace(/_/g, ' / ').replace('.json', ''),
+    url: (dataset) => dataset.url
+  },
+  {
+    name: "Source",
+    value: (dataset) => dataset.source
+  },
+  {
+    name: "Contributor",
+    value: (dataset) => dataset.contributor,
+    url: (dataset) => dataset.contributorUrl,
+    logo: (dataset) => dataset.contributor==="Nextstrain" ?
+      <img alt="nextstrain.org" className="logo" width="24px" src={nextstrainLogoPNG}/> :
+      <MdPerson/>
+  }
+];
+
+class Index extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      dataLoaded: false,
+      errorFetchingData: false,
+      datasetsUrl: "https://staging.nextstrain.org/james/tmp-all-datasets.json"
+    };
+  }
+  async componentDidMount() {
+    try {
+      const datasets = await fetchAndParseDatasetsJSON(this.state.datasetsUrl);
+      this.setState({datasets, dataLoaded: true});
+    } catch (err) {
+      console.error("Error fetching / parsing data.", err.message);
+      this.setState({errorFetchingData: true});
+    }
+  }
+
+  render() {
+    return (
+      <MainLayout>
+        <div className="index-container">
+          <Helmet title={config.siteTitle} />
+          <main>
+            <UserDataWrapper>
+              <NavBar location={this.props.location} />
+            </UserDataWrapper>
+
+            <splashStyles.Container className="container">
+              <HugeSpacer /><HugeSpacer />
+              <splashStyles.H1>{title}</splashStyles.H1>
+              <SmallSpacer />
+
+              <FlexCenter>
+                <splashStyles.CenteredFocusParagraph>
+                  {abstract}
+                </splashStyles.CenteredFocusParagraph>
+              </FlexCenter>
+
+              <HugeSpacer /><HugeSpacer />
+
+              <splashStyles.H2>All datasets</splashStyles.H2>
+              <HugeSpacer />
+              {this.state.dataLoaded && (
+                <DatasetSelect
+                  datasets={this.state.datasets}
+                  columns={tableColumns}
+                  urlDefinedFilterPath={this.props["*"]}
+                  intendedUri={this.props.uri}
+                />
+              )}
+              { this.state.errorFetchingData && <splashStyles.CenteredFocusParagraph>
+                          Something went wrong getting data.
+                          Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
+                          if this continues to happen.</splashStyles.CenteredFocusParagraph>}
+
+              <Footer />
+            </splashStyles.Container>
+          </main>
+        </div>
+      </MainLayout>
+    );
+  }
+}
+
+export default Index;

--- a/static-site/src/pages/influenza-page.jsx
+++ b/static-site/src/pages/influenza-page.jsx
@@ -156,7 +156,7 @@ class Index extends React.Component {
 // regularly to s3 as a resource we request here
 // representing a list of datasets to display on
 // this page with some info about each.
-async function fetchAndParseDatasetsJSON(jsonUrl) {
+export async function fetchAndParseDatasetsJSON(jsonUrl) {
   const datasetsJSON = await fetch(jsonUrl)
     .then((res) => res.text())
     .then((text) => JSON.parse(text));


### PR DESCRIPTION
Proof of principle page which lists all (known) datasets at the URL path "/all". This provides the third page listing datasets (after /influenza and /sars-cov-2).

* Nextstrain core + staging via listing of the S3 buckets
* Nextstrain public groups via the same technique
* Community via [@tsibley's community-search](https://github.com/nextstrain/community-search/)

Currently there is no automation of dataset collection, it is run manually and uploaded to the staging bucket.
