### PR TITLE
charon: Fix duplicated repo name in getAvailable response for /community

### DIFF
--- a/src/sources/community.js
+++ b/src/sources/community.js
@@ -75,7 +75,7 @@ class CommunitySource extends Source {
     const pathnames = utils.getDatasetsFromListOfFilenames(filenames)
       // strip out the repo name from the start of the pathnames
       // as CommunityDataset().baseParts will add this in
-      .map((pathname) => pathname.replace(`${this.repoName}/`, ""));
+      .map((pathname) => this.removeLeadingRepoName(pathname));
     return pathnames;
   }
 
@@ -98,12 +98,26 @@ class CommunitySource extends Source {
       .filter((file) => file.name.endsWith(".md"))
       .filter((file) => file.name.startsWith(this.repoName))
       .map((file) => file.name
-        .replace(this.repoName, "")
-        .replace(/^_/, "")
         .replace(/[.]md$/, "")
         .split("_")
-        .join("/"));
+        .join("/"))
+      .map((path) => this.removeLeadingRepoName(path));
   }
+
+  removeLeadingRepoName(path) {
+    // nested dataset for repo
+    if (path.startsWith(`${this.repoName}/`)) {
+      return path.slice(`${this.repoName}/`.length);
+    }
+
+    // default dataset for repo
+    if (path.startsWith(this.repoName)) {
+      return path.slice(this.repoName.length);
+    }
+
+    return path;
+  }
+
   async getInfo() {
     /* could attempt to fetch a certain file from the repository if we want to implement
     this functionality in the future */


### PR DESCRIPTION
Resolves #121.

The replace in CommunitySource.availableDatasets() that always included
a trailing slash failed to consider "top-level" community datasets (e.g.
repoName.json instead of repoName_datasetName.json).

Although availableNarratives() was doing it right, switch it to using
the same removal function for consistency.

I considered changing the replace pattern to a regexp anchored at the
end with (/|$), but this requires escaping/quoting regexp metachars in
repoName and it turns out there is no handy function to do that.  It'd
be simple in other regexp flavors with interpolation and \Q and \E, but
having to add a quote function plus having to construct the regexp with
string concatenation made for something that seemed less clear than
doing startsWith() + slice() in a method.

