### PR TITLE
Dataset.urlFor(): add `method` parameter

### DIFF
--- a/auspicePaths.js
+++ b/auspicePaths.js
@@ -116,10 +116,10 @@ const isRequestBackedByAuspiceDataset = async (req, res, next) => {
 async function datasetExists(dataset) {
   const options = {method: 'HEAD'}; // only fetch headers to speed up
   try {
-    if ((await fetch(dataset.urlFor("main"), options)).status===200) {
+    if ((await fetch(dataset.urlFor("main", options.method), options)).status===200) {
       return true;
     }
-    if ((await fetch(dataset.urlFor("meta"), options)).status===200) {
+    if ((await fetch(dataset.urlFor("meta", options.method), options)).status===200) {
       return true;
     }
   } catch (err) {

--- a/src/sources.js
+++ b/src/sources.js
@@ -91,7 +91,7 @@ class Dataset {
       ? `${baseName}.json`
       : `${baseName}_${type}.json`;
   }
-  urlFor(type) {
+  urlFor(type, method = 'GET') { // eslint-disable-line no-unused-vars
     const url = new URL(this.baseNameFor(type), this.source.baseUrl);
     return url.toString();
   }
@@ -498,8 +498,8 @@ class PrivateS3Source extends S3Source {
 }
 
 class PrivateS3Dataset extends Dataset {
-  urlFor(type) {
-    return S3.getSignedUrl("getObject", {
+  urlFor(type, method = 'GET') {
+    return S3.getSignedUrl(method === "HEAD" ? "headObject" : "getObject", {
       Bucket: this.source.bucket,
       Key: this.baseNameFor(type)
     });


### PR DESCRIPTION
This new parameter is only relevant for the method in the child class
`PrivateS3Dataset` which needs to know which operation to pass
to `S3.getSignedUrl()`.
