### PR TITLE
List available datasets in Gatsby (not Auspice)

### DIFF
--- a/auspicePaths.js
+++ b/auspicePaths.js
@@ -39,7 +39,6 @@ const potentialAuspiceRoutes = [
   ...coreBuilds.map(url => url + "/*"),
   "/narratives",
   "/narratives/*",
-  "/staging",
   "/staging/*",
   ...groups.map((group) => `/groups/${group}`),
   ...groups.map((group) => `/groups/${group}/*`),
@@ -80,7 +79,6 @@ const isRequestBackedByAuspiceDataset = async (req, res, next) => {
     if (
       pathParts[0]==="status" ||
       pathParts[0]==="narratives" ||
-      pathParts[0]==="staging" ||
       pathParts[0]==="groups" ||
       pathParts[0]==="community" || // note that /community itself is redirected earlier
       pathParts[0]==="fetch"

--- a/auspicePaths.js
+++ b/auspicePaths.js
@@ -1,6 +1,11 @@
+const fetch = require("node-fetch");
 const sources = require("./src/sources");
+const { splitPrefixIntoParts, parsePrefix } = require("./src/getDatasetHelpers");
 
-/* Dataset and narrative paths hit Auspice's entrypoint.
+/**
+ * Auspice core builds have URLs where the first (`/`-separated) field matches the following list.
+ * New core builds must be added here else they will be routed to Gatsby.
+ * This could be dynamically generated at server start time via a S3 API call if we wish.
  */
 const coreBuilds = [
   "/dengue",
@@ -20,7 +25,13 @@ const coreBuilds = [
 
 const groups = [...sources.keys()].filter((k) => !["core", "staging", "community"].includes(k));
 
-const auspicePaths = [
+
+/**
+ * The following routes _may_ be handled by Auspice.
+ * Note: as we add more functionality to Gatsby, this list will shrink
+ * (e.g. /staging will be a gatsby page, not an auspice one)
+ */
+const potentialAuspiceRoutes = [
   "/status",
   "/status/*",
   ...coreBuilds,
@@ -45,4 +56,85 @@ const auspicePaths = [
   "/fetch/*"
 ];
 
-module.exports = auspicePaths;
+/**
+ * Express middleware to examine a path and determine if it should be routed to Auspice
+ * for visualization, or sent a Gatsby-generated page.
+ * This may require a fetch call for the main dataset (or the meta.json if v1 schema)
+ * to decide if a URL is an auspice route or not.
+ *
+ * SIDE-EFFECTS:
+ * Adds the following properties to `req`, which are used by subsequent middleware.
+ * `req.sendToAuspice` {bool}
+ */
+const isRequestBackedByAuspiceDataset = async (req, res, next) => {
+  // TODO: this is similar to `getDataset` and so we should refactor that
+  // and re-use it here so that we don't let them get out of sync.
+  req.sendToAuspice = false; // explicit default
+  try {
+
+    /* Previous to April 2021 work, _ALL_ these routes would be handled by Auspice.
+    We preserve previous behavior with this block, whilst slowly moving entries out
+    as they are build into gatsby.
+    (e.g. /groups/blab will not be handled by Auspice in the long run) */
+    const pathParts = req.path.replace(/^\//, '').replace(/\/$/, '').split("/");
+    if (
+      pathParts[0]==="status" ||
+      pathParts[0]==="narratives" ||
+      pathParts[0]==="staging" ||
+      pathParts[0]==="groups" ||
+      pathParts[0]==="community" || // note that /community itself is redirected earlier
+      pathParts[0]==="fetch"
+    ) {
+      req.sendToAuspice = true;
+      return next();
+    }
+
+    const {source, prefixParts} = splitPrefixIntoParts(req.path);
+    if (!source.visibleToUser(req.user)) {
+      return next();
+    }
+
+    /* For URLs which look like core builds we know that the start of the path must match a hardcoded list */
+    if (source.name==="core" && !coreBuilds.includes("/"+prefixParts[0])) {
+      return next();
+    }
+
+    /* Extract dataset information & check if it exists, storing the result as `req.sendToAuspice` */
+    const { dataset } = parsePrefix(req.path);
+    if (await datasetExists(dataset)) {
+      req.sendToAuspice = true;
+    }
+    return next();
+  } catch (err) {
+    console.log("isRequestBackedByAuspiceDataset", String(err));
+    req.sendToAuspice = false;
+    return next();
+  }
+};
+
+/**
+ * Does the main dataset file exist?
+ * There is no attempt here to examine the validity or completeness of such a file.
+ * Note: as we don't care about the file contents, there should be a
+ * way to avoid fetching the data here and thus speed up this function.
+ * @returns {bool}
+ */
+async function datasetExists(dataset) {
+  try {
+    if ((await fetch(dataset.urlFor("main"))).status===200) {
+      return true;
+    }
+    if ((await fetch(dataset.urlFor("meta"))).status===200) {
+      return true;
+    }
+  } catch (err) {
+    // console.log("Error in datasetExists:", String(err));
+  }
+  return false;
+}
+
+
+module.exports = {
+  isRequestBackedByAuspiceDataset,
+  potentialAuspiceRoutes
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "smoke-test": "NODE_ENV=test ENV=dev jest ./test/smoke-test/auspice_client_requests.test.js",
     "smoke-test:ci": "start-server-and-test server http://localhost:5000 smoke-test",
     "test:ci": "npm run smoke-test:ci",
+    "test:unit": "jest ./test/unit*",
     "dev": "./develop.sh"
   },
   "dependencies": {

--- a/redirects.js
+++ b/redirects.js
@@ -23,6 +23,11 @@ const setup = (app) => {
   app.route(["/ncov"])
     .get((req, res) => res.redirect('/sars-cov-2'));
 
+  /* handle redirects for inrb-drc (first of the Nextstrain groups) */
+  app.get("/inrb-drc*", (req, res) => {
+    res.redirect(`/groups${req.originalUrl}`);
+  });
+
   /*
    * Redirect to translations of narratives if the client has
    * set language preference and the translation is available

--- a/server.js
+++ b/server.js
@@ -8,7 +8,8 @@ const favicon = require('serve-favicon');
 const compression = require('compression');
 const argparse = require('argparse');
 const utils = require("./src/utils");
-const auspicePaths = require('./auspicePaths');
+const { potentialAuspiceRoutes, isRequestBackedByAuspiceDataset } = require('./auspicePaths');
+const { getClosestParentPage } = require('./src/parentPage');
 const cors = require('cors');
 
 const production = process.env.NODE_ENV === "production";
@@ -75,11 +76,12 @@ authn.setup(app);
 redirects.setup(app);
 
 
-/* Static assets.  Auspice hardcodes /dist/… in its Webpack config.
+/* Static assets.
+ * Any paths matching resources here will be handled and not fall through to our handlers below.
+ * E.g. URL `/influenza` gets sent `static-site/public/influenza/index.html`
  */
 app.use(express.static(gatsbyAssetPath()));
-
-app.route("/dist/*")
+app.route("/dist/*") // Auspice hardcodes /dist/… in its Webpack config.
   .all(expressStaticGzip(auspiceAssetPath(), {maxAge: '30d'}));
 
 
@@ -101,20 +103,25 @@ app.route("/charon/getSourceInfo")
 app.route("/charon/*")
   .all((req, res) => res.status(404).end());
 
-app.route(auspicePaths).get((req, res) => {
-  utils.verbose(`Sending Auspice entrypoint for ${req.originalUrl}`);
-  res.sendFile(auspiceAssetPath("dist", "index.html"), {headers: {"Cache-Control": "no-cache, no-store, must-revalidate"}});
-});
-
-/* Everything else hits our Gatsby app's entrypoint.
+/* Specific routes to be handled by Gatsby client-side routing
  */
-app.get("*", (req, res) => {
-  utils.verbose(`Sending Gatsby entrypoint for ${req.originalUrl}`);
-  res.sendFile(gatsbyAssetPath(""), {}, (err) => {
-    // This error callback is used to display the 404 page
-    if (err.code === 'EISDIR') res.status(404).sendFile(gatsbyAssetPath("404.html"));
-  });
-});
+app.route([
+  "/users/:user"
+]).get((req, res) => res.sendFile(gatsbyAssetPath("index.html")));
+
+/* Routes which are plausibly for auspice, as they have specific path signatures.
+ * We verify if these are are backed by datasets and hand to auspice if so.
+ */
+app.route(potentialAuspiceRoutes).get(
+  isRequestBackedByAuspiceDataset,
+  sendAuspiceHandler,
+  sendGatsbyHandler
+);
+
+/**
+ * Finally, we catch all remaining routes and send to Gatsby
+ */
+app.get("*", sendGatsbyHandler);
 
 
 const server = app.listen(app.get('port'), () => {
@@ -133,3 +140,22 @@ const server = app.listen(app.get('port'), () => {
   }
   utils.error(`Uncaught error in app.listen(). Code: ${err.code}`);
 });
+
+
+function sendGatsbyHandler(req, res) {
+  utils.verbose(`Sending Gatsby entrypoint for ${req.originalUrl}`);
+  const closestPage = getClosestParentPage(gatsbyAssetPath, req.path) || gatsbyAssetPath("");
+  return res.sendFile(closestPage, {}, (err) => {
+    // callback runs when the transfer is complete or when an error occurs
+    if (err) res.status(404).sendFile(gatsbyAssetPath("404.html"));
+  });
+}
+
+function sendAuspiceHandler(req, res, next) {
+  if (!req.sendToAuspice) return next(); // see previous middleware
+  utils.verbose(`Sending Auspice entrypoint for ${req.originalUrl}`);
+  return res.sendFile(
+    auspiceAssetPath("dist", "index.html"),
+    {headers: {"Cache-Control": "no-cache, no-store, must-revalidate"}}
+  );
+}

--- a/server.js
+++ b/server.js
@@ -106,11 +106,6 @@ app.route(auspicePaths).get((req, res) => {
   res.sendFile(auspiceAssetPath("dist", "index.html"), {headers: {"Cache-Control": "no-cache, no-store, must-revalidate"}});
 });
 
-/* handle redirects for inrb-drc (first of the Nextstrain groups) */
-app.get("/inrb-drc*", (req, res) => {
-  res.redirect(`/groups${req.originalUrl}`);
-});
-
 /* Everything else hits our Gatsby app's entrypoint.
  */
 app.get("*", (req, res) => {

--- a/src/parentPage.js
+++ b/src/parentPage.js
@@ -1,0 +1,40 @@
+
+/**
+ * This function returns a path to the closest Gatsby-built HTML page
+ * matching the URL request.
+ *
+ * Note 1: Our middleware set up allows this function to assume that both
+ * (a) the request should not be handled by auspice and (b) the URL path
+ * is not matched exactly by a gatsby-built page.
+ *
+ * Note 2: The HTML page sent to the client (chosen via this function) may not
+ * be what the client renders due Gatsby's client-side routing. For instance,
+ * given a URL /a/b/c this function may decide that we should return the HTML
+ * page x. However if gatsby's been set up to handle URLs `a/*` with page y
+ * then the client, having received page x will, in fact, end up rendering page y.
+ * This is set up via the `matchPath` argument to Gatsby's `createPage` API.
+ *
+ * @param {function} gatsbyAssetPath
+ * @param {string} path URL path being requested
+ * @returns {undefined|string} the path-on-disk to a Gatsby built HTML file
+ */
+function getClosestParentPage(gatsbyAssetPath, path) {
+  try {
+    const pathParts = path.replace(/^\//, '').replace(/\/$/, '').split("/");
+    switch (pathParts[0].toLowerCase()) {
+      case ("flu"):
+        return gatsbyAssetPath("influenza", "index.html");
+      case ("sars-cov-2"): // fallthrough
+      case ("ncov"):
+        return gatsbyAssetPath("sars-cov-2", "index.html");
+      default:
+        // unknown parent page
+        return undefined;
+    }
+  } catch (err) {
+    console.log("getClosestParentPage error", String(err)); // uncomment for development purposes
+  }
+  return undefined;
+}
+
+module.exports = {getClosestParentPage};

--- a/src/parentPage.js
+++ b/src/parentPage.js
@@ -27,6 +27,8 @@ function getClosestParentPage(gatsbyAssetPath, path) {
       case ("sars-cov-2"): // fallthrough
       case ("ncov"):
         return gatsbyAssetPath("sars-cov-2", "index.html");
+      case ("staging"):
+        return gatsbyAssetPath("staging", "index.html");
       default:
         // unknown parent page
         return undefined;

--- a/static-site/gatsby-config.js
+++ b/static-site/gatsby-config.js
@@ -1,6 +1,6 @@
 const { createProxyMiddleware } = require("http-proxy-middleware");
 const config = require("./data/SiteConfig");
-const auspicePaths = require("../auspicePaths");
+const {potentialAuspiceRoutes} = require("../auspicePaths");
 
 // const pathPrefix = config.pathPrefix === "/" ? "" : config.pathPrefix;
 
@@ -73,7 +73,7 @@ module.exports = {
     // "gatsby-plugin-catch-links" // See https://github.com/nextstrain/nextstrain.org/issues/34
   ],
   developMiddleware: app => {
-    ['/charon', '/dist', ...auspicePaths].forEach(path => {
+    ['/charon', '/dist', ...potentialAuspiceRoutes].forEach(path => {
       app.use(
         path,
         createProxyMiddleware({

--- a/static-site/gatsby-node.js
+++ b/static-site/gatsby-node.js
@@ -204,6 +204,11 @@ exports.createPages = ({graphql, actions}) => {
           component: path.resolve("src/sections/sars-cov-2-page.jsx")
         });
 
+        createPage({
+          path: "/staging",
+          component: path.resolve("src/sections/staging.jsx")
+        });
+
         /* NOTE: we are using "influenza" URLs for dev purposes only. This will be switched to "flu"
         when this functionality is released & publicized. For unknown reasons, if the component is named
         `influenza.jsx` we lose the matchPath functionality. Therefore in a future commit we should simultaneously

--- a/static-site/src/sections/staging.jsx
+++ b/static-site/src/sections/staging.jsx
@@ -1,0 +1,131 @@
+import React from "react";
+import Helmet from "react-helmet";
+import config from "../../data/SiteConfig";
+import NavBar from "../components/nav-bar";
+import MainLayout from "../components/layout";
+import UserDataWrapper from "../layouts/userDataWrapper";
+import {
+  SmallSpacer,
+  HugeSpacer,
+  FlexCenter,
+} from "../layouts/generalComponents";
+import * as splashStyles from "../components/splash/styles";
+import Footer from "../components/Footer";
+import DatasetSelect from "../components/Datasets/dataset-select";
+
+const nextstrainLogoPNG = require("../../static/logos/favicon.png");
+
+const title = "Staging Datasets";
+const abstract = `This page details staging (i.e. not yet released) datasets maintained by the Nextstrain team.`;
+
+
+const tableColumns = [
+  {
+    name: "Dataset",
+    value: (dataset) => dataset.name,
+    url: (dataset) => dataset.url
+  },
+  {
+    name: "Type",
+    value: (dataset) => dataset.type
+  },
+  {
+    name: "Contributor",
+    value: () => "Nextstrain",
+    valueMobile: () => "",
+    url: () => "https://nextstrain.org",
+    logo: () => (<img alt="nextstrain.org" className="logo" width="24px" src={nextstrainLogoPNG}/>)
+  }
+];
+
+
+class Index extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {data: undefined, errorFetchingData: false};
+  }
+
+  async componentDidMount() {
+    try {
+      const data = await getStagingData();
+      this.setState({data});
+    } catch (err) {
+      console.error("Error fetching / parsing data.", err.message);
+      this.setState({errorFetchingData: true});
+    }
+  }
+
+  render() {
+    return (
+      <MainLayout>
+        <div className="index-container">
+          <Helmet title={config.siteTitle} />
+          <main>
+            <UserDataWrapper>
+              <NavBar location={this.props.location} />
+            </UserDataWrapper>
+
+            <splashStyles.Container className="container">
+              <HugeSpacer /><HugeSpacer />
+              <splashStyles.H1>{title}</splashStyles.H1>
+              <SmallSpacer />
+
+              <FlexCenter>
+                <splashStyles.CenteredFocusParagraph>
+                  {abstract}
+                </splashStyles.CenteredFocusParagraph>
+              </FlexCenter>
+              <HugeSpacer /> <HugeSpacer />
+
+              {this.state.data && (
+                <DatasetSelect
+                  datasets={this.state.data}
+                  columns={tableColumns}
+                />
+              )}
+              {this.state.errorFetchingData && (
+                <splashStyles.CenteredFocusParagraph>
+                  Something went wrong getting data.
+                  Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
+                  if this continues to happen.
+                </splashStyles.CenteredFocusParagraph>
+              )}
+
+              <Footer />
+            </splashStyles.Container>
+          </main>
+        </div>
+      </MainLayout>
+    );
+  }
+}
+
+async function getStagingData() {
+  const available = await fetch("/charon/getAvailable?prefix=/staging")
+    .then((res) => res.json());
+  const formatName = (x) => x.replace(/^\//, '').replace(/\/$/, '').replace(/\//g, " / ");
+  const data = [];
+  if (available.datasets) {
+    available.datasets.forEach((d) => {
+      data.push({
+        url: d.request,
+        filename: d.request,
+        name: formatName(d.request),
+        type: "Dataset"
+      });
+    });
+  }
+  if (available.narratives) {
+    available.narratives.forEach((d) => {
+      data.push({
+        url: d.request,
+        filename: d.request,
+        name: formatName(d.request),
+        type: "Narrative"
+      });
+    });
+  }
+  return data;
+}
+
+export default Index;

--- a/test/unit/routing.test.js
+++ b/test/unit/routing.test.js
@@ -1,0 +1,53 @@
+const {isRequestBackedByAuspiceDataset} = require("../../auspicePaths.js");
+
+jest.setTimeout(10000);
+
+/** The server assumes some globals are set. These will hopefully be removed in the future. */
+global.availableDatasets = {
+  secondTreeOptions: {},
+  defaults: {}
+};
+
+/* NOTE
+`isRequestBackedByAuspiceDataset` only runs if the request does not match a static asset..
+*/
+describe('Check requests are handled by Auspice or Gatsby', () => {
+  const auspicePaths = [
+    /* CORE datasets which (normally) exist */
+    "/zika",
+    "/flu/seasonal/h3n2/ha/3y",
+    /* STAGING datasets which (normally) exist */
+    "/staging/zika",
+    "/staging/flu/seasonal/h3n2/ha/3y",
+    // Following have not yet been extended to be handled through Gatsby
+    // So we preserve previous behavior and let auspice handle them
+    "/groups/blab",
+    "/groups",
+    "/community/org/repo",
+    "/narratives/x",
+    "/fetch/x"
+  ];
+
+  const gatsbyPaths = [
+    /* CORE datasets which don't (normally) exist */
+    "/zika/no",
+    "/flu/h3n2/ha/3y", // missing "seasonal"
+    "/ncov/antartica"
+  ];
+
+  for (let i=0; i<auspicePaths.length; i++) {
+    test(`Test that ${auspicePaths[i]} is routed towards Auspice`, async () => { // eslint-disable-line no-await-in-loop
+      const [req, res, next]= [{path: auspicePaths[i]}, {}, () => {}];
+      await isRequestBackedByAuspiceDataset(req, res, next); // eslint-disable-line no-await-in-loop
+      expect(req.sendToAuspice).toBe(true);
+    });
+  }
+  for (let i=0; i<gatsbyPaths.length; i++) {
+    test(`Test that ${gatsbyPaths[i]} is routed towards Gatsby`, async () => { // eslint-disable-line no-await-in-loop
+      const [req, res, next]= [{path: gatsbyPaths[i]}, {}, () => {}];
+      await isRequestBackedByAuspiceDataset(req, res, next); // eslint-disable-line no-await-in-loop
+      expect(req.sendToAuspice).toBe(false);
+    });
+  }
+});
+

--- a/test/unit/routing.test.js
+++ b/test/unit/routing.test.js
@@ -32,7 +32,9 @@ describe('Check requests are handled by Auspice or Gatsby', () => {
     /* CORE datasets which don't (normally) exist */
     "/zika/no",
     "/flu/h3n2/ha/3y", // missing "seasonal"
-    "/ncov/antartica"
+    "/ncov/antartica",
+    /* STAGING datasets which don't exist are handled by Gatsby */
+    "/staging/not-a-dataset"
   ];
 
   for (let i=0; i<auspicePaths.length; i++) {


### PR DESCRIPTION
Begins an implementation which would close #310. See commit messages for more information.

Currently works with core and staging URLs. All other sources (groups, community etc) are still handled by Auspice. Here are some trial URLs:
* https://nextstrain-s-redirects--ouuvbt.herokuapp.com/flu/vic/yam Invalid flu URL, shows main influenza page instead. 
* https://nextstrain-s-redirects--ouuvbt.herokuapp.com/ncov/antartica ncov dataset which doesn't exist. Shows SARS-CoV-2 main page.
* https://nextstrain-s-redirects--ouuvbt.herokuapp.com/ebola/equateur dataset doesn't exist. Shows the splash page, as we don't yet have a page listing all core datasets.
* https://nextstrain-s-redirects--ouuvbt.herokuapp.com/staging/no-dataset shows new staging page listing datasets & narratives.

(Note that the URL often updates after loading, but that shouldn't happen.)

Next steps:
- [ ] Stop the URL updating (it's happening client side)
- [ ] Add a reusable "Dataset didn't exist, here's the parent page" banner to pages.
- [ ] More unit tests
- [ ] Explore what caching is being used for the server-side dataset fetching (if any)
- [ ] Measure loading times 

Comments welcomed on this direction!
