### PR TITLE
fix community splash pages;

### DIFF
--- a/auspicePaths.js
+++ b/auspicePaths.js
@@ -77,6 +77,7 @@ const isRequestBackedByAuspiceDataset = async (req, res, next) => {
     const pathParts = req.path.replace(/^\//, '').replace(/\/$/, '').split("/");
     if (
       pathParts[0]==="status" ||
+      pathParts[0]==="community" ||
       pathParts.includes("narratives") ||
       pathParts[0]==="fetch"
     ) {

--- a/static-site/src/sections/community-page.jsx
+++ b/static-site/src/sections/community-page.jsx
@@ -43,8 +43,8 @@ class Index extends React.Component {
 
   banner() {
     if (this.state.nonExistentDatasetName && (this.state.nonExistentDatasetName.length > 0)) {
-      const bannerTitle = `The dataset "nextstrain.org${this.props.location.pathname}" doesn't exist.`;
-      const bannerContents = `Here is the staging page instead.`;
+      const bannerTitle = `The community repository or dataset "nextstrain.org${this.props.location.pathname}" doesn't exist.`;
+      const bannerContents = `Here is the community page instead.`;
       return <ErrorBanner title={bannerTitle} contents={bannerContents}/>;
     }
     return null;


### PR DESCRIPTION
#368 implemented error behavior for various
pages including /community/*. In the case of
/community/* pages, this broke the ability to
visit a list of available datasets at a url like
/community/:user/:repo where user and
repo are valid [1].

Since we don't yet have /community/:user/:repo
splash pages in gatsby to list datasets, this
reverts to sending those to auspice to list datasets
for now.

A final note that when we do implement such pages,
they should be the ones to catch errors about invalid
user, repo, or dataset names, as opposed to the
top-level /community splash page. This is how we do
it for /groups as well.

[1] https://github.com/nextstrain/auspice/issues/1378