### PR TITLE
use GET request in datasetExists;

### DIFF
--- a/auspicePaths.js
+++ b/auspicePaths.js
@@ -114,12 +114,11 @@ const isRequestBackedByAuspiceDataset = async (req, res, next) => {
  * @returns {bool}
  */
 async function datasetExists(dataset) {
-  const options = {method: 'HEAD'}; // only fetch headers to speed up
   try {
-    if ((await fetch(dataset.urlFor("main"), options)).status===200) {
+    if ((await fetch(dataset.urlFor("main"))).status===200) {
       return true;
     }
-    if ((await fetch(dataset.urlFor("meta"), options)).status===200) {
+    if ((await fetch(dataset.urlFor("meta"))).status===200) {
       return true;
     }
   } catch (err) {


### PR DESCRIPTION
this is a temporary fix to allow
existence checking of private group
datasets which previously was failing
due to signed s3 requests not working
with the HEAD action (which was being
used to improve performance of this
existence check request). It is a temporary
fix in place of something that allows
making a HEAD or analogous request for
private group datasets.

See https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1624921294208400?thread_ts=1624913762.204500&cid=C01LCTT7JNN

