### PR TITLE
Don't check existence of datasets and narratives for /fetch/…

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -190,15 +190,11 @@ app.use(["/fetch/narratives/:authority", "/fetch/:authority"],
 
 app.routeAsync("/fetch/narratives/:authority/*")
   .all(setNarrative(req => req.params[0]))
-
-  // Assume existence; little benefit to checking when we don't have a fallback page.
   .getAsync(getNarrative)
 ;
 
 app.routeAsync("/fetch/:authority/*")
   .all(setDataset(req => req.params[0]))
-
-  // Assume existence; little benefit to checking when we don't have a fallback page.
   .getAsync(getDataset)
 ;
 

--- a/src/sources/fetch.js
+++ b/src/sources/fetch.js
@@ -35,6 +35,16 @@ class UrlDefinedDataset extends Dataset {
   subresource(type) {
     return new UrlDefinedDatasetSubresource(this, type);
   }
+  async exists() {
+    /* Assume existence.  There's little benefit to checking with extra
+     * requests when we don't have a natural fallback page (e.g. the Group page
+     * or Community page) and checking means that AWS S3 signed URLs can't be
+     * used with /fetch since they dictate a single action (i.e. can't work for
+     * both HEAD and GET).
+     *   -trs, 2 Feb 2022
+     */
+    return true;
+  }
 }
 
 class UrlDefinedDatasetSubresource extends DatasetSubresource {
@@ -58,6 +68,16 @@ class UrlDefinedNarrative extends Narrative {
   }
   subresource(type) {
     return new UrlDefinedNarrativeSubresource(this, type);
+  }
+  async exists() {
+    /* Assume existence.  There's little benefit to checking with extra
+     * requests when we don't have a natural fallback page (e.g. the Group page
+     * or Community page) and checking means that AWS S3 signed URLs can't be
+     * used with /fetch since they dictate a single action (i.e. can't work for
+     * both HEAD and GET).
+     *   -trs, 2 Feb 2022
+     */
+    return true;
   }
 }
 

--- a/test/requests.test.js
+++ b/test/requests.test.js
@@ -79,10 +79,12 @@ describe("datasets", () => {
     testPaths([
       { case: "with extension",
         path: "/fetch/github.com/nextstrain/community-test/raw/master/auspice/community-test_zika_tutorial.json",
+        testDoesNotExist: false,
         ...noSidecars },
 
       { case: "without extension",
         path: "/fetch/github.com/nextstrain/community-test/raw/master/auspice/community-test_zika_tutorial",
+        testDoesNotExist: false,
         ...noSidecars },
     ]);
   });
@@ -91,7 +93,7 @@ describe("datasets", () => {
     cases.forEach(testPath);
   }
 
-  function testPath({case: case_, path, rootSequence = true, tipFrequencies = true}) {
+  function testPath({case: case_, path, rootSequence = true, tipFrequencies = true, testDoesNotExist = true}) {
     describe(case_, () => {
       // Auspice
       testIsAuspice(path);
@@ -149,7 +151,9 @@ describe("datasets", () => {
       });
 
       // Non-existent datasets under this path
-      testGatsby404(`${path}/does-not-exist`);
+      if (testDoesNotExist) {
+        testGatsby404(`${path}/does-not-exist`);
+      }
     });
   }
 });
@@ -193,10 +197,13 @@ describe("narratives", () => {
   describe("fetch", () => {
     testPaths([
       { case: "with extension",
-        path: "/fetch/narratives/github.com/nextstrain/community-test/raw/master/narratives/community-test_intro-to-narratives.md" },
-
+        path: "/fetch/narratives/github.com/nextstrain/community-test/raw/master/narratives/community-test_intro-to-narratives.md",
+        testDoesNotExist: false
+      },
       { case: "without extension",
-        path: "/fetch/narratives/github.com/nextstrain/community-test/raw/master/narratives/community-test_intro-to-narratives" },
+        path: "/fetch/narratives/github.com/nextstrain/community-test/raw/master/narratives/community-test_intro-to-narratives",
+        testDoesNotExist: false
+      },
     ]);
   });
 
@@ -204,7 +211,7 @@ describe("narratives", () => {
     cases.forEach(testPath);
   }
 
-  function testPath({case: case_, path}) {
+  function testPath({case: case_, path, testDoesNotExist = true}) {
     describe(case_, () => {
       // Auspice
       testIsAuspice(path);
@@ -228,7 +235,9 @@ describe("narratives", () => {
       });
 
       // Non-existent narratives under this path
-      testGatsby404(`${path}/does-not-exist`);
+      if (testDoesNotExist) {
+        testGatsby404(`${path}/does-not-exist`);
+      }
     });
   }
 });


### PR DESCRIPTION
### Description of proposed changes    
This fixes a key use case of /fetch where AWS S3 signed URLs are given.

These signed URLs dictate the permitted S3 action, and the same URL
can't support both a HEAD (headObject) and GET (getObject) request.
Prior to the merge and deploy of #443 this morning, the /fetch endpoints
by design didn't guard Auspice's entrypoint with a HEAD request for the
dataset to check existence.  This inadvertently changed in "Refactor
endpoints for GETing a dataset/narrative to make room for additional
media types" (86190b7).

Now once again for /fetch we'll always serve up Auspice, which will make
a request to Charon, which may return an error if the upstream request
fails, and an error from Charon will trigger Auspice's error page.
That's unlike everywhere else where we try to avoid Auspice's error
page, but it's ok.

### Related issues(s)
Resolves #461.

### Testing
Tested locally by generating a signed URL against `nextstrain-data` and watching it no longer make the HEAD request and succeed.
