### PR TITLE
Add coreCards back to /pathogens;

### DIFF
--- a/static-site/src/components/Cards/fluCards.js
+++ b/static-site/src/components/Cards/fluCards.js
@@ -1,0 +1,44 @@
+const fluCards = [
+  {
+    img: "seasonalinfluenza.png",
+    url: "/flu/seasonal/h3n2/ha/2y",
+    title: "A/H3N2"
+  },
+  {
+    img: "seasonalinfluenza.png",
+    url: "/flu/seasonal/h1n1pdm/ha/2y",
+    title: "A/H1N1pdm"
+  },
+  {
+    img: "seasonalinfluenza.png",
+    url: "/flu/seasonal/vic/ha/2y",
+    title: "B/Vic"
+  },
+  {
+    img: "seasonalinfluenza.png",
+    url: "/flu/seasonal/yam/ha/2y",
+    title: "B/Yam"
+  },
+  {
+    img: "avianinfluenza.png",
+    url: "/flu/avian/h5n1/ha",
+    title: "A/H5N1 (Avian)"
+  },
+  {
+    img: "avianinfluenza.png",
+    url: "/flu/avian/h5nx/ha",
+    title: "A/H5NX (Avian)"
+  },
+  {
+    img: "avianinfluenza.png",
+    url: "/flu/avian/h7n9/ha",
+    title: "A/H7N9 (Avian)"
+  },
+  {
+    img: "avianinfluenza.png",
+    url: "/flu/avian/h9n2/ha",
+    title: "A/H9N2 (Avian)"
+  }
+];
+
+export default fluCards;

--- a/static-site/src/components/Cards/pathogenCards.js
+++ b/static-site/src/components/Cards/pathogenCards.js
@@ -1,5 +1,10 @@
 const pathogenCards = [
   {
+    img: "seasonalinfluenza.png",
+    url: "/influenza",
+    title: "Influenza"
+  },
+  {
     img: "ncov.png",
     url: "/sars-cov-2",
     title: "SARS-CoV-2"

--- a/static-site/src/components/Cards/pathogenCards.js
+++ b/static-site/src/components/Cards/pathogenCards.js
@@ -1,0 +1,49 @@
+const pathogenCards = [
+  {
+    img: "ncov.png",
+    url: "/sars-cov-2",
+    title: "SARS-CoV-2"
+  },
+  {
+    img: "wnv.jpg",
+    url: "/WNV",
+    title: "West Nile virus"
+  },
+  {
+    img: "mumps.jpg",
+    url: "/mumps",
+    title: "Mumps"
+  },
+  {
+    img: "zika.png",
+    url: "/zika",
+    title: "Zika"
+  },
+  {
+    img: "ebola.png",
+    url: "/ebola",
+    title: "West African Ebola 2013-16"
+  },
+  {
+    img: "dengue.png",
+    url: "/dengue",
+    title: "Dengue"
+  },
+  {
+    img: "measles.jpg",
+    url: "/measles",
+    title: "Measles"
+  },
+  {
+    img: "enterovirus.jpg",
+    url: "/enterovirus/d68",
+    title: "Enterovirus D68"
+  },
+  {
+    img: "tb.jpg",
+    url: "/tb/global",
+    title: "Tuberculosis"
+  }
+];
+
+export default pathogenCards;

--- a/static-site/src/components/Datasets/pathogen-page-introduction.jsx
+++ b/static-site/src/components/Datasets/pathogen-page-introduction.jsx
@@ -2,9 +2,10 @@
 import React from "react";
 import {Link} from 'gatsby';
 import styled from "styled-components";
-
 import { goToAnchor } from 'react-scrollable-anchor';
 import { FlexCenter } from "../../layouts/generalComponents";
+
+export const AnchorLink = ({to, title}) => <Clickable onClick={() => goToAnchor(to)}>{title}</Clickable>;
 
 export function PathogenPageIntroduction({data}) {
   return (
@@ -18,7 +19,7 @@ export function PathogenPageIntroduction({data}) {
                 s.type === "gatsby" ?
                   <Link to={s.to}>{s.title}</Link> :
                   s.type === "anchor" ?
-                    <Clickable onClick={() => goToAnchor(s.to)}>{s.title}</Clickable> :
+                    <AnchorLink to={s.to} title={s.title} /> :
                     null
               }
               {s.subtext && (

--- a/static-site/src/sections/influenza-page.jsx
+++ b/static-site/src/sections/influenza-page.jsx
@@ -12,6 +12,8 @@ import DatasetSelect from "../components/Datasets/dataset-select";
 import GenericPage from "../layouts/generic-page";
 import { fetchAndParseJSON } from "../util/datasetsHelpers";
 import { ErrorBanner } from "../components/splash/errorMessages";
+import Cards from "../components/Cards/index";
+import fluCards from "../components/Cards/fluCards";
 
 const nextstrainLogoPNG = require("../../static/logos/favicon.png");
 
@@ -23,23 +25,6 @@ We also maintain datasets for a subset of avian influenza viruses that have caus
 and domestic birds, including novel reassortant H5 viruses.`;
 
 const contents = [
-  {
-    type: "external",
-    to: "/flu/seasonal/h3n2/ha/2y",
-    title: "Latest A/H3N2 analysis",
-    subtext: (
-      <span>
-        Jump to our latest A/H3N2 seasonal influenza dataset which is updated weekly. We also maintain datasets for:
-        <br/><a href="/flu/seasonal/h1n1pdm/ha/2y"> A/H1N1pdm</a>
-        <br/><a href="/flu/seasonal/vic/ha/2y"> B/Vic</a>
-        <br/><a href="/flu/seasonal/yam/ha/2y"> B/Yam</a>
-        <br/><a href="/flu/avian/h5n1/ha"> A/H5N1 (Avian)</a>
-        <br/><a href="/flu/avian/h5nx/ha"> A/H5NX (Avian)</a>
-        <br/><a href="/flu/avian/h7n9/ha"> A/H7N9 (Avian)</a>
-        <br/><a href="/flu/avian/h9n2/ha"> A/H9N2 (Avian)</a>
-      </span>
-    )
-  },
   {
     type: "anchor",
     to: "datasets",
@@ -132,13 +117,16 @@ class Index extends React.Component {
 
         <PathogenPageIntroduction data={contents} />
 
+        <MediumSpacer/>
+        <Cards squashed cards={fluCards}/>
+
         <ScrollableAnchor id={"datasets"}>
           <div>
             <HugeSpacer /><HugeSpacer />
             <splashStyles.H2>
               Influenza datasets
             </splashStyles.H2>
-            <HugeSpacer />
+            <MediumSpacer />
             {this.state.dataLoaded && (
               <DatasetSelect
                 datasets={this.state.datasets}

--- a/static-site/src/sections/pathogens.jsx
+++ b/static-site/src/sections/pathogens.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ScrollableAnchor, { configureAnchors } from "react-scrollable-anchor";
 import {
   SmallSpacer,
   HugeSpacer,
@@ -10,10 +11,11 @@ import { fetchAndParseJSON } from "../util/datasetsHelpers";
 import GenericPage from "../layouts/generic-page";
 import Cards from "../components/Cards/index";
 import pathogenCards from "../components/Cards/pathogenCards";
+import { AnchorLink } from "../components/Datasets/pathogen-page-introduction";
 
 const nextstrainLogoPNG = require("../../static/logos/favicon.png");
 
-const title = "Nextstrain-maintained Data";
+const title = "Nextstrain-maintained pathogen analyses";
 const abstract = (
   <>
     These data represent analyses and situation-reports produced by the core Nextstrain team.
@@ -25,6 +27,8 @@ const abstract = (
     <br/><br/>
     To learn more about nextstrain please see <a href="https://docs.nextstrain.org/en/latest/index.html">our documentation</a> or ask a question
     on the <a href="https://discussion.nextstrain.org/">discussion forum</a>.
+    <br/><br/>
+    <AnchorLink to={"search"} title={"Click here to scroll down to all Nextstrain-maintained pathogen analyses"} />.
   </>
 );
 
@@ -51,6 +55,7 @@ const tableColumns = [
 class Index extends React.Component {
   constructor(props) {
     super(props);
+    configureAnchors({ offset: -10 });
     this.state = {data: undefined, errorFetchingData: false};
   }
 
@@ -80,19 +85,23 @@ class Index extends React.Component {
         <Cards squashed cards={pathogenCards}/>
         <HugeSpacer />
 
-        {this.state.data && (
-          <DatasetSelect
-            datasets={this.state.data}
-            columns={tableColumns}
-          />
-        )}
-        {this.state.errorFetchingData && (
-          <splashStyles.CenteredFocusParagraph>
-            Something went wrong getting data.
-            Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
-            if this continues to happen.
-          </splashStyles.CenteredFocusParagraph>
-        )}
+        <ScrollableAnchor id={"search"}>
+          <div>
+            {this.state.data && (
+              <DatasetSelect
+                datasets={this.state.data}
+                columns={tableColumns}
+              />
+            )}
+            {this.state.errorFetchingData && (
+              <splashStyles.CenteredFocusParagraph>
+                Something went wrong getting data.
+                Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
+                if this continues to happen.
+              </splashStyles.CenteredFocusParagraph>
+            )}
+          </div>
+        </ScrollableAnchor>
       </GenericPage>
     );
   }

--- a/static-site/src/sections/pathogens.jsx
+++ b/static-site/src/sections/pathogens.jsx
@@ -8,6 +8,8 @@ import * as splashStyles from "../components/splash/styles";
 import DatasetSelect from "../components/Datasets/dataset-select";
 import { fetchAndParseJSON } from "../util/datasetsHelpers";
 import GenericPage from "../layouts/generic-page";
+import Cards from "../components/Cards/index";
+import pathogenCards from "../components/Cards/pathogenCards";
 
 const nextstrainLogoPNG = require("../../static/logos/favicon.png");
 
@@ -73,7 +75,10 @@ class Index extends React.Component {
             {abstract}
           </splashStyles.CenteredFocusParagraph>
         </FlexCenter>
-        <HugeSpacer /> <HugeSpacer />
+
+        <HugeSpacer />
+        <Cards squashed cards={pathogenCards}/>
+        <HugeSpacer />
 
         {this.state.data && (
           <DatasetSelect


### PR DESCRIPTION
Perhaps misleading to exclude the two influenza
cards which are on the splash page from this selected
list of pathogens on the /pathogen page? Could imagine
someone clicking "see all pathogens" underneath the
two influenza cards wanting to see a list including those
two influenza cards. My reason for not including them
was the niceness of the 3x3 grid without them.