### PR TITLE
Use node version 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "repository": "github:nextstrain/nextstrain.org",
   "homepage": "https://nextstrain.org",
   "engines": {
-    "node": "13.6.x",
-    "npm": "6.13.x"
+    "node": "^14",
+    "npm": "^6.14"
   },
   "scripts": {
     "build": "./build.sh",


### PR DESCRIPTION
The currently used node version `13` [has already reached end-of-life status](https://github.com/nodejs/Release#end-of-life-releases) and is preventing auspice npm updates from working on nextstrain.org (#437, https://github.com/nextstrain/auspice/commit/bec41d6ad42cbb500da81d2a240af7f349d7db42)

Choice of `14` is mostly due to consistency as it is already used in GitHub actions:

- [update-dataset-listings](https://github.com/nextstrain/nextstrain.org/blob/04acaaffe766274ded930b6cafc55b75df8c1311/.github/workflows/update-dataset-listings.yml#L16)
- [update-search](https://github.com/nextstrain/nextstrain.org/blob/04acaaffe766274ded930b6cafc55b75df8c1311/.github/workflows/update-search.yml#L22)

Also updating npm version to 6.14.x since it corresponds with node=14 per https://nodejs.org/en/download/releases/.

[Syntax reference for `^14`, `^6.14`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#dependencies)