### PR TITLE
ResourceNotFoundError if source not found;

### DIFF
--- a/src/getDatasetHelpers.js
+++ b/src/getDatasetHelpers.js
@@ -1,5 +1,6 @@
 const utils = require("./utils");
 const sources = require("./sources");
+const {ResourceNotFoundError} = require("./exceptions");
 
 const handle500Error = (res, clientMsg, serverMsg="") => {
   utils.warn(`${clientMsg} -- ${serverMsg}`);
@@ -56,6 +57,8 @@ const splitPrefixIntoParts = (prefix) => {
   }
 
   const Source = sources.get(sourceName);
+  // Source not found error
+  if (typeof Source !== "function") throw new ResourceNotFoundError();
   let source;
 
   switch (sourceName) {


### PR DESCRIPTION
If we can't parse a request prefix into
a source that we recognize, we should
throw some official error. Not sure this
is how we want to do it but before it
was just a TypeError:
"Source is not a constructor"
happening when trying to call the Source function.

I could be wrong about this behavior but I was confused by a 500 server error when requesting a nonexistent group.