### PR TITLE
Serve community builds from default GitHub branch

### DIFF
--- a/src/getDataset.js
+++ b/src/getDataset.js
@@ -56,7 +56,7 @@ const requestV1Dataset = async (metaJsonUrl, treeJsonUrl) => {
  * then the promise will reject.
  */
 const requestMainDataset = async (res, dataset) => {
-  const main = dataset.urlFor("main");
+  const main = await dataset.urlFor("main");
 
   return new Promise((resolve, reject) => {
     /* try to stream the (v2+) dataset JSON as the response */
@@ -71,8 +71,8 @@ const requestMainDataset = async (res, dataset) => {
         }
         utils.verbose(`The request for ${main} returned ${response.statusCode}.`);
 
-        const meta = dataset.urlFor("meta");
-        const tree = dataset.urlFor("tree");
+        const meta = await dataset.urlFor("meta");
+        const tree = await dataset.urlFor("tree");
         const [success, dataToReturn] = await requestV1Dataset(meta, tree);
         if (success) {
           res.send(dataToReturn);
@@ -121,7 +121,7 @@ const getDataset = async (req, res) => {
   // construct fetch URL
   let datasetInfo;
   try {
-    datasetInfo = helpers.parsePrefix(query.prefix, query);
+    datasetInfo = await helpers.parsePrefix(query.prefix, query);
     utils.verbose("Dataset: ", datasetInfo);
   } catch (err) {
     /* Return a 204 No Content when Auspice makes a dataset request to a
@@ -147,7 +147,7 @@ const getDataset = async (req, res) => {
   /* If we got a partial prefix and resolved it into a full one, redirect to
    * that.  Auspice will notice and update its displayed URL appropriately.
    */
-  if (resolvedPrefix !== helpers.canonicalizePrefix(query.prefix)) {
+  if (resolvedPrefix !== await helpers.canonicalizePrefix(query.prefix)) {
     // A absolute base is required but we won't use it, so use something bogus.
     const resolvedUrl = new URL(req.originalUrl, "http://x");
     resolvedUrl.searchParams.set("prefix", resolvedPrefix);
@@ -160,7 +160,7 @@ const getDataset = async (req, res) => {
   }
 
   if (query.type) {
-    const url = dataset.urlFor(query.type);
+    const url = await dataset.urlFor(query.type);
     try {
       await requestCertainFileType(res, req, url, query);
     } catch (err) {

--- a/src/getDatasetHelpers.js
+++ b/src/getDatasetHelpers.js
@@ -83,7 +83,7 @@ const splitPrefixIntoParts = (prefix) => {
  * automatically provided reverse URL-construction/interpolation function on
  * the matched route.
  */
-const joinPartsIntoPrefix = ({source, prefixParts, isNarrative = false}) => {
+const joinPartsIntoPrefix = async ({source, prefixParts, isNarrative = false}) => {
   const leadingParts = [];
 
   switch (source.name) {
@@ -105,7 +105,7 @@ const joinPartsIntoPrefix = ({source, prefixParts, isNarrative = false}) => {
   switch (source.name) {
     // Community source requires an owner and repo name
     case "community":
-      leadingParts.push(source.owner, source.repoNameWithBranch);
+      leadingParts.push(source.owner, await source.getRepoNameWithBranch());
       break;
 
     // UrlDefined source requires a URL authority part
@@ -161,7 +161,7 @@ const correctPrefixFromAvailable = (sourceName, prefixParts) => {
 /* Parse the prefix (a path-like string specifying a source + dataset path)
  * with resolving of partial prefixes.  Prefixes are case-sensitive.
  */
-const parsePrefix = (prefix) => {
+const parsePrefix = async (prefix) => {
   let {source, prefixParts} = splitPrefixIntoParts(prefix);
 
   // Expand partial prefixes.  This would be cleaner if integerated into the
@@ -170,7 +170,7 @@ const parsePrefix = (prefix) => {
 
   // The resolved prefix, possibly "corrected" above, which we want to use for
   // display.
-  const resolvedPrefix = joinPartsIntoPrefix({source, prefixParts});
+  const resolvedPrefix = await joinPartsIntoPrefix({source, prefixParts});
 
   const dataset = source.dataset(prefixParts);
 
@@ -181,7 +181,7 @@ const parsePrefix = (prefix) => {
 
 /* Round-trip prefix through split/join to canonicalize it for comparison.
  */
-const canonicalizePrefix = (prefix) =>
+const canonicalizePrefix = async (prefix) =>
   joinPartsIntoPrefix(splitPrefixIntoParts(prefix));
 
 

--- a/src/getNarrative.js
+++ b/src/getNarrative.js
@@ -47,7 +47,7 @@ const getNarrative = async (req, res) => {
 
   // Generate the narrative's origin URL for fetching.
   const narrative = source.narrative(prefixParts);
-  const fetchURL = narrative.url();
+  const fetchURL = await narrative.url();
 
   try {
     utils.log(`Fetching narrative ${fetchURL} and streaming to client for parsing`);


### PR DESCRIPTION
When Nextstrain community builds were implemented, the default GitHub branch was "master", and this assumption was build into our server. The ability to explicitly define which GitHub branch should be used was possible (by specifying it in the URL via "@branch`), but in the absence of this "master" was always used.

It is now common for the default / only branch to be "main", and it is surprising for users when Nextstrain community builds result in an error in these cases.

Here we query GitHub for the default branch and use that. If the branch is made explicit via the use of `@branch` in the URLs, then that branch is used (unchanged behaviour). Such a query necessitates that rather a lot of methods & functions become async, and some getters have become (normal) functions.

@tsibley could you review this? It necessitated a cascade of synchronous functions / getters becoming async functions, but in most cases these functions are returning (promise-fulfilled) values. There are other ways of achieving this, but I didn't want to change the data flow of the app too drastically. 

URLs for testing: 
* /community/trvrb/nextstrain-community-build/20210401 (master branch)
* /community/jameshadfield/nextstrain-community-build/20210401 (main branch)

[This docs page](https://github.com/nextstrain/docs.nextstrain.org/blob/master/src/guides/share/community-builds.md) should be updated after merge.

