### PR TITLE
Improve markdown parsing of URLs

### DIFF
--- a/static-site/src/util/parseMarkdown.js
+++ b/static-site/src/util/parseMarkdown.js
@@ -50,8 +50,15 @@ export const parseMarkdown = (mdString) => {
     nonTextTags: ['style', 'script', 'textarea', 'option'],
     transformTags: {
       'a': function(tagName, attribs) { // eslint-disable-line
-        const url = new URL(attribs.href); // URL is not supported on Internet Explorer
-        if (url.hostname !== location.hostname) {
+        try {
+          const url = new URL(attribs.href); // URL is not supported on Internet Explorer
+          if (url.hostname !== location.hostname) {
+            attribs.target = '_blank';
+            attribs.rel = 'noreferrer nofollow';
+          }
+        } catch (err) {
+          // some valid-looking (and commonly used) URLs will cause `new URL` to
+          // throw a TypeError
           attribs.target = '_blank';
           attribs.rel = 'noreferrer nofollow';
         }


### PR DESCRIPTION
Valid-looking URLs which we expect to be commonly used in markdown
(and, indeed, are being used in at least two group overviews) can
result in `new URL()` throwing a `TypeError`. Instead of failing
to parse the markdown, we instead allow the URLs but add the
suitable tags to the `<a>` element.

Closes https://github.com/nextstrain/nextstrain.org/issues/361

