### PR TITLE
Fix URL parsing of tanglterees

### DIFF
--- a/auspicePaths.js
+++ b/auspicePaths.js
@@ -96,7 +96,8 @@ const isRequestBackedByAuspiceDataset = async (req, res, next) => {
     }
 
     /* Extract dataset information & check if it exists, storing the result as `req.sendToAuspice` */
-    const { dataset } = parsePrefix(req.path);
+    /* (If a tangletree URL is requested, we only consider the first dataset here) */
+    const { dataset } = parsePrefix(req.path.split(":")[0]);
     if (await datasetExists(dataset)) {
       req.sendToAuspice = true;
     }


### PR DESCRIPTION
The recent code which checked for dataset existence (in order to route to Auspice or Gatsby) failed to take into account tangletree URL syntax, resulting in the inability to load any tangletrees from a URL. Here we implement a simple fix by only considering the first dataset of a tangle-tree-like URL. Note that Auspice will display a 404-like page if either of the datasets in a tangle-tree URL don't exist, so the solution implemented here is les-than-ideal.
