### PR TITLE
WIP redirect datasets which dont exist to parent page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.12.tgz",
-      "integrity": "sha512-3eJJ841uKxeV8dcN/2yGEUy+RfgQspPEgQat85umsE1rotuquQ2AbIub4S6j7c50a2d+4myc+zSlnXeIHrOnhQ=="
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
+      "integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA=="
     },
     "@babel/core": {
       "version": "7.11.6",
@@ -391,9 +391,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+          "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -406,16 +406,16 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+          "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.13.9",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
+            "@babel/parser": "^7.13.15",
+            "@babel/types": "^7.13.14",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
@@ -470,9 +470,9 @@
       }
     },
     "@babel/helper-define-polyfill-provider": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.5.tgz",
-      "integrity": "sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.0.tgz",
+      "integrity": "sha512-JT8tHuFjKBo8NnaUbblz7mIu1nnvUDiHVjXXkulZULyidvo/7P6TY7+YqpV37IfF+KUFxmlK04elKtGKXaiVgw==",
       "requires": {
         "@babel/helper-compilation-targets": "^7.13.0",
         "@babel/helper-module-imports": "^7.12.13",
@@ -557,9 +557,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+          "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -572,16 +572,16 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+          "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.13.9",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
+            "@babel/parser": "^7.13.15",
+            "@babel/types": "^7.13.14",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
@@ -764,9 +764,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+          "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -779,16 +779,16 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+          "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.13.9",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
+            "@babel/parser": "^7.13.15",
+            "@babel/types": "^7.13.14",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
@@ -1355,9 +1355,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+          "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -1370,16 +1370,16 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+          "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.13.9",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
+            "@babel/parser": "^7.13.15",
+            "@babel/types": "^7.13.14",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
@@ -1588,9 +1588,9 @@
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz",
-      "integrity": "sha512-rPBnhj+WgoSmgq+4gQUtXx/vOcU+UYtjy1AA/aeD61Hwj410fwYyqfUcRP3lR8ucgliVJL/G7sXcNUecC75IXA==",
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.15.tgz",
+      "integrity": "sha512-VapibkWzFeoa6ubXy/NgV5U2U4MVnUlvnx6wo1XhlsaTrLYWE0UFpDQsVrmn22q5CzeloqJ8gEMHSKxuee6ZdA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-remap-async-to-generator": "^7.13.0",
@@ -1621,11 +1621,11 @@
       }
     },
     "@babel/plugin-proposal-decorators": {
-      "version": "7.13.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.13.5.tgz",
-      "integrity": "sha512-i0GDfVNuoapwiheevUOuSW67mInqJ8qw7uWfpjNVeHMn143kXblEy/bmL9AdZ/0yf/4BMQeWXezK0tQIvNPqag==",
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.13.15.tgz",
+      "integrity": "sha512-ibAMAqUm97yzi+LPgdr5Nqb9CMkeieGHvwPg1ywSGjZrZHQEGqE01HmOio8kxRpA/+VtOHouIVy2FMpBbtltjA==",
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.13.0",
+        "@babel/helper-create-class-features-plugin": "^7.13.11",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-decorators": "^7.12.13"
       },
@@ -2170,9 +2170,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+          "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -2185,16 +2185,16 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+          "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.13.9",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
+            "@babel/parser": "^7.13.15",
+            "@babel/types": "^7.13.14",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
@@ -2387,9 +2387,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+          "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -2586,9 +2586,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+          "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -2601,16 +2601,16 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+          "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.13.9",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
+            "@babel/parser": "^7.13.15",
+            "@babel/types": "^7.13.14",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
@@ -2789,9 +2789,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+          "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -2804,16 +2804,16 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+          "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.13.9",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
+            "@babel/parser": "^7.13.15",
+            "@babel/types": "^7.13.14",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
@@ -2993,9 +2993,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+          "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -3008,16 +3008,16 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+          "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.13.9",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
+            "@babel/parser": "^7.13.15",
+            "@babel/types": "^7.13.14",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
@@ -3194,9 +3194,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+          "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -3209,16 +3209,16 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+          "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.13.9",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
+            "@babel/parser": "^7.13.15",
+            "@babel/types": "^7.13.14",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
@@ -3387,9 +3387,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+          "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -3402,16 +3402,16 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+          "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.13.9",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
+            "@babel/parser": "^7.13.15",
+            "@babel/types": "^7.13.14",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
@@ -3571,9 +3571,9 @@
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.13.tgz",
-      "integrity": "sha512-lxb2ZAvSLyJ2PEe47hoGWPmW22v7CtSl9jW8mingV4H2sEX/JOcrAj2nPuGWi56ERUm2bUpjKzONAuT6HCn2EA==",
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.13.15.tgz",
+      "integrity": "sha512-Bk9cOLSz8DiurcMETZ8E2YtIVJbFCPGW28DJWUakmyVWtQSm6Wsf0p4B4BfEr/eL2Nkhe/CICiUiMOCi1TPhuQ==",
       "requires": {
         "regenerator-transform": "^0.14.2"
       }
@@ -3594,15 +3594,15 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.13.10.tgz",
-      "integrity": "sha512-Y5k8ipgfvz5d/76tx7JYbKQTcgFSU6VgJ3kKQv4zGTKr+a9T/KBvfRvGtSFgKDQGt/DBykQixV0vNWKIdzWErA==",
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.13.15.tgz",
+      "integrity": "sha512-d+ezl76gx6Jal08XngJUkXM4lFXK/5Ikl9Mh4HKDxSfGJXmZ9xG64XT2oivBzfxb/eQ62VfvoMkaCZUKJMVrBA==",
       "requires": {
-        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-module-imports": "^7.13.12",
         "@babel/helper-plugin-utils": "^7.13.0",
-        "babel-plugin-polyfill-corejs2": "^0.1.4",
-        "babel-plugin-polyfill-corejs3": "^0.1.3",
-        "babel-plugin-polyfill-regenerator": "^0.1.2",
+        "babel-plugin-polyfill-corejs2": "^0.2.0",
+        "babel-plugin-polyfill-corejs3": "^0.2.0",
+        "babel-plugin-polyfill-regenerator": "^0.2.0",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -3759,16 +3759,16 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.12.tgz",
-      "integrity": "sha512-JzElc6jk3Ko6zuZgBtjOd01pf9yYDEIH8BcqVuYIuOkzOwDesoa/Nz4gIo4lBG6K861KTV9TvIgmFuT6ytOaAA==",
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.15.tgz",
+      "integrity": "sha512-D4JAPMXcxk69PKe81jRJ21/fP/uYdcTZ3hJDF5QX2HSI9bBxxYw/dumdR6dGumhjxlprHPE4XWoPaqzZUVy2MA==",
       "requires": {
-        "@babel/compat-data": "^7.13.12",
-        "@babel/helper-compilation-targets": "^7.13.10",
+        "@babel/compat-data": "^7.13.15",
+        "@babel/helper-compilation-targets": "^7.13.13",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-option": "^7.12.17",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.13.12",
-        "@babel/plugin-proposal-async-generator-functions": "^7.13.8",
+        "@babel/plugin-proposal-async-generator-functions": "^7.13.15",
         "@babel/plugin-proposal-class-properties": "^7.13.0",
         "@babel/plugin-proposal-dynamic-import": "^7.13.8",
         "@babel/plugin-proposal-export-namespace-from": "^7.12.13",
@@ -3816,7 +3816,7 @@
         "@babel/plugin-transform-object-super": "^7.12.13",
         "@babel/plugin-transform-parameters": "^7.13.0",
         "@babel/plugin-transform-property-literals": "^7.12.13",
-        "@babel/plugin-transform-regenerator": "^7.12.13",
+        "@babel/plugin-transform-regenerator": "^7.13.15",
         "@babel/plugin-transform-reserved-words": "^7.12.13",
         "@babel/plugin-transform-shorthand-properties": "^7.12.13",
         "@babel/plugin-transform-spread": "^7.13.0",
@@ -3826,10 +3826,10 @@
         "@babel/plugin-transform-unicode-escapes": "^7.12.13",
         "@babel/plugin-transform-unicode-regex": "^7.12.13",
         "@babel/preset-modules": "^0.1.4",
-        "@babel/types": "^7.13.12",
-        "babel-plugin-polyfill-corejs2": "^0.1.4",
-        "babel-plugin-polyfill-corejs3": "^0.1.3",
-        "babel-plugin-polyfill-regenerator": "^0.1.2",
+        "@babel/types": "^7.13.14",
+        "babel-plugin-polyfill-corejs2": "^0.2.0",
+        "babel-plugin-polyfill-corejs3": "^0.2.0",
+        "babel-plugin-polyfill-regenerator": "^0.2.0",
         "core-js-compat": "^3.9.0",
         "semver": "^6.3.0"
       },
@@ -6041,9 +6041,8 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "auspice": {
-      "version": "2.25.1",
-      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.25.1.tgz",
-      "integrity": "sha512-13Tgq+uJpCd5k4gTeo6ux5IFXxSsLNkPrgCo7Deql1mVl8rx1Y5zOXS0gYokF3ScHylrWIFye5qV8pZde00BwA==",
+      "version": "github:nextstrain/auspice#1e4d95da4f71d8b1eef60cf788c9d291b3b821c6",
+      "from": "github:nextstrain/auspice#allow-redirects",
       "requires": {
         "@babel/core": "^7.3.4",
         "@babel/plugin-proposal-class-properties": "^7.3.4",
@@ -6137,9 +6136,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
-          "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ=="
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.1.tgz",
+          "integrity": "sha512-pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA=="
         },
         "lodash": {
           "version": "4.17.21",
@@ -6622,12 +6621,12 @@
       }
     },
     "babel-plugin-polyfill-corejs2": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.10.tgz",
-      "integrity": "sha512-DO95wD4g0A8KRaHKi0D51NdGXzvpqVLnLu5BTvDlpqUEpTmeEtypgC1xqesORaWmiUOQI14UHKlzNd9iZ2G3ZA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.0.tgz",
+      "integrity": "sha512-9bNwiR0dS881c5SHnzCmmGlMkJLl0OUZvxrxHo9w/iNoRuqaPjqlvBf4HrovXtQs/au5yKkpcdgfT1cC5PAZwg==",
       "requires": {
-        "@babel/compat-data": "^7.13.0",
-        "@babel/helper-define-polyfill-provider": "^0.1.5",
+        "@babel/compat-data": "^7.13.11",
+        "@babel/helper-define-polyfill-provider": "^0.2.0",
         "semver": "^6.1.1"
       },
       "dependencies": {
@@ -6639,20 +6638,20 @@
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz",
-      "integrity": "sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.0.tgz",
+      "integrity": "sha512-zZyi7p3BCUyzNxLx8KV61zTINkkV65zVkDAFNZmrTCRVhjo1jAS+YLvDJ9Jgd/w2tsAviCwFHReYfxO3Iql8Yg==",
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.1.5",
-        "core-js-compat": "^3.8.1"
+        "@babel/helper-define-polyfill-provider": "^0.2.0",
+        "core-js-compat": "^3.9.1"
       }
     },
     "babel-plugin-polyfill-regenerator": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.1.6.tgz",
-      "integrity": "sha512-OUrYG9iKPKz8NxswXbRAdSwF0GhRdIEMTloQATJi4bDuFqrXaXcCUT/VGNrr8pBcjMh1RxZ7Xt9cytVJTJfvMg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.0.tgz",
+      "integrity": "sha512-J7vKbCuD2Xi/eEHxquHN14bXAW9CXtecwuLrOIDJtcZzTaPzV1VdEfoUf9AzcRBMolKUQKM9/GVojeh0hFiqMg==",
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.1.5"
+        "@babel/helper-define-polyfill-provider": "^0.2.0"
       }
     },
     "babel-plugin-strip-function-call": {
@@ -7093,15 +7092,15 @@
       }
     },
     "browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
+      "integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001208",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.712",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
       }
     },
     "bser": {
@@ -7275,9 +7274,9 @@
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-lite": {
-      "version": "1.0.30001207",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
-      "integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw=="
+      "version": "1.0.30001208",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
+      "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -7412,12 +7411,9 @@
       "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
     },
     "chrome-trace-event": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
-      "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
     },
     "ci-info": {
       "version": "2.0.0",
@@ -7752,9 +7748,9 @@
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-js-compat": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.10.0.tgz",
-      "integrity": "sha512-9yVewub2MXNYyGvuLnMHcN1k9RkvB7/ofktpeKTIaASyB88YYqGzUnu0ywMMhJrDHOMiTjSHWGzR+i7Wb9Z1kQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.10.1.tgz",
+      "integrity": "sha512-ZHQTdTPkqvw2CeHiZC970NNJcnwzT6YIueDMASKt+p3WbZsLXOcoD392SkcWhkC0wBBHhlfhqGKKsNCQUozYtg==",
       "requires": {
         "browserslist": "^4.16.3",
         "semver": "7.0.0"
@@ -8503,9 +8499,9 @@
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
     "electron-to-chromium": {
-      "version": "1.3.709",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.709.tgz",
-      "integrity": "sha512-LolItk2/ikSGQ7SN8UkuKVNMBZp3RG7Itgaxj1npsHRzQobj9JjMneZOZfLhtwlYBe5fCJ75k+cVCiDFUs23oA=="
+      "version": "1.3.713",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.713.tgz",
+      "integrity": "sha512-HWgkyX4xTHmxcWWlvv7a87RHSINEcpKYZmDMxkUlHcY+CJcfx7xEfBHuXVsO1rzyYs1WQJ7EgDp2CoErakBIow=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -10271,12 +10267,12 @@
         }
       }
     },
-    "html-parse-stringify2": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz",
-      "integrity": "sha1-3FZwtyksoVi3vJFsmmc1rIhyg0o=",
+    "html-parse-stringify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.0.tgz",
+      "integrity": "sha512-TrTKp/U0tACrpqalte/VhxepqMLii2mOfC8iuOt4+VA7Zdi6BUKKqNJvEsO17Cr3T3E7PpqLe3NdLII6bcYJgg==",
       "requires": {
-        "void-elements": "^2.0.1"
+        "void-elements": "3.1.0"
       }
     },
     "html-webpack-plugin": {
@@ -13748,9 +13744,9 @@
       }
     },
     "jose": {
-      "version": "npm:jose-node-cjs-runtime@3.11.3",
-      "resolved": "https://registry.npmjs.org/jose-node-cjs-runtime/-/jose-node-cjs-runtime-3.11.3.tgz",
-      "integrity": "sha512-BMlluOSxexKyqugN24mrcHCkyG8/ES1uqBgTo6h9UVXdsWCPYMwyREVZ2zNSZRtUIAcI4ot0MBgCu7WipIZ5BQ=="
+      "version": "npm:jose-node-cjs-runtime@3.11.4",
+      "resolved": "https://registry.npmjs.org/jose-node-cjs-runtime/-/jose-node-cjs-runtime-3.11.4.tgz",
+      "integrity": "sha512-1cqX6WzzGLSgyS4/AAiTWAz/zLZaB0g1RKmwlA5HlQRdE9YAqqGjKK+LZBR9k8AhwPGb4LMkkM92p8KRwFL4/w=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -15498,9 +15494,9 @@
       }
     },
     "pbkdf2": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
-      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
       "requires": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -16027,12 +16023,12 @@
       }
     },
     "react-i18next": {
-      "version": "11.8.12",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.8.12.tgz",
-      "integrity": "sha512-M2PSVP9MzT/7yofXfCOF5gAVotinrM4BXWiguk8uFSznJsfFzTjrp3K9CBWcXitpoCBVZGZJ2AnbaWGSNkJqfw==",
+      "version": "11.8.13",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.8.13.tgz",
+      "integrity": "sha512-KTNuLYnEwI9y54nSEal4yBxXBnfCCfh7t/0p/UHfhlGNcIMu+V4x/y5zGKzbOEK4noQrUzZ+J47RPYH7rMs2ZQ==",
       "requires": {
         "@babel/runtime": "^7.13.6",
-        "html-parse-stringify2": "^2.0.1"
+        "html-parse-stringify": "^3.0.0"
       }
     },
     "react-icons": {
@@ -17630,9 +17626,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+          "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -17645,16 +17641,16 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
-          "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+          "version": "7.13.15",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
+          "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
           "requires": {
             "@babel/code-frame": "^7.12.13",
             "@babel/generator": "^7.13.9",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.13",
-            "@babel/types": "^7.13.13",
+            "@babel/parser": "^7.13.15",
+            "@babel/types": "^7.13.14",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
@@ -18018,9 +18014,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }
@@ -18202,7 +18198,8 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.17.1",
@@ -18572,9 +18569,9 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "void-elements": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "argparse": "^1.0.10",
-    "auspice": "2.25.1",
+    "auspice": "nextstrain/auspice#allow-redirects",
     "aws-sdk": "^2.520.0",
     "chalk": "^2.4.1",
     "compression": "^1.7.3",

--- a/redirects.js
+++ b/redirects.js
@@ -1,5 +1,6 @@
 const helpers = require("./src/getDatasetHelpers");
 const { parseNarrativeLanguage } = require("./src/utils");
+const sources = require("./src/sources");
 
 const setup = (app) => {
 
@@ -120,6 +121,21 @@ const setup = (app) => {
 
 };
 
+/**
+ * A getDataset request for the main dataset which 404s should redirect to the closest parent page.
+ * Normally this comes from Auspice when it attempts to load a page X but the dataset doesn't exist.
+ * Instead of returning 404 and letting auspice handle it, we return a redirect to a page which
+ * will be rendered by Gatsby.
+ */
+const getParentPage = (dataset) => {
+  // currently we only redirect core pages starting with "flu"
+  if (dataset.source.name==="core" && dataset.pathParts && dataset.pathParts[0]==="flu") {
+    return "influenza";
+  }
+  return false;
+};
+
 module.exports = {
-  setup
+  setup,
+  getParentPage
 };


### PR DESCRIPTION
We are beginning to add pages listing datasets / narratives into nextstrain.org such as /influenza and /sars-cov-2. (Note the former may be moved to "/flu" shortly.) Where possible, requests to "child" pages which don't have a dataset should redirect to these "parent" pages. 

**What happens currently**
Most URLs end up in Auspice (see flowchart) where a request is made for the corresponding dataset. If this dataset doesn't exist, Auspice shows a 404 page and a listing of datasets/narratives for that Source (core, staging etc). 

**What we would like to happen**
If the corresponding dataset does not exist, then we should redirect the client to the closest parent page, which is rendered from Gatsby. For instance,

* requests to /flu/no-dataset should redirect to /influenza
* requests to /flu/h3n2/no-dataset should redirect to /influenza/seasonal/h3n2 (were this to exist)
* requests to /ncov/antarctica should redirect to /sars-cov-2
* requests to /community/$org/$repo (assuming no default dataset exists) should result in a Gatsby page similar to /influenza which lists the available datasets & narratives for that repo. Similarly for /community/$org/$repo/$x where $x doesn't exist.
* requests for /staging/no-dataset should redirect to /staging, which lists all datasets/narratives from the staging source
* requests for /groups/X (and groups/X/Y if dataset Y doesn't exist) should display a page listing those 

**Complexities**
There are two major ones that I am aware of:
1. We currently don't know if a dataset exists until we try to access it. If it 404s then we can assume it doesn't currently exist. We must recheck this each time as new datasets may have been added (or removed) since the last check.
2. The /community/$org/$repo address should display different pages (one from Gatsby, one from Auspice) depending on whether a default dataset exists.

**This implementation**
This PR begins to implement the above by allowing Auspice to redirect to the desired nextstrain.org page if the dataset does not exist (see orange section in flow chart). Currently only URLs starting with `/flu` are handled, which redirect to `/influenza` if the dataset doesn't exist.

![image](https://user-images.githubusercontent.com/8350992/114497631-abf58380-9c76-11eb-80e6-74d8c4a3c0c8.png)
 
**Alternative implementation**

We could have the initial URL request the client makes to the server attempt to access the corresponding dataset. If this exists, we return Auspice (which then requests the dataset the server's just accessed). If the dataset doesn't exist we can return the Gatsby HTML (or a 302 to the correct page). I didn't attempt this as I believe it will result in long response times, as the server must go fetch the dataset, however there may be clever shortcuts available here. 

