### PR TITLE
Reduce verbose server logging

### DIFF
--- a/src/getDataset.js
+++ b/src/getDataset.js
@@ -122,7 +122,6 @@ const getDataset = async (req, res) => {
   let datasetInfo;
   try {
     datasetInfo = helpers.parsePrefix(query.prefix, query);
-    utils.verbose("Dataset: ", datasetInfo);
   } catch (err) {
     /* Return a 204 No Content when Auspice makes a dataset request to a
      * valid source root without a dataset path.


### PR DESCRIPTION
This object takes c. 16 lines of the logs each time and was
cluttering up logging with no obvious benefits. If has benefits
for development purposes, and a better long term solution
would be different levels of verbosity.
