### PR TITLE
Improve charon API handlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
 script:
   - npm run build
   - npm run lint
+  - npm run test:ci
 notifications:
   email:
     on_success: never

--- a/server.js
+++ b/server.js
@@ -101,7 +101,10 @@ app.routeAsync("/charon/getSourceInfo")
   .getAsync(auspiceServerHandlers.getSourceInfo);
 
 app.routeAsync("/charon/*")
-  .all(() => { throw new NotFound(); });
+  .all((req) => {
+    utils.warn(`(${req.method}) ${req.url} has not been handled / has no handler`);
+    throw new NotFound();
+  });
 
 app.route(auspicePaths).get((req, res) => {
   utils.verbose(`Sending Auspice entrypoint for ${req.originalUrl}`);

--- a/src/getDatasetHelpers.js
+++ b/src/getDatasetHelpers.js
@@ -3,11 +3,6 @@ const {NotFound} = require("http-errors");
 const utils = require("./utils");
 const sources = require("./sources");
 
-const handle500Error = (res, clientMsg, serverMsg="") => {
-  utils.warn(`${clientMsg} -- ${serverMsg}`);
-  return res.status(500).type("text/plain").send(clientMsg);
-};
-
 const unauthorized = (req, res) => {
   const user = req.user
     ? `user ${req.user.username}`
@@ -192,7 +187,6 @@ const canonicalizePrefix = (prefix) =>
 module.exports = {
   splitPrefixIntoParts,
   joinPartsIntoPrefix,
-  handle500Error,
   unauthorized,
   parsePrefix,
   canonicalizePrefix,

--- a/src/sources.js
+++ b/src/sources.js
@@ -157,6 +157,14 @@ class CoreSource extends Source {
         .split("_")
         .join("/"));
   }
+
+  async getInfo() {
+    return {
+      title: `Nextstrain ${this.name} datasets & narratives`,
+      showDatasets: true,
+      showNarratives: true,
+    };
+  }
 }
 
 class CoreStagingSource extends CoreSource {

--- a/test/smoke-test/auspice_client_requests.json
+++ b/test/smoke-test/auspice_client_requests.json
@@ -121,6 +121,7 @@
   },
   {
     "name": "Fetch (core) narrative",
+    "__comment": "This fetch will fetch data from a GitHub repo (where our core narratives live)",
     "url": "/charon/getNarrative?prefix=/narratives/ncov/sit-rep/2020-05-15&type=md",
     "expectStatusCode": 200,
     "responseIsJson": false
@@ -141,9 +142,9 @@
     "expectStatusCode": 404
   },
   {
-    "name": "Fetch from a group which doesn't exist",
+    "name": "Get Source Info for a group which doesn't exist",
     "url": "/charon/getSourceInfo?prefix=/groups/doesntexist",
-    "expectStatusCode": 500
+    "expectStatusCode": 404
   },
   {
     "name": "Getting Source Info for the core nextstrain source",

--- a/test/smoke-test/auspice_client_requests.json
+++ b/test/smoke-test/auspice_client_requests.json
@@ -144,5 +144,23 @@
     "name": "Fetch from a group which doesn't exist",
     "url": "/charon/getSourceInfo?prefix=/groups/doesntexist",
     "expectStatusCode": 500
+  },
+  {
+    "name": "Getting Source Info for the core nextstrain source",
+    "__comment": "Used by the (customized) auspice splash page to list datasets",
+    "url": "/charon/getSourceInfo?prefix=/zika",
+    "expectStatusCode": 200,
+    "responseIsJson": true
+  },
+  {
+    "name": "Getting Source Info for the staging nextstrain source",
+    "url": "/charon/getSourceInfo?prefix=/staging",
+    "expectStatusCode": 200,
+    "responseIsJson": true
+  },
+  {
+    "name": "Unknown charon address should 404",
+    "url": "/charon/unknown",
+    "expectStatusCode": 404
   }
 ]


### PR DESCRIPTION
When running this server daa8ff64348920f8a804728808a8a6de1503a2d6 both live (nextstrain.org) and locally, I was experiencing hard-to-reproduce errors when viewing community splash pages (e.g. /community/jameshadfield/scratch). This is related to the recently deployed #320, however it only occurred when the server requested data from GitHub. Hitting GitHub's API limits during testing didn't help either.

Investigating this led to a grab-bag of server improvements - see commit messages for more. 

One big improvement is the integration of smoke-testing in our CI runs, which ~may have~ would have identified this before deployment.