### PR TITLE
Allow server to work without AWS credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6164,13 +6164,13 @@
       }
     },
     "aws-sdk": {
-      "version": "2.520.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.520.0.tgz",
-      "integrity": "sha512-I0BnCLyoqJ17bW48LYMpBcyhSpMW+c+H0GPnFoB7T8Xi2uype3sNV+4qzmHMVhVYv+2Xba9CMenyiH6qeYSwvQ==",
+      "version": "2.908.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.908.0.tgz",
+      "integrity": "sha512-+UtrKOlwjFhGRRrtf3zl5iwFcAnvuh9m63gBnFj9aA+scbP4K2qOukJxPqXCBDeFPqLGH+ojmMJE/54oSlOfmQ==",
       "requires": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
-        "ieee754": "1.1.8",
+        "ieee754": "1.1.13",
         "jmespath": "0.15.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
@@ -6179,15 +6179,20 @@
         "xml2js": "0.4.19"
       },
       "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
         "events": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
           "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-        },
-        "ieee754": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
         },
         "punycode": {
           "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@awaitjs/express": "^0.6.3",
     "argparse": "^1.0.10",
     "auspice": "2.25.1",
-    "aws-sdk": "^2.520.0",
+    "aws-sdk": "^2.908.0",
     "chalk": "^2.4.1",
     "compression": "^1.7.3",
     "connect-redis": "^4.0.3",

--- a/src/sources.js
+++ b/src/sources.js
@@ -368,6 +368,7 @@ class S3Source extends Source {
       let contents = [];
       S3.listObjectsV2({Bucket: this.bucket}).eachPage((err, data, done) => {
         if (err) {
+          utils.warn(`Could not list S3 objects for group '${this.name}'\n${err.message}`);
           return reject(err);
         }
         if (data===null) { // no more data


### PR DESCRIPTION
Accessing datasets and narratives in public & private groups relies
on using the AWS-SDK to access objects in the underlying S3 buckets.
The SDK silently loads credentials, if available [1].

If credentials are _not_ supplied, then access to private groups fail
with a suitable warning printed; however calls into public groups,
backed by publicly accessible buckets, simply hung (AWS method
`S3.listObjectsV2`) until the request timed out (`ETIMEDOUT`).
We now check to see if credentials are supplied, and if they are not,
skip the calls into S3 and log a warning instead.

If credentials were supplied, but they were invalid, then a fatal
`InvalidAccessKeyId` error was thrown. We now catch this and print a
warning.

In both cases the Source class method (`_listObjects`) will return an
empty array, allowing our charon API to return valid responses.

[1] https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
