### PR TITLE
add: links to africa cdc pgi builds

### DIFF
--- a/static-site/content/SARS-CoV-2-Datasets.yaml
+++ b/static-site/content/SARS-CoV-2-Datasets.yaml
@@ -513,6 +513,37 @@ datasets:
       - 4.070194
     org:
       name: Nextstrain Team
+  
+  - url: https://nextstrain.org/groups/africa-cdc
+    name: Africa CDC
+    geo: africa
+    level: region
+    coords:
+      - 21.824559
+      - 4.070194
+    org:
+      name: Africa CDC
+      url: https://africacdc.org/
+
+#   # Actually maybe linking each of the regions
+#   # example: https://nextstrain.org/groups/africa-cdc/ncov/central-africa
+#     - url: null
+#       name: Central Africa Region
+#       geo: central-africa
+#       parentGeo: africa
+#       org: null
+# 
+#   - url: https://nextstrain.org/groups/africa-cdc/ncov/central-africa
+#     name: Central Africa Region
+#     geo: central-africa
+#     region: Central Africa
+#     level: region
+#     coords:
+#       - 20.9394
+#       - 6.6111
+#     org:
+#       name: Africa CDC
+#       url: https://africacdc.org/
 
   - url: https://nextstrain.org/community/BryanTegomoh/Nextstrain-Builds@main/Cameroon
     name: Cameroon

--- a/static-site/content/SARS-CoV-2-Datasets.yaml
+++ b/static-site/content/SARS-CoV-2-Datasets.yaml
@@ -2176,8 +2176,8 @@ datasets:
     geo: northern-africa
     level: region
     coords:
-      - 67.139
-      - 0.788
+      - 10.1516
+      - 27.2107
     org:
       name: Africa CDC PGI
       url: https://africacdc.org/institutes/ipg/

--- a/static-site/content/SARS-CoV-2-Datasets.yaml
+++ b/static-site/content/SARS-CoV-2-Datasets.yaml
@@ -76,212 +76,212 @@ datasets:
     geo: usa
     parentGeo: north-america
 
-  - geo: alabama
-    name: Alabama
+  - name: Alabama
+    geo: alabama
     parentGeo: usa
 
-  - geo: alaska
-    name: Alaska
+  - name: Alaska
+    geo: alaska
     parentGeo: usa
 
-  - geo: arizona
-    name: Arizona
+  - name: Arizona
+    geo: arizona
     parentGeo: usa
 
-  - geo: arkansas
-    name: Arkansas
+  - name: Arkansas
+    geo: arkansas
     parentGeo: usa
 
-  - geo: california
-    name: California
+  - name: California
+    geo: california
     parentGeo: usa
 
-  - geo: colorado
-    name: Colorado
+  - name: Colorado
+    geo: colorado
     parentGeo: usa
 
-  - geo: connecticut
-    name: Connecticut
+  - name: Connecticut
+    geo: connecticut
     parentGeo: usa
 
-  - geo: delaware
-    name: Delaware
+  - name: Delaware
+    geo: delaware
     parentGeo: usa
 
-  - geo: florida
-    name: Florida
+  - name: Florida
+    geo: florida
     parentGeo: usa
 
-  - geo: georgia
-    name: Georgia
+  - name: Georgia
+    geo: georgia
     parentGeo: usa
 
-  - geo: hawaii
-    name: Hawaii
+  - name: Hawaii
+    geo: hawaii
     parentGeo: usa
 
-  - geo: idaho
-    name: Idaho
+  - name: Idaho
+    geo: idaho
     parentGeo: usa
 
-  - geo: illinois
-    name: Illinois
+  - name: Illinois
+    geo: illinois
     parentGeo: usa
 
-  - geo: indiana
-    name: Indiana
+  - name: Indiana
+    geo: indiana
     parentGeo: usa
 
-  - geo: iowa
-    name: Iowa
+  - name: Iowa
+    geo: iowa
     parentGeo: usa
 
-  - geo: kansas
-    name: Kansas
+  - name: Kansas
+    geo: kansas
     parentGeo: usa
 
-  - geo: kentucky
-    name: Kentucky
+  - name: Kentucky
+    geo: kentucky
     parentGeo: usa
 
-  - geo: louisiana
-    name: Louisiana
+  - name: Louisiana
+    geo: louisiana
     parentGeo: usa
 
-  - geo: maine
-    name: Maine
+  - name: Maine
+    geo: maine
     parentGeo: usa
 
-  - geo: maryland
-    name: Maryland
+  - name: Maryland
+    geo: maryland
     parentGeo: usa
 
-  - geo: massachusetts
-    name: Massachusetts
+  - name: Massachusetts
+    geo: massachusetts
     parentGeo: usa
 
-  - geo: michigan
-    name: Michigan
+  - name: Michigan
+    geo: michigan
     parentGeo: usa
 
-  - geo: minnesota
-    name: Minnesota
+  - name: Minnesota
+    geo: minnesota
     parentGeo: usa
 
-  - geo: mississippi
-    name: Mississippi
+  - name: Mississippi
+    geo: mississippi
     parentGeo: usa
 
-  - geo: missouri
-    name: Missouri
+  - name: Missouri
+    geo: missouri
     parentGeo: usa
 
-  - geo: montana
-    name: Montana
+  - name: Montana
+    geo: montana
     parentGeo: usa
 
-  - geo: nebraska
-    name: Nebraska
+  - name: Nebraska
+    geo: nebraska
     parentGeo: usa
 
-  - geo: nevada
-    name: Nevada
+  - name: Nevada
+    geo: nevada
     parentGeo: usa
 
-  - geo: new_hampshire
-    name: New Hampshire
+  - name: New Hampshire
+    geo: new_hampshire
     parentGeo: usa
 
-  - geo: new_jersey
-    name: New Jersey
+  - name: New Jersey
+    geo: new_jersey
     parentGeo: usa
 
-  - geo: new_mexico
-    name: New Mexico
+  - name: New Mexico
+    geo: new_mexico
     parentGeo: usa
 
-  - geo: new_york
-    name: New York
+  - name: New York
+    geo: new_york
     parentGeo: usa
 
-  - geo: north_carolina
-    name: North Carolina
+  - name: North Carolina
+    geo: north_carolina
     parentGeo: usa
 
-  - geo: north_dakota
-    name: North Dakota
+  - name: North Dakota
+    geo: north_dakota
     parentGeo: usa
 
-  - geo: ohio
-    name: Ohio
+  - name: Ohio
+    geo: ohio
     parentGeo: usa
 
-  - geo: oklahoma
-    name: Oklahoma
+  - name: Oklahoma
+    geo: oklahoma
     parentGeo: usa
 
-  - geo: oregon
-    name: Oregon
+  - name: Oregon
+    geo: oregon
     parentGeo: usa
 
-  - geo: pennsylvania
-    name: Pennsylvania
+  - name: Pennsylvania
+    geo: pennsylvania
     parentGeo: usa
 
-  - geo: puerto_rico
-    name: Puerto Rico
+  - name: Puerto Rico
+    geo: puerto_rico
     parentGeo: usa
 
-  - geo: rhode_island
-    name: Rhode Island
+  - name: Rhode Island
+    geo: rhode_island
     parentGeo: usa
 
-  - geo: south_carolina
-    name: South Carolina
+  - name: South Carolina
+    geo: south_carolina
     parentGeo: usa
 
-  - geo: south_dakota
-    name: South Dakota
+  - name: South Dakota
+    geo: south_dakota
     parentGeo: usa
 
-  - geo: tennessee
-    name: Tennessee
+  - name: Tennessee
+    geo: tennessee
     parentGeo: usa
 
-  - geo: texas
-    name: Texas
+  - name: Texas
+    geo: texas
     parentGeo: usa
 
-  - geo: utah
-    name: Utah
+  - name: Utah
+    geo: utah
     parentGeo: usa
 
-  - geo: vermont
-    name: Vermont
+  - name: Vermont
+    geo: vermont
     parentGeo: usa
 
-  - geo: virginia
-    name: Virginia
+  - name: Virginia
+    geo: virginia
     parentGeo: usa
 
-  - geo: washington
-    name: Washington
+  - name: Washington
+    geo: washington
     parentGeo: usa
 
-  - geo: washington_dc
-    name: Washington DC
+  - name: Washington DC
+    geo: washington_dc
     parentGeo: usa
 
-  - geo: west_virginia
-    name: West Virginia
+  - name: West Virginia
+    geo: west_virginia
     parentGeo: usa
 
-  - geo: wisconsin
-    name: Wisconsin
+  - name: Wisconsin
+    geo: wisconsin
     parentGeo: usa
 
-  - geo: wyoming
-    name: Wyoming
+  - name: Wyoming
+    geo: wyoming
     parentGeo: usa
 
   - name: Austria
@@ -609,7 +609,7 @@ datasets:
     parentGeo: western-africa
 
   - name: Cote d'Ivoire
-    geo: cote-d'ivoire
+    geo: cote-d-ivoire
     parentGeo: western-africa
 
   - name: Gambia
@@ -712,7 +712,6 @@ datasets:
       name: neherlab
       url: https://neherlab.org
 
-  # Bookmark: JC
   - url: https://nextstrain.org/ncov/africa?f_region=Africa
     name: Africa
     geo: africa
@@ -2626,7 +2625,7 @@ datasets:
 
   - url: https://nextstrain.org/groups/africa-cdc/ncov/cote-divoire?c=clade_membership&f_country=Cote%20d%27Ivoire&p=grid&tl=country
     name: Cote d'Ivoire
-    geo: cote-d'ivoire
+    geo: cote-d-ivoire
     level: country
     coords:
       - -5.5679458

--- a/static-site/content/SARS-CoV-2-Datasets.yaml
+++ b/static-site/content/SARS-CoV-2-Datasets.yaml
@@ -2221,8 +2221,8 @@ datasets:
     geo: cameroon
     level: country
     coords:
-      - 13.1535811
-      - 4.6125522
+      - 9.4712
+      - 4.0358
     org:
       name: Africa CDC PGI
       url: https://africacdc.org/institutes/ipg/

--- a/static-site/content/SARS-CoV-2-Datasets.yaml
+++ b/static-site/content/SARS-CoV-2-Datasets.yaml
@@ -44,10 +44,9 @@ datasets:
     geo: north-america
     parentGeo: null
 
-  # bookmark: JC
   - name: Cameroon
     geo: cameroon
-    parentGeo: africa
+    parentGeo: central-africa
 
   - name: New Zealand
     geo: new_zealand
@@ -55,11 +54,11 @@ datasets:
 
   - name: Zambia
     geo: zambia
-    parentGeo: africa
+    parentGeo: southern-africa
 
   - name: South Africa
     geo: south-africa
-    parentGeo: africa
+    parentGeo: southern-africa
 
   - name: Canada
     geo: canada
@@ -473,10 +472,6 @@ datasets:
     geo: burundi
     parentGeo: central-africa
 
-  - name: Cameroon
-    geo: cameroon
-    parentGeo: central-africa
-
   - name: Central African Republic
     geo: central-african-republic
     parentGeo: central-africa
@@ -595,14 +590,6 @@ datasets:
 
   - name: Namibia
     geo: namibia
-    parentGeo: southern-africa
-
-  - name: South Africa
-    geo: south-africa
-    parentGeo: southern-africa
-
-  - name: Zambia
-    geo: zambia
     parentGeo: southern-africa
 
   - name: Zimbabwe
@@ -725,6 +712,7 @@ datasets:
       name: neherlab
       url: https://neherlab.org
 
+  # Bookmark: JC
   - url: https://nextstrain.org/ncov/africa?f_region=Africa
     name: Africa
     geo: africa
@@ -734,37 +722,6 @@ datasets:
       - 4.070194
     org:
       name: Nextstrain Team
-  
-  - url: https://nextstrain.org/groups/africa-cdc
-    name: Africa CDC
-    geo: africa
-    level: region
-    coords:
-      - 21.824559
-      - 4.070194
-    org:
-      name: Africa CDC
-      url: https://africacdc.org/
-
-#   # Actually maybe linking each of the regions
-#   # example: https://nextstrain.org/groups/africa-cdc/ncov/central-africa
-#     - url: null
-#       name: Central Africa Region
-#       geo: central-africa
-#       parentGeo: africa
-#       org: null
-# 
-#   - url: https://nextstrain.org/groups/africa-cdc/ncov/central-africa
-#     name: Central Africa Region
-#     geo: central-africa
-#     region: Central Africa
-#     level: region
-#     coords:
-#       - 20.9394
-#       - 6.6111
-#     org:
-#       name: Africa CDC
-#       url: https://africacdc.org/
 
   - url: https://nextstrain.org/community/BryanTegomoh/Nextstrain-Builds@main/Cameroon
     name: Cameroon
@@ -2192,3 +2149,609 @@ datasets:
     org:
       name: Center for Medical Genetics, Keio University School of Medicine
       url: https://cmg.med.keio.ac.jp/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/central-africa?c=clade_membership&f_country=Burundi,Cameroon,Central%20African%20Republic,Democratic%20Republic%20of%20the%20Congo,Equatorial%20Guinea,Gabon,Republic%20of%20the%20Congo,Chad&p=grid&tl=country
+    name: Central Africa
+    geo: central-africa
+    level: region
+    coords:
+      - 17.2236
+      - -4.010
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/eastern-africa?c=clade_membership&f_country=Comoros,Djibouti,Ethiopia,Kenya,Madagascar,Mauritius,Rwanda,Seychelles,Somalia,South%20Sudan,Sudan,Uganda&p=grid&tl=country
+    name: Eastern Africa
+    geo: eastern-africa
+    level: region
+    coords:
+      - 35.993
+      - 9.132
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/northern-africa?c=clade_membership&f_country=Algeria,Egypt,Libya,Morocco,Tunisia&p=grid&tl=country
+    name: Northern Africa
+    geo: northern-africa
+    level: region
+    coords:
+      - 67.139
+      - 0.788
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/southern-africa?c=clade_membership&f_country=Angola,Botswana,Eswatini,Lesotho,Malawi,Mozambique,Namibia,South%20Africa,Zambia,Zimbabwe&p=grid&tl=country
+    name: Southern Africa
+    geo: southern-africa
+    level: region
+    coords:
+      - 22.438
+      - -22.322
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+  
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/western-africa?c=clade_membership&f_country=Benin,Burkina%20Faso,Cabo%20Verde,Cote%20d%27Ivoire,Gambia,Ghana,Guinea,Guinea-Bissau,Liberia,Mali,Niger,Nigeria,Senegal,Sierra%20Leone,Togo&p=grid&tl=country
+    name: Western Africa
+    geo: western-africa
+    level: region
+    coords:
+      - -3.803
+      - 12.243
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/burundi?c=clade_membership&f_country=Burundi&p=grid&tl=country
+    name: Burundi
+    geo: burundi
+    level: country
+    coords:
+      - 29.8870575
+      - -3.3634357
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/cameroon?c=clade_membership&f_country=Cameroon&p=grid&tl=country
+    name: Cameroon
+    geo: cameroon
+    level: country
+    coords:
+      - 13.1535811
+      - 4.6125522
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/central-african-republic?c=clade_membership&f_country=Central%20African%20Republic&p=grid&tl=country
+    name: Central African Republic
+    geo: central-african-republic
+    level: country
+    coords:
+      - 19.9981227
+      - 7.0323598
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/chad?c=clade_membership&f_country=Chad&p=grid&tl=country
+    name: Chad
+    geo: chad
+    level: country
+    coords:
+      - 19.0156172
+      - 15.6134137
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/republic-of-the-congo?c=clade_membership&f_country=Republic%20of%20the%20Congo&p=grid&tl=country
+    name: Republic of the Congo
+    geo: republic-of-the-congo
+    level: country
+    coords:
+      - 15.877811
+      - -0.516362
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/democratic-republic-of-the-congo?c=clade_membership&f_country=Democratic%20Republic%20of%20the%20Congo&p=grid&tl=country
+    name: Democratic Republic of the Congo
+    geo: democratic-republic-of-the-congo
+    level: country
+    coords:
+      - 21.7587
+      - -4.0383
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/equatorial-guinea?c=clade_membership&f_country=Equatorial%20Guinea&p=grid&tl=country
+    name: Equatorial Guinea
+    geo: equatorial-guinea
+    level: country
+    coords:
+      - 10.5170357
+      - 1.613172
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/gabon?c=clade_membership&f_country=Gabon&p=grid&tl=country
+    name: Gabon
+    geo: gabon
+    level: country
+    coords:
+      - 11.6899699
+      - -0.8999695
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/comoros?c=clade_membership&f_country=Comoros&p=grid&tl=country
+    name: Comoros
+    geo: comoros
+    level: country
+    coords:
+      - 43.872219
+      - -11.875001
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/djibouti?c=clade_membership&f_country=Djibouti&p=grid&tl=country
+    name: Djibouti
+    geo: djibouti
+    level: country
+    coords:
+      - 42.757784519943655
+      - 11.85677545
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/ethiopia?c=clade_membership&f_country=Ethiopia&p=grid&tl=country
+    name: Ethiopia
+    geo: ethiopia
+    level: country
+    coords:
+      - 40.4897
+      - 9.1450
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/kenya?c=clade_membership&f_country=Kenya&p=grid&tl=country
+    name: Kenya
+    geo: kenya
+    level: country
+    coords:
+      - 37.9062
+      - 0.0236
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/madagascar?c=clade_membership&f_country=Madagascar&p=grid&tl=country
+    name: Madagascar
+    geo: madagascar
+    level: country
+    coords:
+      - 46.4416422
+      - -18.9249604
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/mauritius?c=clade_membership&f_country=Mauritius&p=grid&tl=country
+    name: Mauritius
+    geo: mauritius
+    level: country
+    coords:
+      - 57.5703566
+      - -20.2759451
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/rwanda?c=clade_membership&f_country=Rwanda&p=grid&tl=country
+    name: Rwanda
+    geo: rwanda
+    level: country
+    coords:
+      - 30.0644358
+      - -1.9646631
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/seychelles?c=clade_membership&f_country=Seychelles&p=grid&tl=country
+    name: Seychelles
+    geo: seychelles
+    level: country
+    coords:
+      - 55.4540146
+      - -4.6574977
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/somalia?c=clade_membership&f_country=Somalia&p=grid&tl=country
+    name: Somalia
+    geo: somalia
+    level: country
+    coords:
+      - 49.083416
+      - 8.3676771
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/south-sudan?c=clade_membership&f_country=South%20Sudan&p=grid&tl=country
+    name: South Sudan
+    geo: south-sudan
+    level: country
+    coords:
+      - 29.6667897
+      - 7.8699431
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/sudan?c=clade_membership&f_country=Sudan&p=grid&tl=country
+    name: Sudan
+    geo: sudan
+    level: country
+    coords:
+      - 29.4917691
+      - 14.5844444
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/uganda?c=clade_membership&f_country=Uganda&p=grid&tl=country
+    name: Uganda
+    geo: uganda
+    level: country
+    coords:
+      - 32.55149
+      - 1.861287
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/algeria?c=clade_membership&f_country=Algeria&p=grid&tl=country
+    name: Algeria
+    geo: algeria
+    level: country
+    coords:
+      - 2.9999825
+      - 28.0000272
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/egypt?c=clade_membership&f_country=Egypt&p=grid&tl=country
+    name: Egypt
+    geo: egypt
+    level: country
+    coords:
+      - 30.8025
+      - 26.8206
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/libya?c=clade_membership&f_country=Libya&p=grid&tl=country
+    name: Libya
+    geo: libya
+    level: country
+    coords:
+      - 17.30331995251014
+      - 26.4215275
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/morocco?c=clade_membership&f_country=Morocco&p=grid&tl=country
+    name: Morocco
+    geo: morocco
+    level: country
+    coords:
+      - -5.480765
+      - 32.549785
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/tunisia?c=clade_membership&f_country=Tunisia&p=grid&tl=country
+    name: Tunisia
+    geo: tunisia
+    level: country
+    coords:
+      - 9.065134
+      - 33.654143
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/angola?c=clade_membership&f_country=Angola&p=grid&tl=country
+    name: Angola
+    geo: angola
+    level: country
+    coords:
+      - 17.5691241
+      - -11.8775768
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/botswana?c=clade_membership&f_country=Botswana&p=grid&tl=country
+    name: Botswana
+    geo: botswana
+    level: country
+    coords:
+      - 24.5928742
+      - -23.1681782
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/eswatini?c=clade_membership&f_country=Eswatini&p=grid&tl=country
+    name: Eswatini
+    geo: eswatini
+    level: country
+    coords:
+      - 31.3991317
+      - -26.5624806
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/lesotho?c=clade_membership&f_country=Lesotho&p=grid&tl=country
+    name: Lesotho
+    geo: lesotho
+    level: country
+    coords:
+      - 28.3350193
+      - -29.6039267
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/malawi?c=clade_membership&f_country=Malawi&p=grid&tl=country
+    name: Malawi
+    geo: malawi
+    level: country
+    coords:
+      - 33.9301963
+      - -13.2687204
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/mozambique?c=clade_membership&f_country=Mozambique&p=grid&tl=country
+    name: Mozambique
+    geo: mozambique
+    level: country
+    coords:
+      - 34.9144977
+      - -19.302233
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/namibia?c=clade_membership&f_country=Namibia&p=grid&tl=country
+    name: Namibia
+    geo: namibia
+    level: country
+    coords:
+      - 17.3231107
+      - -23.2335499
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/south-africa?c=clade_membership&f_country=South%20Africa&p=grid&tl=country
+    name: South Africa
+    geo: south-africa
+    level: country
+    coords:
+      - 24.991639
+      - -28.8166235
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/zambia?c=clade_membership&f_country=Zambia&p=grid&tl=country
+    name: Zambia
+    geo: zambia
+    level: country
+    coords:
+      - 27.5599164
+      - -14.5186239
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/zimbabwe?c=clade_membership&f_country=Zimbabwe&p=grid&tl=country
+    name: Zimbabwe
+    geo: zimbabwe
+    level: country
+    coords:
+      - 29.7468414
+      - -18.4554963
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/benin?c=clade_membership&f_country=Benin&p=grid&tl=country
+    name: Benin
+    geo: benin
+    level: country
+    coords:
+      - 2.327362
+      - 9.961027
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/burkina-faso?c=clade_membership&f_country=Burkina%20Faso&p=grid&tl=country
+    name: Burkina Faso
+    geo: burkina-faso
+    level: country
+    coords:
+      - -1.683734
+      - 12.78998
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/cabo-verde?c=clade_membership&f_country=Cabo%20Verde&p=grid&tl=country
+    name: Cabo Verde
+    geo: cabo-verde
+    level: country
+    coords:
+      - -24.0083947
+      - 16.0000552
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/cote-divoire?c=clade_membership&f_country=Cote%20d%27Ivoire&p=grid&tl=country
+    name: Cote d'Ivoire
+    geo: cote-d'ivoire
+    level: country
+    coords:
+      - -5.5679458
+      - 7.9897371
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/gambia?c=clade_membership&f_country=Gambia&p=grid&tl=country
+    name: Gambia
+    geo: gambia
+    level: country
+    coords:
+      - -15.5
+      - 13.5
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/ghana?c=clade_membership&f_country=Ghana&p=grid&tl=country
+    name: Ghana
+    geo: ghana
+    level: country
+    coords:
+      - -1.089272
+      - 7.811417
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/guinea?c=clade_membership&f_country=Guinea&p=grid&tl=country
+    name: Guinea
+    geo: guinea
+    level: country
+    coords:
+      - -10.7083587
+      - 10.7226226
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/guinea-bissau?c=clade_membership&f_country=Guinea-Bissau&p=grid&tl=country
+    name: Guinea-Bissau
+    geo: guinea-bissau
+    level: country
+    coords:
+      - -14.9000214
+      - 12.100035
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/liberia?c=clade_membership&f_country=Liberia&p=grid&tl=country
+    name: Liberia
+    geo: liberia
+    level: country
+    coords:
+      - -9.3658524
+      - 5.7499721
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/mali?c=clade_membership&f_country=Mali&p=grid&tl=country
+    name: Mali
+    geo: mali
+    level: country
+    coords:
+      - -2.2900239
+      - 16.3700359
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/niger?c=clade_membership&f_country=Niger&p=grid&tl=country
+    name: Niger
+    geo: niger
+    level: country
+    coords:
+      - 10.145544
+      - 18.061703
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/nigeria?c=clade_membership&f_country=Nigeria&p=grid&tl=country
+    name: Nigeria
+    geo: nigeria
+    level: country
+    coords:
+      - 8.0
+      - 10.0
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/senegal?c=clade_membership&f_country=Senegal&p=grid&tl=country
+    name: Senegal
+    geo: senegal
+    level: country
+    coords:
+      - -14.25
+      - 14.5
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/sierra-leone?c=clade_membership&f_country=Sierra%20Leone&p=grid&tl=country
+    name: Sierra Leone
+    geo: sierra-leone
+    level: country
+    coords:
+      - -11.8400269
+      - 8.6400349
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/
+
+  - url: https://nextstrain.org/groups/africa-cdc/ncov/togo?c=clade_membership&f_country=Togo&p=grid&tl=country
+    name: Togo
+    geo: togo
+    level: country
+    coords:
+      - 1.069709
+      - 8.88625
+    org:
+      name: Africa CDC PGI
+      url: https://africacdc.org/institutes/ipg/

--- a/static-site/content/SARS-CoV-2-Datasets.yaml
+++ b/static-site/content/SARS-CoV-2-Datasets.yaml
@@ -44,6 +44,7 @@ datasets:
     geo: north-america
     parentGeo: null
 
+  # bookmark: JC
   - name: Cameroon
     geo: cameroon
     parentGeo: africa
@@ -447,6 +448,226 @@ datasets:
   - name: Gulf Cooperation Council
     geo: gcc
     parentGeo: asia
+
+  - name: Central Africa
+    geo: central-africa
+    parentGeo: africa
+
+  - name: Eastern Africa
+    geo: eastern-africa
+    parentGeo: africa
+
+  - name: Northern Africa
+    geo: northern-africa
+    parentGeo: africa
+
+  - name: Southern Africa
+    geo: southern-africa
+    parentGeo: africa
+    
+  - name: Western Africa
+    geo: western-africa
+    parentGeo: africa
+
+  - name: Burundi
+    geo: burundi
+    parentGeo: central-africa
+
+  - name: Cameroon
+    geo: cameroon
+    parentGeo: central-africa
+
+  - name: Central African Republic
+    geo: central-african-republic
+    parentGeo: central-africa
+
+  - name: Chad
+    geo: chad
+    parentGeo: central-africa
+
+  - name: Republic of the Congo
+    geo: republic-of-the-congo
+    parentGeo: central-africa
+
+  - name: Democratic Republic of the Congo
+    geo: democratic-republic-of-the-congo
+    parentGeo: central-africa
+
+  - name: Equatorial Guinea
+    geo: equatorial-guinea
+    parentGeo: central-africa
+
+  - name: Gabon
+    geo: gabon
+    parentGeo: central-africa
+
+  - name: Comoros
+    geo: comoros
+    parentGeo: eastern-africa
+
+  - name: Djibouti
+    geo: djibouti
+    parentGeo: eastern-africa
+
+  - name: Ethiopia
+    geo: ethiopia
+    parentGeo: eastern-africa
+
+  - name: Kenya
+    geo: kenya
+    parentGeo: eastern-africa
+
+  - name: Madagascar
+    geo: madagascar
+    parentGeo: eastern-africa
+
+  - name: Mauritius
+    geo: mauritius
+    parentGeo: eastern-africa
+
+  - name: Rwanda
+    geo: rwanda
+    parentGeo: eastern-africa
+
+  - name: Seychelles
+    geo: seychelles
+    parentGeo: eastern-africa
+
+  - name: Somalia
+    geo: somalia
+    parentGeo: eastern-africa
+
+  - name: South Sudan
+    geo: south-sudan
+    parentGeo: eastern-africa
+
+  - name: Sudan
+    geo: sudan
+    parentGeo: eastern-africa
+
+  - name: Uganda
+    geo: uganda
+    parentGeo: eastern-africa
+
+  - name: Algeria
+    geo: algeria
+    parentGeo: northern-africa
+
+  - name: Egypt
+    geo: egypt
+    parentGeo: northern-africa
+
+  - name: Libya
+    geo: libya
+    parentGeo: northern-africa
+
+  - name: Morocco
+    geo: morocco
+    parentGeo: northern-africa
+
+  - name: Tunisia
+    geo: tunisia
+    parentGeo: northern-africa
+
+  - name: Angola
+    geo: angola
+    parentGeo: southern-africa
+
+  - name: Botswana
+    geo: botswana
+    parentGeo: southern-africa
+
+  - name: Eswatini
+    geo: eswatini
+    parentGeo: southern-africa
+
+  - name: Lesotho
+    geo: lesotho
+    parentGeo: southern-africa
+
+  - name: Malawi
+    geo: malawi
+    parentGeo: southern-africa
+
+  - name: Mozambique
+    geo: mozambique
+    parentGeo: southern-africa
+
+  - name: Namibia
+    geo: namibia
+    parentGeo: southern-africa
+
+  - name: South Africa
+    geo: south-africa
+    parentGeo: southern-africa
+
+  - name: Zambia
+    geo: zambia
+    parentGeo: southern-africa
+
+  - name: Zimbabwe
+    geo: zimbabwe
+    parentGeo: southern-africa
+
+  - name: Benin
+    geo: benin
+    parentGeo: western-africa
+
+  - name: Burkina Faso
+    geo: burkina-faso
+    parentGeo: western-africa
+
+  - name: Cabo Verde
+    geo: cabo-verde
+    parentGeo: western-africa
+
+  - name: Cote d'Ivoire
+    geo: cote-d'ivoire
+    parentGeo: western-africa
+
+  - name: Gambia
+    geo: gambia
+    parentGeo: western-africa
+
+  - name: Ghana
+    geo: ghana
+    parentGeo: western-africa
+
+  - name: Guinea
+    geo: guinea
+    parentGeo: western-africa
+
+  - name: Guinea-Bissau
+    geo: guinea-bissau
+    parentGeo: western-africa
+
+  - name: Liberia
+    geo: liberia
+    parentGeo: western-africa
+
+  - name: Mali
+    geo: mali
+    parentGeo: western-africa
+
+  - name: Niger
+    geo: niger
+    parentGeo: western-africa
+
+  - name: Nigeria
+    geo: nigeria
+    parentGeo: western-africa
+
+  - name: Senegal
+    geo: senegal
+    parentGeo: western-africa
+
+  - name: Sierra Leone
+    geo: sierra-leone
+    parentGeo: western-africa
+
+  - name: Togo
+    geo: togo
+    parentGeo: western-africa
 
   # Entries below this comment define datasets. They should have a URL pointing to the analysis
   # visualisation as well as a name and coords for rendering on the map. The `geo` value should


### PR DESCRIPTION
### Description of proposed changes    

Update the https://nextstrain.org/sars-cov-2/ map to link out to the country-level analyses at https://nextstrain.org/groups/africa-cdc. 

Mostly following steps from: https://docs.nextstrain.org/en/latest/guides/share/sars-cov-2.html

### Testing

Check links. Let me know if we're allowed to have duplicate dataset entries for the same location or if I need unique geo IDs.

Example:

```
  - url: https://nextstrain.org/groups/SC2ZamPub/ncov/africa/zambia
    name: Zambia
    geo: zambia
    level: country
    coords:
      - 30
      - -15
    org:
      name: Zambia Genomic Sequencing Consortium
      url: https://nextstrain.org/groups/SC2ZamPub
```

and 

```
  - url: https://nextstrain.org/groups/africa-cdc/ncov/zambia?c=clade_membership&f_country=Zambia&p=grid&tl=country
    name: Zambia
    geo: zambia
    level: country
    coords:
      - 27.5599164      #<= pulled from lat_longs.tsv, not sure if these need to exactly match the earlier entry
      - -14.5186239
    org:
      name: Africa CDC PGI
      url: https://africacdc.org/institutes/ipg/
```

I'm open to suggestions or edits.


