### PR TITLE
Redirect core (GISAID) nCoV URLs

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -24,6 +24,18 @@ const setup = (app) => {
     res.redirect(`/groups${req.originalUrl}`);
   });
 
+  /** prior to June 2021 our core nCoV builds were available at
+   * /ncov/global, ncov/asia etc. These used GISAID data exclusively.
+   * We now have GISAID builds and GenBank builds, and so the URLs
+   * (i.e. names on s3://nextstrain-data) have changed. We add redirects
+   * for the old URLs to point to the new GISAID URLs.
+   * The timestamped URLs (e.g. /ncov/:region/YYYY-MM-DD) which currently exist
+   * will not be redirected, but new URLs will be of the format
+   * /ncov/gisaid/:region/YYYY-MM-DD.
+   */
+  app.route('/ncov/:region((global|asia|oceania|north-america|south-america|europe|africa))')
+    .get((req, res) => res.redirect(`/ncov/gisaid/${req.params.region}`));
+
   /*
    * Redirect to translations of narratives if the client has
    * set language preference and the translation is available


### PR DESCRIPTION
Currently all core nCoV builds have used GISAID data, and have been
available at URLS /ncov/global, ncov/asia, etc. The nextstrain/ncov
PR #628 [1] updates our workflow to produce builds for both GISAID and
GenBank data sources, which will result in URLs /ncov/gisaid/:region and
/ncov/genbank/:region, respectively.

Links such as /ncov/:region are heavily used and are assumed to mean
"the latest analysis for :region using GISAID data". This commit
adds redirects so that /ncov/:region now goes to /ncov/gisaid/:region.

Note that this commit should only be merged after [1] has been merged
and a build successfully completed, which will produce the files
s3://nextstrain-data/ncov_{:region}.json.

[1] https://github.com/nextstrain/ncov/pull/628
