### PR TITLE
Update SARS-CoV-2-Datasets.yaml - Puerto Rico Public Health Laboratory Nextstrain Build

### DIFF
--- a/static-site/content/SARS-CoV-2-Datasets.yaml
+++ b/static-site/content/SARS-CoV-2-Datasets.yaml
@@ -1146,6 +1146,18 @@ datasets:
     org:
       name: CDC/AMD
       url: https://www.cdc.gov/amd/
+      
+  - url: https://nextstrain.org/community/arodzh-sudo/ncov-puertorico
+    name: Puerto Rico
+    geo: puerto_rico
+    region: North America
+    level: country
+    coords:
+      - -66.5901
+      - 18.2208
+    org:
+      name: Puerto Rico Public Health Laboratory
+      url: https://www.salud.gov.pr/
 
   - url: https://nextstrain.org/groups/spheres/ncov/rhode-island
     name: Rhode Island


### PR DESCRIPTION
### Description of proposed changes    
Hello Nextstrain Team,
This a request to add our SARS-CoV-2 dataset. Our goal is to provide a public build and help the local scientific community keep track of the circulating SARS-CoV-2 strains in Puerto Rico. The github repository is [https://github.com/arodzh-sudo/ncov-puertorico](https://github.com/arodzh-sudo/ncov-puertorico).

### Testing
Earlier in the pandemic, sequences from Puerto Rico were uploaded to GISAID as North America / USA / Puerto Rico. Currently, almost every sequence is uploaded as North America / Puerto Rico. For this build, I changed the color_ordering and lat_longs files to reflect this.

If you notice, I added to the code (to also reflect the change):
    region: North America
    level: country

There is one other build focused on Puerto Rico maintained by the CDC/AMD which has:
    level: division

I'm not quite sure if the parentGeo should be changed from usa to north-america or add a new one as this might affect the CDC/AMD build.

Please let me know if there are any suggestions or additional changes we have to make for this build. Thanks!

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
