### PR TITLE
Fix bug serving narratives for groups

### DIFF
--- a/auspicePaths.js
+++ b/auspicePaths.js
@@ -77,7 +77,7 @@ const isRequestBackedByAuspiceDataset = async (req, res, next) => {
     const pathParts = req.path.replace(/^\//, '').replace(/\/$/, '').split("/");
     if (
       pathParts[0]==="status" ||
-      pathParts[0]==="narratives" ||
+      pathParts.includes("narratives") ||
       pathParts[0]==="community" || // note that /community itself is redirected earlier
       pathParts[0]==="fetch"
     ) {


### PR DESCRIPTION
The intention of the code modified in this commit was to pass
all URLs which represent narratives to Auspice, as the ability
to determine narrative existence is not yet incorporated by
`isRequestBackedByAuspiceDataset` (which may need to be renamed!).
