### PR TITLE
use react context for userDataWrapper;

### DIFF
--- a/static-site/src/components/nav-bar/index.jsx
+++ b/static-site/src/components/nav-bar/index.jsx
@@ -3,7 +3,7 @@ import {Link} from 'gatsby';
 import styled, {css} from 'styled-components';
 import { startsWith } from "lodash";
 import nextstrainLogo from "../../../static/logos/nextstrain-logo-small.png";
-
+import { UserContext } from "../../layouts/userDataWrapper";
 
 const NavContainer = styled.div`
   display: flex;
@@ -82,6 +82,8 @@ const NavLinkInactive = styled.div`
 `;
 
 class NavBar extends React.Component {
+  static contextType = UserContext;
+
   selectedClass(name) {
     if (!this.props.location || !this.props.location.pathname) return "";
     return startsWith(this.props.location.pathname, `/${name}`); // can't run this.props.location.pathname.startsWith(`/${name}`) on IE
@@ -129,10 +131,10 @@ class NavBar extends React.Component {
               <NavLinkInactive minified={minified}>BLOG</NavLinkInactive> :
               <NavLinkToBeHandledByGatsby minified={minified} to="/blog">BLOG</NavLinkToBeHandledByGatsby>
         }
-        {this.props.user ? (
+        {this.context.user ? (
           <NavLinkToGoToServer minified={minified} href="/whoami">
             <span role="img" aria-labelledby="userIcon">👤</span>
-            {` ${this.props.user.username}`}
+            {` ${this.context.user.username}`}
           </NavLinkToGoToServer>
         ) :
           <NavLinkToGoToServer minified={minified} href="/login">LOGIN</NavLinkToGoToServer>

--- a/static-site/src/components/splash/index.jsx
+++ b/static-site/src/components/splash/index.jsx
@@ -11,12 +11,15 @@ import * as Styles from "./styles";
 import { SmallSpacer, BigSpacer, HugeSpacer, FlexCenter } from "../../layouts/generalComponents";
 import Footer from "../Footer";
 import UserGroups from "./userGroups";
+import { UserContext } from "../../layouts/userDataWrapper";
 
 class Splash extends React.Component {
   constructor() {
     super();
     configureAnchors({ offset: -10 });
   }
+
+  static contextType = UserContext;
 
   render() {
     return (
@@ -51,7 +54,7 @@ class Splash extends React.Component {
         </FlexCenter>
 
         <HugeSpacer/>
-        {this.props.user && <UserGroups user={this.props.user} visibleGroups={this.props.visibleGroups} />}
+        {this.context.user && <UserGroups user={this.context.user} visibleGroups={this.context.visibleGroups} />}
 
         <ScrollableAnchor id={'ncov'}>
           <Styles.H1>SARS-CoV-2 (COVID-19)</Styles.H1>

--- a/static-site/src/components/splash/userGroups.jsx
+++ b/static-site/src/components/splash/userGroups.jsx
@@ -1,14 +1,17 @@
-import React, { Fragment } from "react";
+import React, { Fragment, useContext } from "react";
 import ScrollableAnchor from "react-scrollable-anchor";
 import * as Styles from "./styles";
 import Cards from "../Cards";
 import { HugeSpacer, FlexCenter } from "../../layouts/generalComponents";
 import { theme } from "../../layouts/theme";
+import { UserContext } from "../../layouts/userDataWrapper";
 
-const UserGroups = (props) => {
+const UserGroups = () => {
   const colors = [...theme.titleColors];
 
-  const groupCards = props.visibleGroups.map((group) => {
+  const userContext = useContext(UserContext);
+
+  const groupCards = userContext.visibleGroups.map((group) => {
     const groupColor = colors[0];
     colors.push(colors.shift());
 
@@ -33,7 +36,7 @@ const UserGroups = (props) => {
         <Styles.CenteredFocusParagraph>
           Nextstrain groups represent collections of datasets, potentially with controlled access.
           You (
-          <Styles.StrongerText>{props.user.username}</Styles.StrongerText>
+          <Styles.StrongerText>{userContext.user.username}</Styles.StrongerText>
           ) have access to the following groups (a padlock icon indicates a private group):
         </Styles.CenteredFocusParagraph>
       </FlexCenter>

--- a/static-site/src/layouts/generic-page.jsx
+++ b/static-site/src/layouts/generic-page.jsx
@@ -15,12 +15,12 @@ const GenericPage = ({location, children}) => (
       <main>
         <UserDataWrapper>
           <NavBar location={location} />
+          <splashStyles.Container className="container">
+            <HugeSpacer /><HugeSpacer />
+            {children}
+            <Footer />
+          </splashStyles.Container>
         </UserDataWrapper>
-        <splashStyles.Container className="container">
-          <HugeSpacer /><HugeSpacer />
-          {children}
-          <Footer />
-        </splashStyles.Container>
       </main>
     </div>
   </MainLayout>

--- a/static-site/src/layouts/userDataWrapper.jsx
+++ b/static-site/src/layouts/userDataWrapper.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+export const UserContext = React.createContext();
+
 export default class UserDataWrapper extends React.Component {
   state = {
     user: undefined,
@@ -18,14 +20,9 @@ export default class UserDataWrapper extends React.Component {
   }
 
   render() {
-    const { children } = this.props;
-    const childElements = React.Children.map(children, child =>
-      // Passes the user state as a prop to all children elements via the prop `user`
-      child && React.cloneElement(child, {
-        user: this.state.user,
-        visibleGroups: this.state.visibleGroups,
-      })
-    );
-    return <div>{ childElements }</div>;
+    return (
+      <UserContext.Provider value={this.state}>
+        {this.props.children}
+      </UserContext.Provider>);
   }
 }

--- a/static-site/src/sections/users.jsx
+++ b/static-site/src/sections/users.jsx
@@ -1,12 +1,12 @@
-import React, {Fragment} from "react";
+import React, {Fragment, useContext} from "react";
 import styled from "styled-components";
-import UserDataWrapper from "../layouts/userDataWrapper";
+import UserDataWrapper, { UserContext } from "../layouts/userDataWrapper";
 import NavBar from '../components/nav-bar';
 import { Logos } from "../components/logos";
 import MainLayout from "../components/layout";
 
-const UserPage = (props) => {
-  const { user, visibleGroups } = props;
+const UserPage = () => {
+  const { user, visibleGroups } = useContext(UserContext);
 
   const LoggedIn = () => (
     <Fragment>


### PR DESCRIPTION
Instead of requiring that children components be nested directly
beneath the userDataWrapper component in order to use its state
(by cloning all children of the wrapper and passing props to each),
this uses react's Context (https://reactjs.org/docs/context.html)
to allow children at any nesting level within userDataWrapper to
access its state.

Needs testing. Useful for #316 and #314 