### PR TITLE
Relative URLs on individual groups pages

### DIFF
--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -24,7 +24,7 @@ class Index extends React.Component {
     return list.map((d) => {
       return {
         filename: d.request.replace(`groups/${groupName}/`, '').replace('narratives/', ''),
-        url: `https://nextstrain.org/${d.request}`,
+        url: `/${d.request}`,
         contributor: groupName
       };
     });


### PR DESCRIPTION
This helps with development, as clicking on the dataset/narrative
will use the current (dev) server, rather than nextstrain.org
