### PR TITLE
collect staging datasets instead of use manifest;

### DIFF
--- a/.github/workflows/update-dataset-listings.yml
+++ b/.github/workflows/update-dataset-listings.yml
@@ -2,9 +2,9 @@ name: 'update nextstrain.org dataset listing resources on s3'
 
 on:
   schedule:
-    # once every 5 minutes
+    # once every hour
     # * is a special character in YAML so you have to quote this string
-    - cron:  '*/5 * * * *'
+    - cron:  '0 * * * *'
 
 jobs:
   update-search:
@@ -21,8 +21,9 @@ jobs:
         python3 -m pip install nextstrain-cli
         PATH="$HOME/.local/bin:$PATH"
         ./scripts/collect-datasets.js --keyword flu
+        nextstrain remote upload s3://nextstrain-data data/datasets_influenza.json
         ./scripts/collect-datasets.js --keyword staging
-        nextstrain remote upload s3://nextstrain-data data/datasets_influenza.json data/datasets_staging.json
+        nextstrain remote upload s3://nextstrain-staging data/datasets_staging.json
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/update-flu-catalogue.yml
+++ b/.github/workflows/update-flu-catalogue.yml
@@ -1,4 +1,4 @@
-name: 'update nextstrain.org/influenza with latest flu datasets in s3'
+name: 'update nextstrain.org dataset listing resources on s3'
 
 on:
   schedule:
@@ -14,14 +14,15 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 14
-    - name: update flu catalogue
+    - name: update dataset listings # currently just /staging and /influenza use these
       run: |
         npm ci
         python3 -m pip install --upgrade pip setuptools
         python3 -m pip install nextstrain-cli
         PATH="$HOME/.local/bin:$PATH"
-        ./scripts/collect-datasets.js --pathogen flu
-        nextstrain remote upload s3://nextstrain-data data/datasets_influenza.json
+        ./scripts/collect-datasets.js --keyword flu
+        ./scripts/collect-datasets.js --keyword staging
+        nextstrain remote upload s3://nextstrain-data data/datasets_influenza.json data/datasets_staging.json
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/scripts/collect-datasets.js
+++ b/scripts/collect-datasets.js
@@ -124,14 +124,17 @@ function filenameLooksLikeDataset(filename) {
   if (filename.endsWith("_meta.json") || filename.endsWith("_tree.json")) return false;
   if (filename.endsWith("_frequencies.json")) return false;
   if (filename.endsWith("_titers.json")) return false;
-  if (filename.endsWith("_frequencies.json")) return false;
   if (filename.endsWith("_tip-frequencies.json")) return false;
   if (filename.endsWith("_aa-mutation-frequencies.json")) return false;
   if (filename.endsWith("_sequences.json")) return false;
   if (filename.endsWith("_entropy.json")) return false;
   if (filename.endsWith("_root-sequence.json")) return false;
-  if (filename.includes("/")) return false;
   if (filename.includes("manifest")) return false;
   if (filename === ("datasets_staging.json")) return false;
+  // The line below is due to the fact that
+  // S3 objects (files) in folders cannot be accessed by Auspice
+  // so we ingore them here as we collect datasets which will
+  // be turned into Auspice URLs.
+  if (filename.includes("/")) return false;
   return true;
 }

--- a/static-site/src/sections/staging.jsx
+++ b/static-site/src/sections/staging.jsx
@@ -6,7 +6,7 @@ import {
 } from "../layouts/generalComponents";
 import * as splashStyles from "../components/splash/styles";
 import DatasetSelect from "../components/Datasets/dataset-select";
-import { getDatasetsAndNarratives } from "./pathogens";
+import { fetchAndParseJSON } from "../util/datasetsHelpers";
 import GenericPage from "../layouts/generic-page";
 
 const nextstrainLogoPNG = require("../../static/logos/favicon.png");
@@ -22,12 +22,8 @@ const abstract = (
 const tableColumns = [
   {
     name: "Name",
-    value: (dataset) => dataset.name,
+    value: (dataset) => dataset.filename.replace(/_/g, ' / ').replace('.json', ''),
     url: (dataset) => dataset.url
-  },
-  {
-    name: "Type",
-    value: (dataset) => dataset.type
   },
   {
     name: "Contributor",
@@ -35,6 +31,10 @@ const tableColumns = [
     valueMobile: () => "",
     url: () => "https://nextstrain.org",
     logo: () => (<img alt="nextstrain.org" className="logo" width="24px" src={nextstrainLogoPNG}/>)
+  },
+  {
+    name: "Uploaded Date",
+    value: (dataset) => dataset.date_uploaded
   }
 ];
 
@@ -47,7 +47,7 @@ class Index extends React.Component {
 
   async componentDidMount() {
     try {
-      const data = await getDatasetsAndNarratives("/charon/getAvailable?prefix=/staging");
+      const data = await fetchAndParseJSON("https://staging.nextstrain.org/datasets_staging.json");
       this.setState({data});
     } catch (err) {
       console.error("Error fetching / parsing data.", err.message);

--- a/static-site/src/sections/staging.jsx
+++ b/static-site/src/sections/staging.jsx
@@ -16,6 +16,9 @@ const abstract = (
   <>
     This page details Nextstrain-managed datasets and narratives available on our staging server.
     <strong> These datasets should be considered unreleased and/or out of date; they should not be used to draw scientific conclusions</strong>.
+    Note that this listing is refreshed about once per hour.
+    Narratives are not (yet) listed on this page;
+    &quot;Staging narratives&quot; can be found <a target="_blank" rel="noopener noreferrer nofollow" href="https://github.com/nextstrain/narratives/tree/staging" >on GitHub</a>.
   </>
 );
 


### PR DESCRIPTION
Currently the /staging page uses a /charon request
to source its dataset listing via the manifest. Here we
change to doing the following instead:
- Collect staging datasets with scripts/collect-datasets.js
  script and publish this list to s3 in a github action
- On /staging we request this listing from s3 to show a more
  frequently updated listing than with the manifest

This strategy is a comprimise between existing attempts:
(1)  using the manifest via a /charon request (current)
(2) crawling the s3 bucket via a /charon request (see https://github.com/nextstrain/nextstrain.org/pull/362)

in that it crawls the s3 bucket but on a regular interval
instead of with each request. Requests are made to a static
listing which is regenerated every 5 minutes (at no cost to the
nextstrain.org server). This should allow us to have caching
benefits that would be more complex to implement in (2) but
improves the freshness/accuracy of the listing compared to (1).

Some notes:
- currently the page is requesting the listing from https://staging.nextstrain.org/datasets_staging.json
  for testing purposes but we'll probably want this on
  data.nextstrain.org for production.
- we aren't getting narratives from the staging bucket.
  There aren't many there but we could do this if desired.
- I tacked the running of the collection script onto an existing
  GH action but there could be benefits to not coupling these udpates.
- I haven't implemented or configured any caching.
  There are many levels at which this can happen, and I'm
  not sure the degree we need for this case.