### PR TITLE
gatsby groups page parse markdown overview;

### DIFF
--- a/auspicePaths.js
+++ b/auspicePaths.js
@@ -30,7 +30,6 @@ const auspicePaths = [
   "/narratives/*",
   "/staging",
   "/staging/*",
-  ...groups.map((group) => `/groups/${group}`),
   ...groups.map((group) => `/groups/${group}/*`),
 
   /* Auspice gets specific /community paths so it can show an index of datasets

--- a/static-site/gatsby-node.js
+++ b/static-site/gatsby-node.js
@@ -193,6 +193,13 @@ exports.createPages = ({graphql, actions}) => {
           component: path.resolve("src/sections/users.jsx")
         });
 
+        // Create individual groups pages
+        createPage({
+          path: "/groups/*",
+          matchPath: "/groups/*",
+          component: path.resolve("src/sections/individual-group-page.jsx")
+        });
+
         // Create page detailing all things SARS-CoV-2
         // Note that this is in src/sections, not src/pages. This is because we don't
         // want to render anything at the exact url of nextstrain.org/sars-cov-2-page

--- a/static-site/package-lock.json
+++ b/static-site/package-lock.json
@@ -4690,7 +4690,8 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "optional": true
         },
         "slice-ansi": {
           "version": "3.0.0",
@@ -6806,6 +6807,11 @@
       "requires": {
         "domelementtype": "1"
       }
+    },
+    "dompurify": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.7.tgz",
+      "integrity": "sha512-jdtDffdGNY+C76jvodNTu9jt5yYj59vuTUyx+wXdzcSwAGTYZDAQkQ7Iwx9zcGrA4ixC1syU4H3RZROqRxokxg=="
     },
     "domutils": {
       "version": "1.5.1",
@@ -11990,12 +11996,14 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "optional": true
         },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "optional": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -12036,6 +12044,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -12043,7 +12052,8 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "optional": true
         },
         "emoji-regex": {
           "version": "8.0.0",
@@ -12060,7 +12070,8 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "optional": true
         },
         "mimic-fn": {
           "version": "2.1.0",
@@ -12113,6 +12124,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -13941,6 +13953,11 @@
       "requires": {
         "repeat-string": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA=="
     },
     "math-random": {
       "version": "1.0.4",
@@ -19711,6 +19728,7 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
       "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+      "optional": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/static-site/package.json
+++ b/static-site/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "babel-plugin-styled-components": "^1.10.6",
+    "dompurify": "^2.2.7",
     "gatsby": "^2.18.21",
     "gatsby-plugin-catch-links": "^2.1.24",
     "gatsby-plugin-feed": "^2.3.26",
@@ -57,6 +58,7 @@
     "lodash": "^4.17.15",
     "lodash-webpack-plugin": "^0.11.4",
     "mapbox-gl": "1.13.0",
+    "marked": "^2.0.3",
     "prismjs": "^1.18.0",
     "prop-types": "^15.6.0",
     "react": "^16.12.0",

--- a/static-site/src/components/Datasets/dataset-select.jsx
+++ b/static-site/src/components/Datasets/dataset-select.jsx
@@ -57,6 +57,7 @@ class DatasetSelect extends React.Component {
   render() {
     const childrenToRender = this.props.interface || ["FilterSelect", "FilterDisplay", "ListDatasets"];
     const filteredDatasets = getFilteredDatasets(this.props.datasets, this.state.filters, this.props.columns);
+    const unit = this.props.unit || "dataset"; // we want it it say "filter narratives" if we are passing narratives as the filterable list
     return (
       <>
         {childrenToRender.map((Child) => {
@@ -67,6 +68,7 @@ class DatasetSelect extends React.Component {
                   key={String(Object.keys(this.state.filters).length)}
                   options={collectAvailableFilteringOptions(this.props.datasets, this.props.columns)}
                   applyFilter={this.applyFilter}
+                  unit={unit}
                 />
               );
             case "FilterDisplay":
@@ -83,6 +85,7 @@ class DatasetSelect extends React.Component {
                   key="ListDatasets"
                   columns={this.props.columns}
                   datasets={filteredDatasets}
+                  unit={unit}
                 />
               );
             default:

--- a/static-site/src/components/Datasets/filter-selection.jsx
+++ b/static-site/src/components/Datasets/filter-selection.jsx
@@ -22,19 +22,19 @@ const StyledTooltip = styled(ReactTooltip)`
   pointer-events: auto !important;
 `;
 
-export const FilterSelect = ({options, applyFilter}) => {
+export const FilterSelect = ({options, applyFilter, unit}) => {
 
   return (
     <CenteredContainer>
       <splashStyles.H3 left>
-        {`Filter datasets `}
+        {`Filter ${unit}s `}
         <>
           <span style={{cursor: "help"}} data-tip data-for={"build-filter-info"}>
             <FaInfoCircle/>
           </span>
           <StyledTooltip type="dark" effect="solid" id={"build-filter-info"}>
             <>
-              {`Use this box to filter the displayed list of datasets based upon filtering criteria.`}
+              {`Use this box to filter the displayed list of ${unit}s based upon filtering criteria.`}
               <br/>
               {/* TODO do we want to keep this set logic? It's currently broken */}
               Data is filtered by forming a union of selected values within each category, and then

--- a/static-site/src/components/Datasets/list-datasets.jsx
+++ b/static-site/src/components/Datasets/list-datasets.jsx
@@ -58,8 +58,12 @@ const HeaderRow = ({columns}) => {
         <Col {...columnStyles[0][0]} key={names[0]}>{names[0]}</Col>
 
         {/* column 2: (typically the contributor) - both main & mobile views */}
-        <Col {...columnStyles[1][0]} key={names[1]}>{names[1]}</Col>
-        <Col {...columnStyles[1][1]} key={`${names[1]}-mobile`}>{names[1]}</Col>
+        {names.length>=2 && (
+          <>
+            <Col {...columnStyles[1][0]} key={names[1]}>{names[1]}</Col>
+            <Col {...columnStyles[1][1]} key={`${names[1]}-mobile`}>{names[1]}</Col>
+          </>
+        )}
 
         {/* column 3: optional. Not rendered on small screens. */}
         {names.length===3 && (
@@ -81,12 +85,16 @@ const NormalRow = ({columns, dataset}) => {
         </Col>
 
         {/* column 2: (typically the contributor) - both main & mobile views */}
-        <Col {...columnStyles[1][0]} key={names[1]}>
-          <Value dataset={dataset} columnInfo={columns[1]}/>
-        </Col>
-        <Col {...columnStyles[1][1]} key={`${names[1]}-mobile`}>
-          <Value dataset={dataset} columnInfo={columns[1]} mobileView/>
-        </Col>
+        {names.length>=2 && (
+          <>
+            <Col {...columnStyles[1][0]} key={names[1]}>
+              <Value dataset={dataset} columnInfo={columns[1]}/>
+            </Col>
+            <Col {...columnStyles[1][1]} key={`${names[1]}-mobile`}>
+              <Value dataset={dataset} columnInfo={columns[1]} mobileView/>
+            </Col>
+          </>
+        )}
 
         {/* column 3: optional. Not rendered on small screens. */}
         {names.length===3 && (

--- a/static-site/src/components/splash/markdownDisplay.jsx
+++ b/static-site/src/components/splash/markdownDisplay.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { parseMarkdown } from "../../util/parseMarkdown";
+
+export default function MarkdownDisplay({ mdstring, ...props }) {
+  let cleanDescription;
+  try {
+    cleanDescription = parseMarkdown(mdstring);
+  } catch (error) {
+    console.error(`Error parsing footer description: ${error}`);
+    cleanDescription = '<p>There was an error parsing the footer description.</p>';
+  }
+  return (
+    <div
+      {...props}
+      dangerouslySetInnerHTML={{ __html: cleanDescription }} // eslint-disable-line react/no-danger
+    />
+  );
+}

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -173,7 +173,7 @@ class Index extends React.Component {
 const createDatasetListing = (list, groupName) => {
   return list.map((d) => {
     return {
-      filename: d.request,
+      filename: d.request.replace(`groups/${groupName}/`, '').replace('narratives/', ''),
       url: `https://nextstrain.org/${d.request}`,
       contributor: groupName
     };

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -8,11 +8,8 @@ import {
 import * as splashStyles from "../components/splash/styles";
 import DatasetSelect from "../components/Datasets/dataset-select";
 import GenericPage from "../layouts/generic-page";
+import MarkdownDisplay from "../components/splash/markdownDisplay";
 
-// TODO: these functions are copied from auspice-client/customizations/splash.js
-// We should abstract them into a util function JS file if we actually want to use
-// them in both places going forward, otherwise we can go another direction with the
-// interface here.
 function Title({avatarSrc, children}) {
   if (!children) return null;
   const AvatarImg = styled.img`
@@ -66,6 +63,18 @@ function Website({children}) {
   );
 }
 
+const OverviewContainer = styled.div`
+  text-align: justify;
+  font-size: 16px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  font-weight: 300;
+  color: var(--darkGrey);
+  line-height: 1.42857143;
+  margin: 0px auto 0px auto;
+  max-width: 900px;
+`;
+
 class Index extends React.Component {
   constructor(props) {
     super(props);
@@ -112,17 +121,24 @@ class Index extends React.Component {
     return (
       <GenericPage location={this.props.location}>
         {this.state.sourceInfo &&
-        <FlexCenter>
-          <Title avatarSrc={this.state.sourceInfo.avatar}>
-            {this.state.sourceInfo.title}
-            <Byline>{this.state.sourceInfo.byline}</Byline>
-            <Website>{this.state.sourceInfo.website}</Website>
-          </Title>
-        </FlexCenter>
-        // TODO display this.state.sourceInfo.overview (markdown)
-        }
+        <>
+          <FlexCenter>
+            <Title avatarSrc={this.state.sourceInfo.avatar}>
+              {this.state.sourceInfo.title}
+              <Byline>{this.state.sourceInfo.byline}</Byline>
+              <Website>{this.state.sourceInfo.website}</Website>
+            </Title>
+          </FlexCenter>
+          {this.state.sourceInfo.overview &&
+            <FlexCenter>
+              <OverviewContainer>
+                <MarkdownDisplay mdstring={this.state.sourceInfo.overview}/>
+              </OverviewContainer>
+            </FlexCenter>
+          }
+        </>}
         <HugeSpacer />
-        {this.state.dataLoaded && this.state.sourceInfo && this.state.sourceInfo.showDatasets && (
+        {this.state.dataLoaded && this.state.sourceInfo && this.state.sourceInfo.showDatasets && this.state.datasets.length > 0 && (
           <ScrollableAnchor id={"datasets"}>
             <div>
               <splashStyles.H3>Available datasets</splashStyles.H3>
@@ -140,7 +156,7 @@ class Index extends React.Component {
           </ScrollableAnchor>
         )}
         <HugeSpacer />
-        {this.state.dataLoaded && this.state.sourceInfo && this.state.sourceInfo.showNarratives && (
+        {this.state.dataLoaded && this.state.sourceInfo && this.state.sourceInfo.showNarratives && this.state.narratives.length > 0 &&(
           <ScrollableAnchor id={"narratives"}>
             <div>
               <splashStyles.H3>Available narratives</splashStyles.H3>

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -118,7 +118,7 @@ class Index extends React.Component {
           </FlexCenter>
           {/* TODO display this.state.sourceInfo.overview (markdown) */}
           <HugeSpacer />
-          {this.state.sourceInfo.showDatasets && (
+          {this.state.sourceInfo.showDatasets && this.state.datasets.length > 0 && (
             <ScrollableAnchor id={"datasets"}>
               <div>
                 <splashStyles.H3>Available datasets</splashStyles.H3>
@@ -136,7 +136,7 @@ class Index extends React.Component {
             </ScrollableAnchor>
           )}
           <HugeSpacer />
-          {this.state.sourceInfo.showNarratives && (
+          {this.state.sourceInfo.showNarratives && this.state.narratives.length > 0 && (
             <ScrollableAnchor id={"narratives"}>
               <div>
                 <splashStyles.H3>Available narratives</splashStyles.H3>

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -1,9 +1,7 @@
 import React from "react";
 import ScrollableAnchor, { configureAnchors } from "react-scrollable-anchor";
-import { MdPerson } from "react-icons/md";
 import styled from 'styled-components';
 import {
-  SmallSpacer,
   HugeSpacer,
   FlexCenter
 } from "../layouts/generalComponents";
@@ -48,6 +46,7 @@ function Byline({children}) {
   if (!children) return null;
   const Div = styled.div`
     && {
+      font-size: 18px;
       font-weight: 400;
       line-height: 1.428;
       color: #A9ADB1;
@@ -66,29 +65,6 @@ function Website({children}) {
     </a>
   );
 }
-
-const nextstrainLogoPNG = require("../../static/logos/favicon.png");
-
-const tableColumns = [
-  {
-    name: "Dataset",
-    value: (dataset) => dataset.filename.replace(/_/g, ' / ').replace('.json', ''),
-    url: (dataset) => dataset.url
-  },
-  {
-    name: "Contributor",
-    value: (dataset) => dataset.contributor,
-    valueMobile: () => "",
-    url: (dataset) => dataset.contributorUrl,
-    logo: (dataset) => dataset.contributor==="Nextstrain Team" ?
-      <img alt="nextstrain.org" className="logo" width="24px" src={nextstrainLogoPNG}/> :
-      undefined,
-    logoMobile: (dataset) => dataset.contributor==="Nextstrain Team" ?
-      <img alt="nextstrain.org" className="logo" width="24px" src={nextstrainLogoPNG}/> :
-      <MdPerson/>
-  }
-];
-
 
 class Index extends React.Component {
   constructor(props) {
@@ -116,7 +92,7 @@ class Index extends React.Component {
       console.error("Cannot find group.", err.message);
       this.setState({groupNotFound: true});
     }
-    if (sourceInfo && sourceInfo.showDatasets || sourceInfo.showNarratives) {
+    if (sourceInfo && (sourceInfo.showDatasets || sourceInfo.showNarratives)) {
       const getAvailableUrl = `/charon/getAvailable?prefix=/groups/${groupName}/`;
       try {
         const {datasets, narratives} = await fetchAndParseJSON(getAvailableUrl, groupName);
@@ -141,30 +117,47 @@ class Index extends React.Component {
             </Title>
           </FlexCenter>
           {/* TODO display this.state.sourceInfo.overview (markdown) */}
-          <SmallSpacer />
-          <ScrollableAnchor id={"datasets"}>
-            <div>
-              <HugeSpacer />
-              {this.state.sourceInfo.showDatasets && (
+          <HugeSpacer />
+          {this.state.sourceInfo.showDatasets && (
+            <ScrollableAnchor id={"datasets"}>
+              <div>
+                <splashStyles.H3>Available datasets</splashStyles.H3>
                 <DatasetSelect
                   datasets={this.state.datasets}
-                  columns={tableColumns}
+                  columns={[
+                    {
+                      name: "Dataset",
+                      value: (dataset) => dataset.filename.replace(/_/g, ' / ').replace('.json', ''),
+                      url: (dataset) => dataset.url
+                    }
+                  ]}
                 />
-              )}
-              <HugeSpacer />
-              <splashStyles.H3>Narratives</splashStyles.H3>
-              {this.state.sourceInfo.showNarratives && (
+              </div>
+            </ScrollableAnchor>
+          )}
+          <HugeSpacer />
+          {this.state.sourceInfo.showNarratives && (
+            <ScrollableAnchor id={"narratives"}>
+              <div>
+                <splashStyles.H3>Available narratives</splashStyles.H3>
                 <DatasetSelect
                   datasets={this.state.narratives}
-                  columns={tableColumns}
+                  columns={[
+                    {
+                      name: "Narrative",
+                      value: (dataset) => dataset.filename.replace(/_/g, ' / ').replace('.json', ''),
+                      url: (dataset) => dataset.url
+                    }
+                  ]}
+                  unit="narrative"
                 />
-              )}
-              { this.state.errorFetchingData && <splashStyles.CenteredFocusParagraph>
+              </div>
+            </ScrollableAnchor>
+          )}
+          { this.state.errorFetchingData && <splashStyles.CenteredFocusParagraph>
                         Something went wrong getting data.
                         Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
                         if this continues to happen.</splashStyles.CenteredFocusParagraph>}
-            </div>
-          </ScrollableAnchor>
         </>}
       </GenericPage>
     );

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -111,58 +111,60 @@ class Index extends React.Component {
   render() {
     return (
       <GenericPage location={this.props.location}>
-        {this.state.sourceInfo && this.state.dataLoaded &&
-        <>
+        {this.state.sourceInfo &&
+        <FlexCenter>
+          <Title avatarSrc={this.state.sourceInfo.avatar}>
+            {this.state.sourceInfo.title}
+            <Byline>{this.state.sourceInfo.byline}</Byline>
+            <Website>{this.state.sourceInfo.website}</Website>
+          </Title>
+        </FlexCenter>
+        // TODO display this.state.sourceInfo.overview (markdown)
+        }
+        <HugeSpacer />
+        {this.state.dataLoaded && this.state.sourceInfo && this.state.sourceInfo.showDatasets && (
+          <ScrollableAnchor id={"datasets"}>
+            <div>
+              <splashStyles.H3>Available datasets</splashStyles.H3>
+              <DatasetSelect
+                datasets={this.state.datasets}
+                columns={[
+                  {
+                    name: "Dataset",
+                    value: (dataset) => dataset.filename.replace(/_/g, ' / ').replace('.json', ''),
+                    url: (dataset) => dataset.url
+                  }
+                ]}
+              />
+            </div>
+          </ScrollableAnchor>
+        )}
+        <HugeSpacer />
+        {this.state.dataLoaded && this.state.sourceInfo && this.state.sourceInfo.showNarratives && (
+          <ScrollableAnchor id={"narratives"}>
+            <div>
+              <splashStyles.H3>Available narratives</splashStyles.H3>
+              <DatasetSelect
+                datasets={this.state.narratives}
+                columns={[
+                  {
+                    name: "Narrative",
+                    value: (dataset) => dataset.filename.replace(/_/g, ' / ').replace('.json', ''),
+                    url: (dataset) => dataset.url
+                  }
+                ]}
+                unit="narrative"
+              />
+            </div>
+          </ScrollableAnchor>
+        )}
+        { this.state.errorFetchingData &&
           <FlexCenter>
-            <Title avatarSrc={this.state.sourceInfo.avatar}>
-              {this.state.sourceInfo.title}
-              <Byline>{this.state.sourceInfo.byline}</Byline>
-              <Website>{this.state.sourceInfo.website}</Website>
-            </Title>
-          </FlexCenter>
-          {/* TODO display this.state.sourceInfo.overview (markdown) */}
-          <HugeSpacer />
-          {this.state.sourceInfo.showDatasets && this.state.datasets.length > 0 && (
-            <ScrollableAnchor id={"datasets"}>
-              <div>
-                <splashStyles.H3>Available datasets</splashStyles.H3>
-                <DatasetSelect
-                  datasets={this.state.datasets}
-                  columns={[
-                    {
-                      name: "Dataset",
-                      value: (dataset) => dataset.filename.replace(/_/g, ' / ').replace('.json', ''),
-                      url: (dataset) => dataset.url
-                    }
-                  ]}
-                />
-              </div>
-            </ScrollableAnchor>
-          )}
-          <HugeSpacer />
-          {this.state.sourceInfo.showNarratives && this.state.narratives.length > 0 && (
-            <ScrollableAnchor id={"narratives"}>
-              <div>
-                <splashStyles.H3>Available narratives</splashStyles.H3>
-                <DatasetSelect
-                  datasets={this.state.narratives}
-                  columns={[
-                    {
-                      name: "Narrative",
-                      value: (dataset) => dataset.filename.replace(/_/g, ' / ').replace('.json', ''),
-                      url: (dataset) => dataset.url
-                    }
-                  ]}
-                  unit="narrative"
-                />
-              </div>
-            </ScrollableAnchor>
-          )}
-          { this.state.errorFetchingData && <splashStyles.CenteredFocusParagraph>
-                        Something went wrong getting data.
-                        Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
-                        if this continues to happen.</splashStyles.CenteredFocusParagraph>}
-        </>}
+            <splashStyles.CenteredFocusParagraph>
+                  Something went wrong getting data.
+                  Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
+                  if this continues to happen.</splashStyles.CenteredFocusParagraph>
+          </FlexCenter>}
       </GenericPage>
     );
   }

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -1,0 +1,200 @@
+import React from "react";
+import ScrollableAnchor, { configureAnchors } from "react-scrollable-anchor";
+import { MdPerson } from "react-icons/md";
+import styled from 'styled-components';
+import {
+  SmallSpacer,
+  HugeSpacer,
+  FlexCenter
+} from "../layouts/generalComponents";
+import * as splashStyles from "../components/splash/styles";
+import DatasetSelect from "../components/Datasets/dataset-select";
+import GenericPage from "../layouts/generic-page";
+
+// TODO: these functions are copied from auspice-client/customizations/splash.js
+// We should abstract them into a util function JS file if we actually want to use
+// them in both places going forward, otherwise we can go another direction with the
+// interface here.
+function Title({avatarSrc, children}) {
+  if (!children) return null;
+  const AvatarImg = styled.img`
+    width: 140px;
+    margin-right: 20px;
+    object-fit: contain;
+  `;
+  const TitleDiv = styled.div`
+    && {
+      font-weight: 500;
+      font-size: 26px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+  `;
+  return (
+    <div style={{display: "flex", justifyContent: "start", padding: "50px 0px 20px 0px"}}>
+      {avatarSrc ?
+        <AvatarImg alt="avatar" src={avatarSrc}/> :
+        null
+      }
+      <TitleDiv>
+        {children}
+      </TitleDiv>
+    </div>
+  );
+}
+
+function Byline({children}) {
+  if (!children) return null;
+  const Div = styled.div`
+    && {
+      font-weight: 400;
+      line-height: 1.428;
+      color: #A9ADB1;
+    }
+  `;
+  return (<Div>{children}</Div>);
+}
+
+function Website({children}) {
+  if (!children) return null;
+  return (
+    <a href={children}
+      style={{color: "#A9ADB1", lineHeight: "1.0", textDecoration: "none", cursor: "pointer", fontWeight: "400", fontSize: "16px"}}
+    >
+      {children}
+    </a>
+  );
+}
+
+const nextstrainLogoPNG = require("../../static/logos/favicon.png");
+
+const tableColumns = [
+  {
+    name: "Dataset",
+    value: (dataset) => dataset.filename.replace(/_/g, ' / ').replace('.json', ''),
+    url: (dataset) => dataset.url
+  },
+  {
+    name: "Contributor",
+    value: (dataset) => dataset.contributor,
+    valueMobile: () => "",
+    url: (dataset) => dataset.contributorUrl,
+    logo: (dataset) => dataset.contributor==="Nextstrain Team" ?
+      <img alt="nextstrain.org" className="logo" width="24px" src={nextstrainLogoPNG}/> :
+      undefined,
+    logoMobile: (dataset) => dataset.contributor==="Nextstrain Team" ?
+      <img alt="nextstrain.org" className="logo" width="24px" src={nextstrainLogoPNG}/> :
+      <MdPerson/>
+  }
+];
+
+
+class Index extends React.Component {
+  constructor(props) {
+    super(props);
+    configureAnchors({ offset: -10 });
+    this.state = {
+      dataLoaded: false,
+      errorFetchingData: false,
+      groupNotFound: false,
+      groupName: undefined,
+      sourceInfo: undefined
+    };
+  }
+  async componentDidMount() {
+    const groupName = this.props["*"];
+    const getSourceInfoUrl = `/charon/getSourceInfo?prefix=/groups/${groupName}/`;
+    let sourceInfo;
+    // TODO promise logic and error catching improvements here
+    try {
+      sourceInfo = await fetch(getSourceInfoUrl)
+        .then((res) => res.text())
+        .then((text) => JSON.parse(text));
+      this.setState({sourceInfo});
+    } catch (err) {
+      console.error("Cannot find group.", err.message);
+      this.setState({groupNotFound: true});
+    }
+    if (sourceInfo && sourceInfo.showDatasets || sourceInfo.showNarratives) {
+      const getAvailableUrl = `/charon/getAvailable?prefix=/groups/${groupName}/`;
+      try {
+        const {datasets, narratives} = await fetchAndParseJSON(getAvailableUrl, groupName);
+        this.setState({datasets, narratives, dataLoaded: true, groupName});
+      } catch (err) {
+        console.error("Error fetching / parsing data.", err.message);
+        this.setState({errorFetchingData: true});
+      }
+    }
+  }
+
+  render() {
+    return (
+      <GenericPage location={this.props.location}>
+        {this.state.sourceInfo && this.state.dataLoaded &&
+        <>
+          <FlexCenter>
+            <Title avatarSrc={this.state.sourceInfo.avatar}>
+              {this.state.sourceInfo.title}
+              <Byline>{this.state.sourceInfo.byline}</Byline>
+              <Website>{this.state.sourceInfo.website}</Website>
+            </Title>
+          </FlexCenter>
+          {/* TODO display this.state.sourceInfo.overview (markdown) */}
+          <SmallSpacer />
+          <ScrollableAnchor id={"datasets"}>
+            <div>
+              <HugeSpacer />
+              {this.state.sourceInfo.showDatasets && (
+                <DatasetSelect
+                  datasets={this.state.datasets}
+                  columns={tableColumns}
+                />
+              )}
+              <HugeSpacer />
+              <splashStyles.H3>Narratives</splashStyles.H3>
+              {this.state.sourceInfo.showNarratives && (
+                <DatasetSelect
+                  datasets={this.state.narratives}
+                  columns={tableColumns}
+                />
+              )}
+              { this.state.errorFetchingData && <splashStyles.CenteredFocusParagraph>
+                        Something went wrong getting data.
+                        Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
+                        if this continues to happen.</splashStyles.CenteredFocusParagraph>}
+            </div>
+          </ScrollableAnchor>
+        </>}
+      </GenericPage>
+    );
+  }
+}
+
+const createDatasetListing = (list, groupName) => {
+  return list.map((d) => {
+    return {
+      filename: d.request,
+      url: `https://nextstrain.org/${d.request}`,
+      contributor: groupName
+    };
+  });
+};
+
+async function fetchAndParseJSON(jsonUrl, groupName) {
+  const datasetsJSON = await fetch(jsonUrl)
+    .then((res) => res.text())
+    .then((text) => {
+      const data = JSON.parse(text);
+      return {
+        datasets: createDatasetListing(data.datasets, groupName),
+        narratives: createDatasetListing(data.narratives, groupName)
+      };
+    })
+    .catch((err) => {
+      console.err(err);
+    });
+  return datasetsJSON;
+}
+
+export default Index;

--- a/static-site/src/util/parseMarkdown.js
+++ b/static-site/src/util/parseMarkdown.js
@@ -1,0 +1,69 @@
+import marked from "marked";
+import dompurify from "dompurify";
+
+dompurify.addHook("afterSanitizeAttributes", (node) => {
+  // Set external links to open in a new tab
+  if ('href' in node && location.hostname !== node.hostname) { // eslint-disable-line no-restricted-globals
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noreferrer nofollow');
+  }
+  // Find nodes that contain images and add imageContainer class to update styling
+  const nodeContainsImg = ([...node.childNodes].filter((child) => child.localName === 'img')).length > 0;
+  if (nodeContainsImg) {
+    // For special case of image links, set imageContainer on outer parent
+    if (node.localName === 'a') {
+      node.parentNode.className += ' imageContainer';
+    } else {
+      node.className += ' imageContainer';
+    }
+  }
+});
+
+const ALLOWED_TAGS = ['div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'em', 'strong', 'del', 'ol', 'ul', 'li', 'a', 'img'];
+ALLOWED_TAGS.push('#text', 'code', 'pre', 'hr', 'table', 'thead', 'tbody', 'th', 'tr', 'td', 'sub', 'sup');
+// We want to support SVG elements, requiring the following tags (we exclude "foreignObject", "style" and "script")
+ALLOWED_TAGS.push("svg", "altGlyph", "altGlyphDef", "altGlyphItem", "animate", "animateColor", "animateMotion", "animateTransform");
+ALLOWED_TAGS.push("circle", "clipPath", "color-profile", "cursor", "defs", "desc", "ellipse", "feBlend", "feColorMatrix", "feComponentTransfer");
+ALLOWED_TAGS.push("feComposite", "feConvolveMatrix", "feDiffuseLighting", "feDisplacementMap", "feDistantLight", "feFlood", "feFuncA");
+ALLOWED_TAGS.push("feFuncB", "feFuncG", "feFuncR", "feGaussianBlur", "feImage", "feMerge", "feMergeNode", "feMorphology", "feOffset");
+ALLOWED_TAGS.push("fePointLight", "feSpecularLighting", "feSpotLight", "feTile", "feTurbulence", "filter", "font", "font-face");
+ALLOWED_TAGS.push("font-face-format", "font-face-name", "font-face-src", "font-face-uri", "g", "glyph", "glyphRef");
+ALLOWED_TAGS.push("hkern", "image", "line", "linearGradient", "marker", "mask", "metadata", "missing-glyph", "mpath", "path");
+ALLOWED_TAGS.push("pattern", "polygon", "polyline", "radialGradient", "rect", "set", "stop", "switch", "symbol");
+ALLOWED_TAGS.push("text", "textPath", "title", "tref", "tspan", "use", "view", "vkern");
+
+const ALLOWED_ATTR = ['href', 'src', 'width', 'height', 'alt'];
+// We add the following Attributes for SVG via https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute
+// Certain values have been excluded here, e.g. "style"
+ALLOWED_ATTR.push("accent-height", "accumulate", "additive", "alignment-baseline", "allowReorder", "alphabetic", "amplitude", "arabic-form", "ascent", "attributeName", "attributeType", "autoReverse", "azimuth");
+ALLOWED_ATTR.push("baseFrequency", "baseline-shift", "baseProfile", "bbox", "begin", "bias", "by");
+ALLOWED_ATTR.push("calcMode", "cap-height", "class", "clip", "clipPathUnits", "clip-path", "clip-rule", "color", "color-interpolation", "color-interpolation-filters", "color-profile", "color-rendering", "cursor", "cx", "cy");
+ALLOWED_ATTR.push("d", "decelerate", "descent", "diffuseConstant", "direction", "display", "divisor", "dominant-baseline", "dur", "dx", "dy");
+ALLOWED_ATTR.push("edgeMode", "elevation", "enable-background", "end", "exponent", "externalResourcesRequired");
+ALLOWED_ATTR.push("fill", "fill-opacity", "fill-rule", "filter", "filterRes", "filterUnits", "flood-color", "flood-opacity", "font-family", "font-size", "font-size-adjust", "font-stretch", "font-style", "font-variant", "font-weight", "format", "from", "fr", "fx", "fy");
+ALLOWED_ATTR.push("g1", "g2", "glyph-name", "glyph-orientation-horizontal", "glyph-orientation-vertical", "glyphRef", "gradientTransform", "gradientUnits");
+ALLOWED_ATTR.push("hanging", "height", "href", "hreflang", "horiz-adv-x", "horiz-origin-x");
+ALLOWED_ATTR.push("id", "ideographic", "image-rendering", "in", "in2", "intercept");
+ALLOWED_ATTR.push("k", "k1", "k2", "k3", "k4", "kernelMatrix", "kernelUnitLength", "kerning", "keyPoints", "keySplines", "keyTimes");
+ALLOWED_ATTR.push("lang", "lengthAdjust", "letter-spacing", "lighting-color", "limitingConeAngle", "local");
+ALLOWED_ATTR.push("marker-end", "marker-mid", "marker-start", "markerHeight", "markerUnits", "markerWidth", "mask", "maskContentUnits", "maskUnits", "mathematical", "max", "media", "method", "min", "mode");
+ALLOWED_ATTR.push("name", "numOctaves");
+ALLOWED_ATTR.push("offset", "opacity", "operator", "order", "orient", "orientation", "origin", "overflow", "overline-position", "overline-thickness");
+ALLOWED_ATTR.push("panose-1", "paint-order", "path", "pathLength", "patternContentUnits", "patternTransform", "patternUnits", "ping", "pointer-events", "points", "pointsAtX", "pointsAtY", "pointsAtZ", "preserveAlpha", "preserveAspectRatio", "primitiveUnits");
+ALLOWED_ATTR.push("r", "radius", "referrerPolicy", "refX", "refY", "rel", "rendering-intent", "repeatCount", "repeatDur", "requiredExtensions", "requiredFeatures", "restart", "result", "rotate", "rx", "ry");
+ALLOWED_ATTR.push("scale", "seed", "shape-rendering", "slope", "spacing", "specularConstant", "specularExponent", "speed", "spreadMethod", "startOffset", "stdDeviation", "stemh", "stemv", "stitchTiles", "stop-color", "stop-opacity", "strikethrough-position", "strikethrough-thickness", "string", "stroke", "stroke-dasharray", "stroke-dashoffset", "stroke-linecap", "stroke-linejoin", "stroke-miterlimit", "stroke-opacity", "stroke-width", "surfaceScale", "systemLanguage");
+ALLOWED_ATTR.push("tabindex", "tableValues", "target", "targetX", "targetY", "text-anchor", "text-decoration", "text-rendering", "textLength", "to", "transform", "type");
+ALLOWED_ATTR.push("u1", "u2", "underline-position", "underline-thickness", "unicode", "unicode-bidi", "unicode-range", "units-per-em");
+ALLOWED_ATTR.push("v-alphabetic", "v-hanging", "v-ideographic", "v-mathematical", "values", "vector-effect", "version", "vert-adv-y", "vert-origin-x", "vert-origin-y", "viewBox", "viewTarget", "visibility");
+ALLOWED_ATTR.push("width", "widths", "word-spacing", "writing-mode");
+ALLOWED_ATTR.push("x", "x-height", "x1", "x2", "xChannelSelector");
+ALLOWED_ATTR.push("y", "y1", "y2", "yChannelSelector");
+ALLOWED_ATTR.push("z", "zoomAndPan");
+
+export const parseMarkdown = (mdString) => {
+  const sanitizer = dompurify.sanitize;
+  const sanitizerConfig = {ALLOWED_TAGS, ALLOWED_ATTR, KEEP_CONTENT: false, ALLOW_DATA_ATTR: false};
+  const rawDescription = marked(mdString);
+  const cleanDescription = sanitizer(rawDescription, sanitizerConfig);
+  return cleanDescription;
+};


### PR DESCRIPTION
Copies the approach of auspice,
previously done by
auspice-client/customisations/splash.js.
That page will be retired once gatsby
performs all the necessary function to
handle routing to either gatsby landing
pages or to auspice.

* not working due to issue with `dompurify` which i am trying to sort out.