### PR TITLE
sources: Load YAML frontmatter for groups-overview.md safely

### DIFF
--- a/src/sources/s3.js
+++ b/src/sources/s3.js
@@ -54,7 +54,7 @@ class S3Source extends Source {
     return object.Body;
   }
   parseOverviewMarkdown(overviewMarkdown) {
-    const frontMatter = yamlFront.loadFront(overviewMarkdown);
+    const frontMatter = yamlFront.safeLoadFront(overviewMarkdown);
     if (!frontMatter.title) {
       throw new Error("The overview file requires `title` in the frontmatter.");
     }


### PR DESCRIPTION
Prevents deserializing potentially unsafe data types from user input.

yaml-front-matter uses js-yaml 3.x, which is unsafe by default, hence
the "safe" mode.  js-yaml 4.x is safe by default, but not used here.

---

I plan to merge and deploy this as soon as it passes CI.
