### PR TITLE
preserve query params in gisaid builds redirects

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -1,3 +1,4 @@
+const url = require('url');
 const helpers = require("./src/getDatasetHelpers");
 const { parseNarrativeLanguage } = require("./src/utils");
 
@@ -34,7 +35,12 @@ const setup = (app) => {
    * /ncov/gisaid/:region/YYYY-MM-DD.
    */
   app.route('/ncov/:region((global|asia|oceania|north-america|south-america|europe|africa))')
-    .get((req, res) => res.redirect(`/ncov/gisaid/${req.params.region}`));
+    .get((req, res) => res.redirect(
+      url.format({
+        pathname: `/ncov/gisaid/${req.params.region}`,
+        query: req.query
+      })
+    ));
 
   /*
    * Redirect to translations of narratives if the client has


### PR DESCRIPTION
Fixes a bug introduced by #350 where we lose query params when redirecting from e.g. https://nextstrain.org/ncov/africa?f_region=Africa and get https://nextstrain.org/ncov/gisaid/africa without the region filter query param.

Needs more testing and review as I'm not an expert in express.js. Also we redirect many other URLs, so might be worth having a look at doing something similar where appropriate among other existing redirects for nextstrain.org.