### PR TITLE
Request headers-only to check dataset existence

### DIFF
--- a/auspicePaths.js
+++ b/auspicePaths.js
@@ -113,16 +113,15 @@ const isRequestBackedByAuspiceDataset = async (req, res, next) => {
 /**
  * Does the main dataset file exist?
  * There is no attempt here to examine the validity or completeness of such a file.
- * Note: as we don't care about the file contents, there should be a
- * way to avoid fetching the data here and thus speed up this function.
  * @returns {bool}
  */
 async function datasetExists(dataset) {
+  const options = {method: 'HEAD'}; // only fetch headers to speed up
   try {
-    if ((await fetch(dataset.urlFor("main"))).status===200) {
+    if ((await fetch(dataset.urlFor("main"), options)).status===200) {
       return true;
     }
-    if ((await fetch(dataset.urlFor("meta"))).status===200) {
+    if ((await fetch(dataset.urlFor("meta"), options)).status===200) {
       return true;
     }
   } catch (err) {


### PR DESCRIPTION
This change produces a reproducible increase in speed when testing
locally using the /zika dataset of c. 120ms vs 150ms (HEAD vs GET
methods). For datasets which don't exist (e.g. /zika/no), as expected
there is little change (both methods take c. 280-300ms; longer times
are expected as we make a second request for the v1 dataset).
Larger datasets should experience a larger speed improvement here.

Cacheing of status codes would be another avenue to pursue to improve
speed for this middleware, but that carries its own downsides.
