### PR TITLE
remove matchPath for /pathogens and /staging;

### DIFF
--- a/static-site/gatsby-node.js
+++ b/static-site/gatsby-node.js
@@ -225,13 +225,11 @@ exports.createPages = ({graphql, actions}) => {
 
         createPage({
           path: "/staging",
-          matchPath: "/staging/*",
           component: path.resolve("src/sections/staging.jsx")
         });
 
         createPage({
           path: "/pathogens",
-          matchPath: "/pathogens/*",
           component: path.resolve("src/sections/pathogens.jsx")
         });
 

--- a/static-site/src/sections/pathogens.jsx
+++ b/static-site/src/sections/pathogens.jsx
@@ -79,7 +79,6 @@ class Index extends React.Component {
           <DatasetSelect
             datasets={this.state.data}
             columns={tableColumns}
-            urlDefinedFilterPath={this.props["*"]}
           />
         )}
         {this.state.errorFetchingData && (

--- a/static-site/src/sections/staging.jsx
+++ b/static-site/src/sections/staging.jsx
@@ -73,7 +73,6 @@ class Index extends React.Component {
             title="Filter Data "
             datasets={this.state.data}
             columns={tableColumns}
-            urlDefinedFilterPath={this.props["*"]}
           />
         )}
         {this.state.errorFetchingData && (


### PR DESCRIPTION
we were attempting to prefilter
listings on these pages according
to the * in e.g. /pathogens/* but
this was causing issues with linking
to auspice datasets from these pages.
This is not a high priority feature
and was not advertised yet so this
removes it (for now) to make sure
linking to auspice datasets from these
pages functions correctly.