### PR TITLE
Handle non-existent narratives on our various splash/404 pages

### DIFF
--- a/static-site/gatsby-node.js
+++ b/static-site/gatsby-node.js
@@ -214,6 +214,12 @@ exports.createPages = ({graphql, actions}) => {
           component: path.resolve("src/sections/community-repo-page.jsx")
         });
 
+        createPage({
+          path: "/community/narratives/:userName/:repoName",
+          matchPath: "/community/narratives/:userName/:repoName/*",
+          component: path.resolve("src/sections/community-repo-page.jsx")
+        });
+
         // Create page detailing all things SARS-CoV-2
         createPage({
           path: "/sars-cov-2",

--- a/static-site/src/sections/community-page.jsx
+++ b/static-site/src/sections/community-page.jsx
@@ -38,12 +38,12 @@ class Index extends React.Component {
 
   componentDidMount() {
     // For some reason if this is set in the constructor it breaks the banner.
-    this.setState({nonExistentDatasetName: this.props["*"]});
+    this.setState({nonExistentPath: this.props["*"]});
   }
 
   banner() {
-    if (this.state.nonExistentDatasetName && (this.state.nonExistentDatasetName.length > 0)) {
-      const bannerTitle = `The community repository or dataset "nextstrain.org${this.props.location.pathname}" doesn't exist.`;
+    if (this.state.nonExistentPath && (this.state.nonExistentPath.length > 0)) {
+      const bannerTitle = `The community repository, dataset, or narrative "nextstrain.org${this.props.location.pathname}" doesn't exist.`;
       const bannerContents = `Here is the community page instead.`;
       return <ErrorBanner title={bannerTitle} contents={bannerContents}/>;
     }

--- a/static-site/src/sections/community-repo-page.jsx
+++ b/static-site/src/sections/community-repo-page.jsx
@@ -12,10 +12,10 @@ class Index extends React.Component {
   constructor(props) {
     super(props);
     configureAnchors({ offset: -10 });
-    const nonExistentDatasetName = this.props["*"];
+    const nonExistentPath = this.props["*"];
     this.state = {
       repoNotFound: false,
-      nonExistentDatasetName
+      nonExistentPath
     };
   }
 
@@ -53,11 +53,13 @@ class Index extends React.Component {
   }
 
   banner() {
-    const {userName, repoName} = this.props;
+    const {userName, repoName, location} = this.props;
     let bannerTitle, bannerContents;
-    // Set up a banner if dataset doesn't exist
-    if (this.state.nonExistentDatasetName) {
-      bannerTitle = `The dataset "nextstrain.org/community/${userName}/${repoName}/${this.state.nonExistentDatasetName}" doesn't exist.`;
+    // Set up a banner if dataset or narrative doesn't exist
+    if (this.state.nonExistentPath) {
+      bannerTitle = location.pathname.startsWith("/community/narratives/")
+        ? `The narrative "nextstrain.org/community/narratives/${userName}/${repoName}/${this.state.nonExistentPath}" doesn't exist.`
+        : `The dataset "nextstrain.org/community/${userName}/${repoName}/${this.state.nonExistentPath}" doesn't exist.`;
       bannerContents = `Here is the page for the "${repoName}" repository.`;
     }
     // Set up a banner or update the existing one if the repo doesn't exist

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -12,10 +12,10 @@ class Index extends React.Component {
   constructor(props) {
     super(props);
     configureAnchors({ offset: -10 });
-    const nonExistentDatasetName = this.props["*"];
+    const nonExistentPath = this.props["*"];
     this.state = {
       groupNotFound: false,
-      nonExistentDatasetName
+      nonExistentPath
     };
   }
 
@@ -53,8 +53,10 @@ class Index extends React.Component {
     const groupName = this.props["groupName"];
     let bannerTitle, bannerContents;
     // Set up a banner if dataset doesn't exist
-    if (this.state.nonExistentDatasetName) {
-      bannerTitle = `The dataset "nextstrain.org/groups/${groupName}/${this.state.nonExistentDatasetName}" doesn't exist.`;
+    if (this.state.nonExistentPath) {
+      bannerTitle = this.state.nonExistentPath.startsWith("narratives/")
+        ? `The narrative "nextstrain.org/groups/${groupName}/${this.state.nonExistentPath}" doesn't exist.`
+        : `The dataset "nextstrain.org/groups/${groupName}/${this.state.nonExistentPath}" doesn't exist.`;
       bannerContents = `Here is the page for the "${groupName}" Nextstrain Group.`;
     }
     // Set up a banner or update the existing one if the group doesn't exist

--- a/static-site/src/sections/staging-page.jsx
+++ b/static-site/src/sections/staging-page.jsx
@@ -65,13 +65,15 @@ class Index extends React.Component {
       data,
       errorFetchingData,
       // For some reason if this is set in the constructor it breaks the banner.
-      nonExistentDatasetName: this.props["*"]
+      nonExistentPath: this.props["*"]
     });
   }
 
   banner() {
-    if (this.state.nonExistentDatasetName && (this.state.nonExistentDatasetName.length > 0)) {
-      const bannerTitle = `The dataset "nextstrain.org${this.props.location.pathname}" doesn't exist.`;
+    if (this.state.nonExistentPath && (this.state.nonExistentPath.length > 0)) {
+      const bannerTitle = this.state.nonExistentPath.startsWith("narratives/")
+        ? `The staging narrative "nextstrain.org${this.props.location.pathname}" doesn't exist.`
+        : `The staging dataset "nextstrain.org${this.props.location.pathname}" doesn't exist.`;
       const bannerContents = `Here is the staging page instead.`;
       return <ErrorBanner title={bannerTitle} contents={bannerContents}/>;
     }


### PR DESCRIPTION
These splash pages also serve as 404 pages for matching paths beneath
their respective sections.  Previously the pages assumed the
non-existent path was always for a dataset.
