### PR TITLE
Improve async error handling in routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@awaitjs/express": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@awaitjs/express/-/express-0.6.3.tgz",
+      "integrity": "sha512-x7N92+Rmy/WHEaXXunV2ArVa/AqzkJlouc8pokuVF9h6DeUtbkPaEKVYKMDEFs2u5Hbw2XfwGVyLf69yr2UG5g=="
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -6931,6 +6936,18 @@
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
         },
+        "http-errors": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
         "iconv-lite": {
           "version": "0.4.24",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -10338,15 +10355,27 @@
       "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
     },
     "http-errors": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+      "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
       "requires": {
         "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.1",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "setprototypeof": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+          "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+        }
       }
     },
     "http-proxy-agent": {
@@ -15944,6 +15973,18 @@
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
         },
+        "http-errors": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
         "iconv-lite": {
           "version": "0.4.24",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -16781,6 +16822,23 @@
         "statuses": "~1.5.0"
       },
       "dependencies": {
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
         "mime": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev": "./develop.sh"
   },
   "dependencies": {
+    "@awaitjs/express": "^0.6.3",
     "argparse": "^1.0.10",
     "auspice": "2.25.1",
     "aws-sdk": "^2.520.0",
@@ -35,6 +36,7 @@
     "express-session": "^1.16.2",
     "express-static-gzip": "^0.2.2",
     "heroku-ssl-redirect": "0.0.4",
+    "http-errors": "^1.8.0",
     "ioredis": "^4.14.1",
     "iso-639-1": "^2.1.0",
     "jose": "npm:jose-node-cjs-runtime@^3.11.3",

--- a/redirects.js
+++ b/redirects.js
@@ -30,8 +30,8 @@ const setup = (app) => {
    * Currently only used for nCoV narratives and requires the
    * language code to be the second to last part of the url.
    */
-  app.route("/narratives/ncov/sit-rep/*")
-    .get(async (req, res, next) => {
+  app.routeAsync("/narratives/ncov/sit-rep/*")
+    .getAsync(async (req, res, next) => {
       const {source, prefixParts} = helpers.splitPrefixIntoParts(req.url);
       const availableNarratives = await source.availableNarratives();
       const availableLanguages = new Set(availableNarratives

--- a/server.js
+++ b/server.js
@@ -10,6 +10,8 @@ const argparse = require('argparse');
 const utils = require("./src/utils");
 const auspicePaths = require('./auspicePaths');
 const cors = require('cors');
+const {addAsync} = require("@awaitjs/express");
+const {NotFound} = require('http-errors');
 
 const production = process.env.NODE_ENV === "production";
 
@@ -51,7 +53,7 @@ const auspiceAssetPath = (...subpath) =>
 
 /* BASIC APP SETUP */
 // NOTE: order of app.get is first come first serve (https://stackoverflow.com/questions/32603818/order-of-router-precedence-in-express-js)
-const app = express();
+const app = addAsync(express());
 
 // In production, trust Heroku as a reverse proxy and Express will use request
 // metadata from the proxy.
@@ -85,21 +87,21 @@ app.route("/dist/*")
 
 /* Charon API used by Auspice.
  */
-app.route("/charon/getAvailable")
+app.routeAsync("/charon/getAvailable")
   .all(cors({origin: 'http://localhost:8000'})) // allow cross-origin from the gatsby dev server
-  .get(auspiceServerHandlers.getAvailable);
+  .getAsync(auspiceServerHandlers.getAvailable);
 
-app.route("/charon/getDataset")
-  .get(auspiceServerHandlers.getDataset);
+app.routeAsync("/charon/getDataset")
+  .getAsync(auspiceServerHandlers.getDataset);
 
-app.route("/charon/getNarrative")
-  .get(auspiceServerHandlers.getNarrative);
+app.routeAsync("/charon/getNarrative")
+  .getAsync(auspiceServerHandlers.getNarrative);
 
-app.route("/charon/getSourceInfo")
-  .get(auspiceServerHandlers.getSourceInfo);
+app.routeAsync("/charon/getSourceInfo")
+  .getAsync(auspiceServerHandlers.getSourceInfo);
 
-app.route("/charon/*")
-  .all((req, res) => res.status(404).end());
+app.routeAsync("/charon/*")
+  .all(() => { throw new NotFound(); });
 
 app.route(auspicePaths).get((req, res) => {
   utils.verbose(`Sending Auspice entrypoint for ${req.originalUrl}`);

--- a/src/exceptions.js
+++ b/src/exceptions.js
@@ -7,12 +7,6 @@ class NextstrainError extends Error {
   }
 }
 
-class ResourceNotFoundError extends NextstrainError {
-  constructor(msg = "The requested URLs do not exist", ...rest) {
-    super(msg, ...rest);
-  }
-}
-
 /* Thrown when a valid Source object is asked to create a new Dataset object
  * without a dataset path.
  */
@@ -34,6 +28,5 @@ class InvalidSourceImplementation extends NextstrainError {
 
 module.exports = {
   InvalidSourceImplementation,
-  ResourceNotFoundError,
   NoDatasetPathError
 };

--- a/src/getAvailable.js
+++ b/src/getAvailable.js
@@ -1,7 +1,6 @@
 const utils = require("./utils");
 const queryString = require("query-string");
 const {splitPrefixIntoParts, joinPartsIntoPrefix, unauthorized} = require("./getDatasetHelpers");
-const {ResourceNotFoundError} = require("./exceptions");
 
 /* handler for /charon/getAvailable requests */
 const getAvailable = async (req, res) => {
@@ -15,22 +14,13 @@ const getAvailable = async (req, res) => {
     return unauthorized(req, res);
   }
 
-  let datasets;
-  let narratives;
+  const datasets = await source.availableDatasets() || [];
+  const narratives = await source.availableNarratives() || [];
 
-  try {
-    datasets = await source.availableDatasets() || [];
-    narratives = await source.availableNarratives() || [];
-  } catch (err) {
-    if (err instanceof ResourceNotFoundError) {
-      return res.status(404).send("The requested URL does not exist.");
-    }
-  }
-
-  if (!datasets || !datasets.length) {
+  if (!datasets.length) {
     utils.verbose(`No datasets available for ${source.name}`);
   }
-  if (!narratives || !narratives.length) {
+  if (!narratives.length) {
     utils.verbose(`No narratives available for ${source.name}`);
   }
 

--- a/src/getDatasetHelpers.js
+++ b/src/getDatasetHelpers.js
@@ -1,3 +1,5 @@
+const {NotFound} = require("http-errors");
+
 const utils = require("./utils");
 const sources = require("./sources");
 
@@ -56,6 +58,8 @@ const splitPrefixIntoParts = (prefix) => {
   }
 
   const Source = sources.get(sourceName);
+  if (!Source) throw new NotFound();
+
   let source;
 
   switch (sourceName) {

--- a/src/getSourceInfo.js
+++ b/src/getSourceInfo.js
@@ -2,7 +2,6 @@ const queryString = require("query-string");
 const assert = require('assert').strict;
 
 const helpers = require("./getDatasetHelpers");
-const {ResourceNotFoundError} = require("./exceptions");
 
 /**
  * Prototype implementation.
@@ -15,24 +14,14 @@ const getSourceInfo = async (req, res) => {
     return res.status(400).send("No prefix defined");
   }
 
-  let sourceInfo;
-  try {
-    const {source} = helpers.splitPrefixIntoParts(query.prefix);
+  const {source} = helpers.splitPrefixIntoParts(query.prefix);
 
-    // Authorization
-    if (!source.visibleToUser(req.user)) {
-      return helpers.unauthorized(req, res);
-    }
-
-    sourceInfo = await source.getInfo();
-  } catch (err) {
-    if (err instanceof ResourceNotFoundError) {
-      return res.status(404).send("The requested URL does not exist");
-    }
-
-    return helpers.handle500Error(res, 'Error processing source info', err.message);
+  // Authorization
+  if (!source.visibleToUser(req.user)) {
+    return helpers.unauthorized(req, res);
   }
-  return res.json(sourceInfo);
+
+  return res.json(await source.getInfo());
 };
 
 

--- a/src/sources.js
+++ b/src/sources.js
@@ -4,7 +4,8 @@ const zlib = require("zlib");
 const yamlFront = require("yaml-front-matter");
 const {fetch} = require("./fetch");
 const queryString = require("query-string");
-const {ResourceNotFoundError, NoDatasetPathError, InvalidSourceImplementation} = require("./exceptions");
+const {NotFound} = require('http-errors');
+const {NoDatasetPathError, InvalidSourceImplementation} = require("./exceptions");
 const utils = require("./utils");
 
 const S3 = new AWS.S3();
@@ -140,7 +141,7 @@ class CoreSource extends Source {
     const qs = queryString.stringify({ref: this.branch});
     const response = await fetch(`https://api.github.com/repos/${this.repo}/contents?${qs}`);
 
-    if (response.status === 404) throw new ResourceNotFoundError();
+    if (response.status === 404) throw new NotFound();
     else if (response.status !== 200 && response.status !== 304) {
       utils.warn(`Error fetching available narratives from GitHub for source ${this.name}`, await utils.responseDetails(response));
       return [];
@@ -211,7 +212,7 @@ class CommunitySource extends Source {
     const qs = queryString.stringify({ref: this.branch});
     const response = await fetch(`https://api.github.com/repos/${this.repo}/contents/auspice?${qs}`);
 
-    if (response.status === 404) throw new ResourceNotFoundError();
+    if (response.status === 404) throw new NotFound();
     else if (response.status !== 200 && response.status !== 304) {
       utils.warn(`Error fetching available datasets from GitHub for source ${this.name}`, await utils.responseDetails(response));
       return [];


### PR DESCRIPTION
Switches to async-friendly Express routers. Async-friendly routers eliminate the need for most of our own try/catch blocks around internal awaits, as they automatically catch exceptions and send an appropriate error response.  This also lets us start throwing exceptions for HTTP error codes instead passing around the Express response object.

Few immediate functional changes, but this enables future simplifications as we touch other code paths. As an example, the 404 handling is now much simpler.

Reviewing https://github.com/nextstrain/nextstrain.org/pull/317 made me recall that on a local work-in-progress branch I had a similar fix for the 500 error on unknown sources that included these broader error-handling changes. I've rebased them off of that WIP, which was focused on entirely different changes, and onto the current `master` branch for this PR.
