### PR TITLE
ErrorBanner component

### DIFF
--- a/static-site/src/components/splash/errorMessages.jsx
+++ b/static-site/src/components/splash/errorMessages.jsx
@@ -1,29 +1,29 @@
 import React from 'react';
-import { FlexCenter } from "../../layouts/generalComponents";
+import styled from 'styled-components';
 import * as splashStyles from "./styles";
 
+const FixedBanner = styled.div`
+  left: 0px;
+  width: 100%;
+  height: 10%;
+  background-color: #c2c1be;
+  font-size: 18px;
+  padding: 5% 5%;
+  margin: 25px 0px;
+  text-align: center;
+`;
+
 const PleaseEmailUsIfYouBelieveThisToBeAnError = () => (
-  <p>Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a> if you believe this to be an error.</p>
+  <>Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a> if you believe this to be an error.</>
 );
 
-export const BannerIfGroupsDatasetNotFound = ({missingDatasetName, groupName}) => (
-  <>{missingDatasetName &&
-    <FlexCenter>
-      <splashStyles.CenteredFocusParagraph>
-        {`The dataset "nextstrain.org/groups/${groupName}/${missingDatasetName}" doesn't exist.
-          Here is the groups page for the "${groupName}" group.`}
-        <PleaseEmailUsIfYouBelieveThisToBeAnError/>
-      </splashStyles.CenteredFocusParagraph>
-    </FlexCenter>}
-  </>
-);
-
-export const GroupNotFound = ({groupName}) => (
-  <FlexCenter>
-    <splashStyles.CenteredFocusParagraph>
-      {`The Nextstrain Group "${groupName}" doesn't exist yet, or there was an error getting data for that group. `}
-      For available Nextstrain Groups, check out the <a href="/groups">Groups page</a>.
-      <PleaseEmailUsIfYouBelieveThisToBeAnError/>
-    </splashStyles.CenteredFocusParagraph>
-  </FlexCenter>
+export const ErrorBanner = ({title, contents}) => (
+  <FixedBanner>
+    <splashStyles.StrongerText>
+      {title}
+    </splashStyles.StrongerText>
+    <br/>
+    <PleaseEmailUsIfYouBelieveThisToBeAnError/>
+    <p>{contents}</p>
+  </FixedBanner>
 );

--- a/static-site/src/layouts/generic-page.jsx
+++ b/static-site/src/layouts/generic-page.jsx
@@ -8,13 +8,14 @@ import { HugeSpacer } from "../layouts/generalComponents";
 import * as splashStyles from "../components/splash/styles";
 import Footer from "../components/Footer";
 
-const GenericPage = ({location, children}) => (
+const GenericPage = ({location, children, banner}) => (
   <MainLayout>
     <div className="index-container">
       <Helmet title={config.siteTitle} />
       <main>
         <UserDataWrapper>
           <NavBar location={location} />
+          {banner}
           <splashStyles.Container className="container">
             <HugeSpacer /><HugeSpacer />
             {children}


### PR DESCRIPTION
creates a generally applicable
ErrorBanner component to be passed
as the `banner` prop to GenericPage.
ErrorBanner takes `title` and `contents`
props.

Current examples can be seen on the
individual-group-page.jsx page, e.g.
/groups/not-a-group
/groups/not-a-group/not-a-dataset
/groups/blab/not-a-dataset