### PR TITLE
Use node version 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: false
 dist: bionic
 node_js:
-  - "13.6"
+  - "14"
 install:
   - npm ci
 script:

--- a/static-site/package.json
+++ b/static-site/package.json
@@ -11,8 +11,8 @@
   "license": "MIT",
   "main": "n/a",
   "engines": {
-    "node": "13.6.x",
-    "npm": "6.13.x"
+    "node": "^14",
+    "npm": "^6.14"
   },
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
Follow-up to https://github.com/nextstrain/nextstrain.org/pull/438#issuecomment-978515507 with the same reasoning:

> The currently used node version `13` [has already reached end-of-life status](https://github.com/nodejs/Release#end-of-life-releases) ...
> 
> Choice of `14` is mostly due to consistency as it is already used in GitHub actions:
> 
> - [update-dataset-listings](https://github.com/nextstrain/nextstrain.org/blob/04acaaffe766274ded930b6cafc55b75df8c1311/.github/workflows/update-dataset-listings.yml#L16)
> - [update-search](https://github.com/nextstrain/nextstrain.org/blob/04acaaffe766274ded930b6cafc55b75df8c1311/.github/workflows/update-search.yml#L22)
> 
> Also updating npm version to 6.14.x since it corresponds with node=14 per https://nodejs.org/en/download/releases/.