### PR TITLE
parse /groups/:groupName markdown;

### DIFF
--- a/static-site/package-lock.json
+++ b/static-site/package-lock.json
@@ -4690,7 +4690,8 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "optional": true
         },
         "slice-ansi": {
           "version": "3.0.0",
@@ -10121,6 +10122,59 @@
         "unist-util-visit": "^1.4.1"
       },
       "dependencies": {
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          },
+          "dependencies": {
+            "domhandler": {
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+              "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+              "requires": {
+                "domelementtype": "^2.2.0"
+              }
+            }
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        },
+        "domhandler": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        },
+        "domutils": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
+          "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          },
+          "dependencies": {
+            "domhandler": {
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+              "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+              "requires": {
+                "domelementtype": "^2.2.0"
+              }
+            }
+          }
+        },
         "hast-to-hyperscript": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-5.0.0.tgz",
@@ -10182,6 +10236,17 @@
             "hast-util-parse-selector": "^2.2.0",
             "property-information": "^4.0.0",
             "space-separated-tokens": "^1.0.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0",
+            "domutils": "^2.0.0",
+            "entities": "^2.0.0"
           }
         },
         "is-plain-obj": {
@@ -10290,6 +10355,17 @@
             "stringify-entities": "^1.0.1",
             "unherit": "^1.0.4",
             "xtend": "^4.0.1"
+          }
+        },
+        "sanitize-html": {
+          "version": "1.27.5",
+          "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.27.5.tgz",
+          "integrity": "sha512-M4M5iXDAUEcZKLXkmk90zSYWEtk5NH3JmojQxKxV371fnMh+x9t1rqdmXaGoyEHw3z/X/8vnFhKjGL5xFGOJ3A==",
+          "requires": {
+            "htmlparser2": "^4.1.0",
+            "lodash": "^4.17.15",
+            "parse-srcset": "^1.0.2",
+            "postcss": "^7.0.27"
           }
         },
         "stringify-entities": {
@@ -11990,12 +12066,14 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "optional": true
         },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "optional": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -12036,6 +12114,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -12043,7 +12122,8 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "optional": true
         },
         "emoji-regex": {
           "version": "8.0.0",
@@ -12060,7 +12140,8 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "optional": true
         },
         "mimic-fn": {
           "version": "2.1.0",
@@ -12113,6 +12194,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -13322,6 +13404,11 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
     },
+    "klona": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
+      "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
+    },
     "known-css-properties": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.2.0.tgz",
@@ -13614,11 +13701,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
-    "lodash.escaperegexp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
-    },
     "lodash.every": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.every/-/lodash.every-4.6.0.tgz",
@@ -13644,16 +13726,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
@@ -13673,11 +13745,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -13941,6 +14008,11 @@
       "requires": {
         "repeat-string": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.7.tgz",
+      "integrity": "sha512-BJXxkuIfJchcXOJWTT2DOL+yFWifFv2yGYOUzvXg8Qz610QKw+sHCvTMYwA+qWGhlA2uivBezChZ/pBy1tWdkQ=="
     },
     "math-random": {
       "version": "1.0.4",
@@ -14602,6 +14674,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
       "optional": true
+    },
+    "nanoid": {
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -15488,6 +15565,11 @@
         "is-ssh": "^1.3.0",
         "protocols": "^1.4.0"
       }
+    },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
     },
     "parse-url": {
       "version": "5.0.1",
@@ -19629,54 +19711,86 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sanitize-html": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.23.0.tgz",
-      "integrity": "sha512-7MgUrbZpaig6zHwuHjpNqhkiuutFPWWoFY/RmdtEnvrFKMLafzSHfFyOozVpKWytkZIUhbYu3VQ/93OmYdo3ag==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.4.0.tgz",
+      "integrity": "sha512-Y1OgkUiTPMqwZNRLPERSEi39iOebn2XJLbeiGOBhaJD/yLqtLGu6GE5w7evx177LeGgSE+4p4e107LMiydOf6A==",
       "requires": {
-        "chalk": "^2.4.1",
-        "htmlparser2": "^4.1.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.mergewith": "^4.6.2",
-        "postcss": "^7.0.27",
-        "srcset": "^2.0.1",
-        "xtend": "^4.0.1"
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "klona": "^2.0.3",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.0.2"
       },
       "dependencies": {
+        "colorette": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+        },
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
         "domelementtype": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
         },
         "domhandler": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
-          "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+          "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
           "requires": {
-            "domelementtype": "^2.0.1"
+            "domelementtype": "^2.2.0"
           }
         },
         "domutils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.0.0.tgz",
-          "integrity": "sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
+          "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
           "requires": {
-            "dom-serializer": "^0.2.1",
-            "domelementtype": "^2.0.1",
-            "domhandler": "^3.0.0"
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
           }
         },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
         "htmlparser2": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
-          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
           "requires": {
             "domelementtype": "^2.0.1",
-            "domhandler": "^3.0.0",
-            "domutils": "^2.0.0",
+            "domhandler": "^4.0.0",
+            "domutils": "^2.5.2",
             "entities": "^2.0.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        },
+        "postcss": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.0.tgz",
+          "integrity": "sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==",
+          "requires": {
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
           }
         }
       }
@@ -19711,6 +19825,7 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
       "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+      "optional": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -20477,6 +20592,11 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
+    },
     "source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -20713,11 +20833,6 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
-    },
-    "srcset": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/srcset/-/srcset-2.0.1.tgz",
-      "integrity": "sha512-00kZI87TdRKwt+P8jj8UZxbfp7mK2ufxcIMWvhAOZNJTRROimpHeruWrGvCZneiuVDLqdyHefVp748ECTnyUBQ=="
     },
     "sshpk": {
       "version": "1.16.1",

--- a/static-site/package.json
+++ b/static-site/package.json
@@ -57,6 +57,7 @@
     "lodash": "^4.17.15",
     "lodash-webpack-plugin": "^0.11.4",
     "mapbox-gl": "1.13.0",
+    "marked": "^2.0.7",
     "prismjs": "^1.18.0",
     "prop-types": "^15.6.0",
     "react": "^16.12.0",
@@ -73,6 +74,7 @@
     "react-tweet-embed": "^1.1.0",
     "react-twitter-widgets": "^1.4.0",
     "react-virtualized-select": "^3.1.3",
+    "sanitize-html": "^2.4.0",
     "save": "^2.3.2",
     "styled-components": "^2.4.1",
     "whatwg-fetch": "^3.0.0"

--- a/static-site/src/components/splash/groupHeading.jsx
+++ b/static-site/src/components/splash/groupHeading.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from 'styled-components';
 import { StyledLink } from "../Datasets/list-datasets";
 import { FlexCenter } from "../../layouts/generalComponents";
+import MarkdownDisplay from "./markdownDisplay";
 
 const OverviewContainer = styled.div`
   text-align: justify;
@@ -13,6 +14,19 @@ const OverviewContainer = styled.div`
   line-height: 1.42857143;
   margin: 0px auto 0px auto;
   max-width: 900px;
+  table, th {
+    border-style: none;
+    border-collapse: separate;
+    padding: 0;
+  }
+  td {
+    border-style: none;
+    width: 200px;
+    padding: 0;
+  }
+  a, p {
+    font-size: 94%;
+  }
 `;
 
 function Title({avatarSrc, children}) {
@@ -69,7 +83,7 @@ export default function GroupHeading({sourceInfo}) {
       {sourceInfo.overview &&
         <FlexCenter>
           <OverviewContainer>
-            {sourceInfo.overview}
+            <MarkdownDisplay mdstring={sourceInfo.overview}/>
           </OverviewContainer>
         </FlexCenter>
       }

--- a/static-site/src/components/splash/markdownDisplay.jsx
+++ b/static-site/src/components/splash/markdownDisplay.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { parseMarkdown } from "../../util/parseMarkdown";
+
+export default function MarkdownDisplay({ mdstring, ...props }) {
+  let cleanDescription;
+  try {
+    cleanDescription = parseMarkdown(mdstring);
+  } catch (error) {
+    console.error(`Error parsing footer description: ${error}`);
+    cleanDescription = '<p>There was an error parsing the footer description.</p>';
+  }
+  return (
+    <div
+      {...props}
+      dangerouslySetInnerHTML={{ __html: cleanDescription }} // eslint-disable-line react/no-danger
+    />
+  );
+}

--- a/static-site/src/components/splash/markdownDisplay.jsx
+++ b/static-site/src/components/splash/markdownDisplay.jsx
@@ -6,8 +6,8 @@ export default function MarkdownDisplay({ mdstring, ...props }) {
   try {
     cleanDescription = parseMarkdown(mdstring);
   } catch (error) {
-    console.error(`Error parsing footer description: ${error}`);
-    cleanDescription = '<p>There was an error parsing the footer description.</p>';
+    console.error(`Error parsing markdown: ${error}`);
+    cleanDescription = '<p>There was an error parsing markdown content.</p>';
   }
   return (
     <div

--- a/static-site/src/util/parseMarkdown.js
+++ b/static-site/src/util/parseMarkdown.js
@@ -47,11 +47,17 @@ export const parseMarkdown = (mdString) => {
   const sanitizerConfig = {
     allowedTags,
     allowedAttributes: {"*": allowedAttributes},
-    // These two config settings come from https://github.com/cure53/DOMPurify
-    // and it's not clear how to set them in https://github.com/apostrophecms/sanitize-html
-    // which we are using here.
-    // KEEP_CONTENT: false,
-    // ALLOW_DATA_ATTR: false
+    nonTextTags: ['style', 'script', 'textarea', 'option'],
+    transformTags: {
+      'a': function(tagName, attribs) { // eslint-disable-line
+        const url = new URL(attribs.href); // URL is not supported on Internet Explorer
+        if (url.hostname !== location.hostname) {
+          attribs.target = '_blank';
+          attribs.rel = 'noreferrer nofollow';
+        }
+        return {tagName, attribs};
+      }
+    }
   };
   const rawDescription = marked(mdString);
   const cleanDescription = sanitizeHtml(rawDescription, sanitizerConfig);

--- a/static-site/src/util/parseMarkdown.js
+++ b/static-site/src/util/parseMarkdown.js
@@ -1,0 +1,59 @@
+import marked from "marked";
+import sanitizeHtml from 'sanitize-html';
+
+// All of these tags may not be necessary, this list was adopted from https://github.com/nextstrain/auspice/blob/master/src/util/parseMarkdown.js
+const allowedTags = ['div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'em', 'strong', 'del', 'ol', 'ul', 'li', 'a', 'img'];
+allowedTags.push('#text', 'code', 'pre', 'hr', 'table', 'thead', 'tbody', 'th', 'tr', 'td', 'sub', 'sup');
+// We want to support SVG elements, requiring the following tags (we exclude "foreignObject", "style" and "script")
+allowedTags.push("svg", "altGlyph", "altGlyphDef", "altGlyphItem", "animate", "animateColor", "animateMotion", "animateTransform");
+allowedTags.push("circle", "clipPath", "color-profile", "cursor", "defs", "desc", "ellipse", "feBlend", "feColorMatrix", "feComponentTransfer");
+allowedTags.push("feComposite", "feConvolveMatrix", "feDiffuseLighting", "feDisplacementMap", "feDistantLight", "feFlood", "feFuncA");
+allowedTags.push("feFuncB", "feFuncG", "feFuncR", "feGaussianBlur", "feImage", "feMerge", "feMergeNode", "feMorphology", "feOffset");
+allowedTags.push("fePointLight", "feSpecularLighting", "feSpotLight", "feTile", "feTurbulence", "filter", "font", "font-face");
+allowedTags.push("font-face-format", "font-face-name", "font-face-src", "font-face-uri", "g", "glyph", "glyphRef");
+allowedTags.push("hkern", "image", "line", "linearGradient", "marker", "mask", "metadata", "missing-glyph", "mpath", "path");
+allowedTags.push("pattern", "polygon", "polyline", "radialGradient", "rect", "set", "stop", "switch", "symbol");
+allowedTags.push("text", "textPath", "title", "tref", "tspan", "use", "view", "vkern");
+
+const allowedAttributes = ['href', 'src', 'width', 'height', 'alt'];
+// We add the following Attributes for SVG via https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute
+// Certain values have been excluded here, e.g. "style"
+allowedAttributes.push("accent-height", "accumulate", "additive", "alignment-baseline", "allowReorder", "alphabetic", "amplitude", "arabic-form", "ascent", "attributeName", "attributeType", "autoReverse", "azimuth");
+allowedAttributes.push("baseFrequency", "baseline-shift", "baseProfile", "bbox", "begin", "bias", "by");
+allowedAttributes.push("calcMode", "cap-height", "class", "clip", "clipPathUnits", "clip-path", "clip-rule", "color", "color-interpolation", "color-interpolation-filters", "color-profile", "color-rendering", "cursor", "cx", "cy");
+allowedAttributes.push("d", "decelerate", "descent", "diffuseConstant", "direction", "display", "divisor", "dominant-baseline", "dur", "dx", "dy");
+allowedAttributes.push("edgeMode", "elevation", "enable-background", "end", "exponent", "externalResourcesRequired");
+allowedAttributes.push("fill", "fill-opacity", "fill-rule", "filter", "filterRes", "filterUnits", "flood-color", "flood-opacity", "font-family", "font-size", "font-size-adjust", "font-stretch", "font-style", "font-variant", "font-weight", "format", "from", "fr", "fx", "fy");
+allowedAttributes.push("g1", "g2", "glyph-name", "glyph-orientation-horizontal", "glyph-orientation-vertical", "glyphRef", "gradientTransform", "gradientUnits");
+allowedAttributes.push("hanging", "height", "href", "hreflang", "horiz-adv-x", "horiz-origin-x");
+allowedAttributes.push("id", "ideographic", "image-rendering", "in", "in2", "intercept");
+allowedAttributes.push("k", "k1", "k2", "k3", "k4", "kernelMatrix", "kernelUnitLength", "kerning", "keyPoints", "keySplines", "keyTimes");
+allowedAttributes.push("lang", "lengthAdjust", "letter-spacing", "lighting-color", "limitingConeAngle", "local");
+allowedAttributes.push("marker-end", "marker-mid", "marker-start", "markerHeight", "markerUnits", "markerWidth", "mask", "maskContentUnits", "maskUnits", "mathematical", "max", "media", "method", "min", "mode");
+allowedAttributes.push("name", "numOctaves");
+allowedAttributes.push("offset", "opacity", "operator", "order", "orient", "orientation", "origin", "overflow", "overline-position", "overline-thickness");
+allowedAttributes.push("panose-1", "paint-order", "path", "pathLength", "patternContentUnits", "patternTransform", "patternUnits", "ping", "pointer-events", "points", "pointsAtX", "pointsAtY", "pointsAtZ", "preserveAlpha", "preserveAspectRatio", "primitiveUnits");
+allowedAttributes.push("r", "radius", "referrerPolicy", "refX", "refY", "rel", "rendering-intent", "repeatCount", "repeatDur", "requiredExtensions", "requiredFeatures", "restart", "result", "rotate", "rx", "ry");
+allowedAttributes.push("scale", "seed", "shape-rendering", "slope", "spacing", "specularConstant", "specularExponent", "speed", "spreadMethod", "startOffset", "stdDeviation", "stemh", "stemv", "stitchTiles", "stop-color", "stop-opacity", "strikethrough-position", "strikethrough-thickness", "string", "stroke", "stroke-dasharray", "stroke-dashoffset", "stroke-linecap", "stroke-linejoin", "stroke-miterlimit", "stroke-opacity", "stroke-width", "surfaceScale", "systemLanguage");
+allowedAttributes.push("tabindex", "tableValues", "target", "targetX", "targetY", "text-anchor", "text-decoration", "text-rendering", "textLength", "to", "transform", "type");
+allowedAttributes.push("u1", "u2", "underline-position", "underline-thickness", "unicode", "unicode-bidi", "unicode-range", "units-per-em");
+allowedAttributes.push("v-alphabetic", "v-hanging", "v-ideographic", "v-mathematical", "values", "vector-effect", "version", "vert-adv-y", "vert-origin-x", "vert-origin-y", "viewBox", "viewTarget", "visibility");
+allowedAttributes.push("width", "widths", "word-spacing", "writing-mode");
+allowedAttributes.push("x", "x-height", "x1", "x2", "xChannelSelector");
+allowedAttributes.push("y", "y1", "y2", "yChannelSelector");
+allowedAttributes.push("z", "zoomAndPan");
+
+export const parseMarkdown = (mdString) => {
+  const sanitizerConfig = {
+    allowedTags,
+    allowedAttributes: {"*": allowedAttributes},
+    // These two config settings come from https://github.com/cure53/DOMPurify
+    // and it's not clear how to set them in https://github.com/apostrophecms/sanitize-html
+    // which we are using here.
+    // KEEP_CONTENT: false,
+    // ALLOW_DATA_ATTR: false
+  };
+  const rawDescription = marked(mdString);
+  const cleanDescription = sanitizeHtml(rawDescription, sanitizerConfig);
+  return cleanDescription;
+};


### PR DESCRIPTION
Copies auspice approach:
https://github.com/nextstrain/auspice/blob/master/src/util/parseMarkdown.js
but uses "sanitize-html" library:
https://github.com/apostrophecms/sanitize-html

A couple of config options from the auspice approach
didn't seem to have analogous options in the library I
use here. Also I don't add a hook to set the <a> tags
to open links in a new tab as is done in auspice. There's
probably a way to set this with the "sanitize-html" library
but it wasn't obvious to me and it wasn't working anyway
on nextstrain.org groups pages (which was using the auspice
code to parse markdown until recently for groups pages).

