### PR TITLE
Available staging data reflect bucket contents

### DIFF
--- a/src/setAvailableDatasets.js
+++ b/src/setAvailableDatasets.js
@@ -119,40 +119,24 @@ const convertManifestJsonToAvailableDatasetList = (old) => {
  * SIDE EFFECT: sets global.availableDatasets
  */
 const setAvailableDatasetsFromManifest = async () => {
-  utils.verbose("Fetching manifests for core & staging");
+  utils.verbose("Fetching manifests for core datasets");
 
-  const servers = {
-    core: "data",
-    staging: "staging"
-  };
+  fetch(`https://data.nextstrain.org/manifest_guest.json`)
+    .then((result) => {
+      return result.json();
+    })
+    .then((data) => {
+      const {datasets, secondTreeOptions, defaults} = convertManifestJsonToAvailableDatasetList(data);
+      global.availableDatasets.core = datasets;
+      global.availableDatasets.secondTreeOptions.core = secondTreeOptions;
+      global.availableDatasets.defaults.core = defaults;
 
-  const promises = Object.keys(servers).map((server) => {
-    return fetch(`http://${servers[server]}.nextstrain.org/manifest_guest.json`)
-      .then((result) => {
-        return result.json();
-      })
-      .then((data) => {
-        const {datasets, secondTreeOptions, defaults} = convertManifestJsonToAvailableDatasetList(data);
-        utils.verbose(`Successfully got manifest for "${server}"`);
-
-        global.availableDatasets[server] = datasets;
-        global.availableDatasets.secondTreeOptions[server] = secondTreeOptions;
-        global.availableDatasets.defaults[server] = defaults;
-      })
-      .catch((e) => {
-        console.error(e);
-        utils.warn(`Failed to getch manifest for "${server}"`);
-      });
-  });
-
-  Promise.all(promises)
-    .then(() => {
-      utils.log(`Got manifests for ${Object.keys(global.availableDatasets).join(", ")}`);
+      utils.log(`Successfully got manifest for core datasets`);
     })
     .catch((e) => {
       console.error(e);
+      utils.warn(`Failed to fetch manifest for core datasets`);
     });
-
 };
 
 setAvailableDatasetsFromManifest();


### PR DESCRIPTION
This moves away from a hardcoded list of staging datasets (via the
manifest on s3://nextstrain-staging), which was out-of-date and
rarely updated. We now crawl the bucket so that all available datasets
are reported.

This introduces a significant speed penalty and the performance of the
server may not scale if many requests are made to list bucket contents.
Subsequent work should add a caching layer to `availableDatasets()`, or
similar.

The second tree options are now empty, which is an improvement on the
previous version which reported the options for the core (not staging)
source. This has the effect that the "Second Tree" dropdown is empty
when viewing staging datasets in Auspice.
