### PR TITLE
Semi-automate migration of a Group from a single-tenant to multi-tenant bucket

### DIFF
--- a/aws/iam/policy/NextstrainDotOrgServerInstance.json
+++ b/aws/iam/policy/NextstrainDotOrgServerInstance.json
@@ -41,8 +41,6 @@
         "arn:aws:s3:::nextstrain-africa-cdc",
         "arn:aws:s3:::nextstrain-usda-ars-flucrew",
         "arn:aws:s3:::nextstrain-offlu-swine-private",
-        "arn:aws:s3:::nextstrain-group-test",
-        "arn:aws:s3:::nextstrain-group-test-private",
         "arn:aws:s3:::nextstrain-valldhebronvirology",
         "arn:aws:s3:::nextstrain-valldhebronvirology-private"
       ]
@@ -88,8 +86,6 @@
         "arn:aws:s3:::nextstrain-africa-cdc/*",
         "arn:aws:s3:::nextstrain-usda-ars-flucrew/*",
         "arn:aws:s3:::nextstrain-offlu-swine-private/*",
-        "arn:aws:s3:::nextstrain-group-test/*",
-        "arn:aws:s3:::nextstrain-group-test-private/*",
         "arn:aws:s3:::nextstrain-valldhebronvirology/*",
         "arn:aws:s3:::nextstrain-valldhebronvirology-private/*"
       ]

--- a/aws/iam/policy/NextstrainDotOrgServerInstanceDev.json
+++ b/aws/iam/policy/NextstrainDotOrgServerInstanceDev.json
@@ -21,9 +21,7 @@
         "arn:aws:s3:::nextstrain-spheres",
         "arn:aws:s3:::nextstrain-niph",
         "arn:aws:s3:::nextstrain-epicovigal",
-        "arn:aws:s3:::nextstrain-waphl",
-        "arn:aws:s3:::nextstrain-group-test",
-        "arn:aws:s3:::nextstrain-group-test-private"
+        "arn:aws:s3:::nextstrain-waphl"
       ]
     },
     {
@@ -47,9 +45,7 @@
         "arn:aws:s3:::nextstrain-spheres/*",
         "arn:aws:s3:::nextstrain-niph/*",
         "arn:aws:s3:::nextstrain-epicovigal/*",
-        "arn:aws:s3:::nextstrain-waphl/*",
-        "arn:aws:s3:::nextstrain-group-test/*",
-        "arn:aws:s3:::nextstrain-group-test-private/*"
+        "arn:aws:s3:::nextstrain-waphl/*"
       ]
     },
     {

--- a/aws/iam/policy/NextstrainDotOrgServerInstanceDev.json
+++ b/aws/iam/policy/NextstrainDotOrgServerInstanceDev.json
@@ -61,8 +61,8 @@
       "Resource": [
         "arn:aws:s3:::nextstrain-groups"
       ],
-      "Condition" : {
-        "StringEquals" : {
+      "Condition": {
+        "StringEquals": {
           "s3:prefix": [
             "test/",
             "test-private/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,65 @@
       "resolved": "https://registry.npmjs.org/@awaitjs/express/-/express-0.6.3.tgz",
       "integrity": "sha512-x7N92+Rmy/WHEaXXunV2ArVa/AqzkJlouc8pokuVF9h6DeUtbkPaEKVYKMDEFs2u5Hbw2XfwGVyLf69yr2UG5g=="
     },
+    "@aws-crypto/crc32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/crc32c": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
+      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "@aws-crypto/ie11-detection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
       "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
       "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha1-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
+      "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -110,6 +164,37 @@
         }
       }
     },
+    "@aws-sdk/chunked-blob-reader": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.52.0.tgz",
+      "integrity": "sha512-BAZhriHHfvnGOd0P9xcnGu8DGyxOa0lgmEw+Tc6nZpXJzx0P+1Sd76q5gE5d/IZ0r5VTB6rfwwKUoG6iShNCwQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/chunked-blob-reader-native": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.52.0.tgz",
+      "integrity": "sha512-/hVzC0Q12/mWRMBBQD3v82xsLSxZ4RwG6N44XP7MuJoHy4ui4T7D9RSuvBpzzr/4fqF0w9M7XYv6aM4BD2pFIQ==",
+      "requires": {
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "@aws-sdk/client-cognito-identity-provider": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.52.0.tgz",
@@ -154,6 +239,1070 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
           "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/client-iam": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.53.0.tgz",
+      "integrity": "sha512-EAJQOzZXmUtIZxJDtnaOhDWi7RaR8OuuERJmQvD7U5PRfHuWgXwCLbPGZk+C2jg5LIlwLXcOfMwLJF9uabYPbA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.53.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/credential-provider-node": "3.53.0",
+        "@aws-sdk/fetch-http-handler": "3.53.0",
+        "@aws-sdk/hash-node": "3.53.0",
+        "@aws-sdk/invalid-dependency": "3.53.0",
+        "@aws-sdk/middleware-content-length": "3.53.0",
+        "@aws-sdk/middleware-host-header": "3.53.0",
+        "@aws-sdk/middleware-logger": "3.53.0",
+        "@aws-sdk/middleware-retry": "3.53.0",
+        "@aws-sdk/middleware-serde": "3.53.0",
+        "@aws-sdk/middleware-signing": "3.53.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/middleware-user-agent": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/node-http-handler": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/smithy-client": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "@aws-sdk/util-base64-node": "3.52.0",
+        "@aws-sdk/util-body-length-browser": "3.52.0",
+        "@aws-sdk/util-body-length-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+        "@aws-sdk/util-defaults-mode-node": "3.53.0",
+        "@aws-sdk/util-user-agent-browser": "3.53.0",
+        "@aws-sdk/util-user-agent-node": "3.53.0",
+        "@aws-sdk/util-utf8-browser": "3.52.0",
+        "@aws-sdk/util-utf8-node": "3.52.0",
+        "@aws-sdk/util-waiter": "3.53.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.53.0.tgz",
+          "integrity": "sha512-Xe7IX2mpf/qOjh1LrPnJ1UtiDw3cBlmy8n+Q2xSP5vaS/9IH0OMdQUveC9MV9HSgzICX+xzbPyUuSKc+4tufBQ==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.53.0.tgz",
+          "integrity": "sha512-X32YHHc5MO7xO4W3Ly8DeryieeEiDOsnl6ypBkfML7loO3M0ckvvL+HnNUR1J+HYyseEV7V93BsF/A1z5HmINQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.53.0",
+            "@aws-sdk/fetch-http-handler": "3.53.0",
+            "@aws-sdk/hash-node": "3.53.0",
+            "@aws-sdk/invalid-dependency": "3.53.0",
+            "@aws-sdk/middleware-content-length": "3.53.0",
+            "@aws-sdk/middleware-host-header": "3.53.0",
+            "@aws-sdk/middleware-logger": "3.53.0",
+            "@aws-sdk/middleware-retry": "3.53.0",
+            "@aws-sdk/middleware-serde": "3.53.0",
+            "@aws-sdk/middleware-stack": "3.53.0",
+            "@aws-sdk/middleware-user-agent": "3.53.0",
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/node-http-handler": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/smithy-client": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/url-parser": "3.53.0",
+            "@aws-sdk/util-base64-browser": "3.52.0",
+            "@aws-sdk/util-base64-node": "3.52.0",
+            "@aws-sdk/util-body-length-browser": "3.52.0",
+            "@aws-sdk/util-body-length-node": "3.52.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+            "@aws-sdk/util-defaults-mode-node": "3.53.0",
+            "@aws-sdk/util-user-agent-browser": "3.53.0",
+            "@aws-sdk/util-user-agent-node": "3.53.0",
+            "@aws-sdk/util-utf8-browser": "3.52.0",
+            "@aws-sdk/util-utf8-node": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.53.0.tgz",
+          "integrity": "sha512-MNG+Pmw/zZQ0kboZtsc8UEGM9pn8abjStDN0Yk67fwFAZMqz8sUHDtFXpa3gSXMrFqBwT+jMFXmIxqiq7XuAeA==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.53.0",
+            "@aws-sdk/credential-provider-node": "3.53.0",
+            "@aws-sdk/fetch-http-handler": "3.53.0",
+            "@aws-sdk/hash-node": "3.53.0",
+            "@aws-sdk/invalid-dependency": "3.53.0",
+            "@aws-sdk/middleware-content-length": "3.53.0",
+            "@aws-sdk/middleware-host-header": "3.53.0",
+            "@aws-sdk/middleware-logger": "3.53.0",
+            "@aws-sdk/middleware-retry": "3.53.0",
+            "@aws-sdk/middleware-sdk-sts": "3.53.0",
+            "@aws-sdk/middleware-serde": "3.53.0",
+            "@aws-sdk/middleware-signing": "3.53.0",
+            "@aws-sdk/middleware-stack": "3.53.0",
+            "@aws-sdk/middleware-user-agent": "3.53.0",
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/node-http-handler": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/smithy-client": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/url-parser": "3.53.0",
+            "@aws-sdk/util-base64-browser": "3.52.0",
+            "@aws-sdk/util-base64-node": "3.52.0",
+            "@aws-sdk/util-body-length-browser": "3.52.0",
+            "@aws-sdk/util-body-length-node": "3.52.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+            "@aws-sdk/util-defaults-mode-node": "3.53.0",
+            "@aws-sdk/util-user-agent-browser": "3.53.0",
+            "@aws-sdk/util-user-agent-node": "3.53.0",
+            "@aws-sdk/util-utf8-browser": "3.52.0",
+            "@aws-sdk/util-utf8-node": "3.52.0",
+            "entities": "2.2.0",
+            "fast-xml-parser": "3.19.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.53.0.tgz",
+          "integrity": "sha512-wAqP/xNx49H1dutHWHjhKduaKtAcDg2KoH25W6peW2qXZ6OfpVcxRIBbJE4Z0yGOmFFaxw0OeH3h2ptP7tdhGQ==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-config-provider": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.53.0.tgz",
+          "integrity": "sha512-ocqZ4w7y7eay2M+uUBAD6NkhikUPoajEFX1/7iMvEFMmS5MyzjuolHPNK7Hh8lFmPyoflxaMXJVKO8C1MguA/A==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.53.0.tgz",
+          "integrity": "sha512-aKc8POSqCi58566KhF1p8Sxt7LHehMnshyfQzNAOB7xshSxuWg41rxafnQU4Soq9Tz7q5bwkauR2CEUihv/TRg==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/url-parser": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.53.0.tgz",
+          "integrity": "sha512-g+UoJ1ikDrfpI1wHAhlrcBtX4OHxoLV6vakirpG27hhFwuMih565Q/Sjn3o5hLT8PBlWxwT2YeRuxCjtaL3cDA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.53.0",
+            "@aws-sdk/credential-provider-imds": "3.53.0",
+            "@aws-sdk/credential-provider-sso": "3.53.0",
+            "@aws-sdk/credential-provider-web-identity": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-credentials": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.53.0.tgz",
+          "integrity": "sha512-sy0NeuJHOBhe7XwxCX2y+YZAB4CqcHveyXJfT6mv7eY6bYQskkMTCPp2D586hSH3c6cfIsmvLSxNhNJApj1Atw==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.53.0",
+            "@aws-sdk/credential-provider-imds": "3.53.0",
+            "@aws-sdk/credential-provider-ini": "3.53.0",
+            "@aws-sdk/credential-provider-process": "3.53.0",
+            "@aws-sdk/credential-provider-sso": "3.53.0",
+            "@aws-sdk/credential-provider-web-identity": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-credentials": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.53.0.tgz",
+          "integrity": "sha512-nazHndueCa4y5jUM58OHSysb52E953r3VhmpCs0qIv1ZH5Ijs3kT/usbUq7Yms7pcpaUmpu00VZTc6IfOOC0GA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-credentials": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.53.0.tgz",
+          "integrity": "sha512-EongClNxdVw+O4y+S0mZFjNeLHv1ssdAnBM/9L1PfR6sH06eikVmU6isEN2quwoKBy9HRVPaIVF075Q8QIpipg==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-credentials": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.53.0.tgz",
+          "integrity": "sha512-YbysBkX3mbomHJZULxk/3jyQ7NWn6rZ68IDY28bmp8cNWajWeGzDxKmR4Y+c8gNiN2ziWjUZWfHcnZC056/79Q==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.53.0.tgz",
+          "integrity": "sha512-0CcEYarIAVAoGzu1ClO2xDq30Jii6AevDFJYR7M9yojqAMvwjP31DY4/qfPc2nCpSAd9dASR6vcx6r/RoIynVg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/querystring-builder": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-base64-browser": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.53.0.tgz",
+          "integrity": "sha512-0xK5PSUUVOPttvCLWrrUTmrKe7Fz6njPdBYvB3ESk1whXL+TY3syJj4em63Sq6yFyeuXdqyTzqfcs9fU2puWkA==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-buffer-from": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.53.0.tgz",
+          "integrity": "sha512-qp2qRFa1a/AjZRCe6MZCpbaXo5t4enGAtch/83fuH4rRkzVOctYox1gyTGTliHk28rjMREtSgZDQZojp5/5M5w==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.53.0.tgz",
+          "integrity": "sha512-CXANhpL2MAE2tPKmu0cOf4Fd99useIj5kgX6UA+HWg/ZbJ4qBg6Q4W/nYVt+OuukeqwEEbpt3wv0lKQ8k/vINQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.53.0.tgz",
+          "integrity": "sha512-w5qMAUgy52fvJGqzqruNJhv4BtkanE4I368zWiysmwXXL5xmpKs8TpkGqcSQw4g2wKS8MR2Yxh21LukHlsgAJw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.53.0.tgz",
+          "integrity": "sha512-jMME8OOyPHliHhVD3FaBQ+4X+FDCQovw6CYGqPdqP0JUuhR8E1LWKHV1+xRpkpOICKwBnIXrgD8/0NQo/+Z84A==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.53.0.tgz",
+          "integrity": "sha512-TKEdTLP//SjasunU3/yX7avXMxhIEDoSOaiwj77zEpPGF2NWcR99UFfqNLeJsRPCyzYScYo1JSuxIwgXHNIhyQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/service-error-classification": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.53.0.tgz",
+          "integrity": "sha512-b9AUXYqA5jaUTpWu7wPZz43RQnmy1WGPFVHd8CvcUzFdMzwJlQeH4wq+sEdZ1KtIsz6n6TmY7vobzrScgq3ftg==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/signature-v4": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.53.0.tgz",
+          "integrity": "sha512-jPoou51ULWN2PpvWkDF3wLKnTezyM33NBdF89mvfnI4++Za0/NpuL12636YqWLXt2CK87u8cA2Q+7Opob7KocA==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.53.0.tgz",
+          "integrity": "sha512-r3g2ytin1YbhXCDedMfR7ZSlt1B39GWA0+J04ZZzUdevtnS2VnkFNhsanO5os/WOpVUV7iqk/ncJgSpn9LI2DA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/signature-v4": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.53.0.tgz",
+          "integrity": "sha512-YanQOVUXGjm63GCZVRYPlPMl6niaWtVjE2C0+0lpCrJQYaUIrvKh27Ff40JLi3U0F89hmsYOO7yPQOPTbc9NBg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.53.0.tgz",
+          "integrity": "sha512-ClKxpFXoHLhdnDxyDRRVNaFYQnfylps7rk1wfbRLWb+FWQwKWBvLq5c5ZPvznBU8BvftDSkFtrY+7OLMlj6qxA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.53.0.tgz",
+          "integrity": "sha512-l00gDzU7n2WSIBHZPVW8/t6L0UD6qwtre5kuGKiv8ZkZKynPg9VV39IB/JZ7swp2uydbXuqxgDxFvqImvY3IyA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.53.0.tgz",
+          "integrity": "sha512-YqovPyn75gNzDSvPWQUTAEbwhr8PBdp1MQz65bB8p+qOlzQi1jGCyj1uHqG7qwVIlis9+bAfqpAqNDuYpdGsNg==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/querystring-builder": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.53.0.tgz",
+          "integrity": "sha512-qrVFYcOV/Da7/ozW2bDLDz0JQP0NLIn6/eNUwT2fqKVw9MWcrLf6xtyAJhCwckdUVOWS2HoBSyvEopa4mdh9Sw==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
+          "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.53.0.tgz",
+          "integrity": "sha512-oliOrup52985pSKOjHbbm7t3bGL0HTPs9UODhBuDpHE7l0pdWE1hv9YiU3FF5NUIF25VwbL83GYmL9R52GxZhA==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-uri-escape": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.53.0.tgz",
+          "integrity": "sha512-wEkS40w/wW4eBSnf7xt+m8InZFVzjLAzRYK1yPab2qfOIShpWgxg1ndqEP0eu14MvwdEfMPW9xU6J2AiWoxWng==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.53.0.tgz",
+          "integrity": "sha512-l5g8QncKk0ZmzQL7mWyQ6n5xWkd1XQJuoOfLZPBas9SJAyz7wanV5P3CG9PX6s1GVHWLC+2MafpIQ6+aH1x5cQ=="
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.53.0.tgz",
+          "integrity": "sha512-CUvCIrwiiWpJd/ldSA04RERXPsdvkuKW3+gBDIUREq4uc7co7Cml1/wbIJ0UOHAmJpDw82NDYqAUthYB1kbHrQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-hex-encoding": "3.52.0",
+            "@aws-sdk/util-uri-escape": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.53.0.tgz",
+          "integrity": "sha512-/mZn1/1/BXFgV5PwbGfXczbSyZFrhUEhWQzPG7x1NXLQh3kcSoHGDSONqFhqTeHWkfEXp1Tn0zUe7R4vAseFmQ==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.53.0.tgz",
+          "integrity": "sha512-lB0U5TkBDSdJK8h3noDkSG/P1cGnpSxOxBroMgPHA8Lrf5lmFRMvDXLXMhRDnTiqtsd/DpHDPyat91pfwLVEwA==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-credentials": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.53.0.tgz",
+          "integrity": "sha512-XP/3mYOmSn5KpWv+PnBTP2UExXb+hx1ugbH4Gkveshdq9KBlVnpV5eVgIwSAnKBsplScfsNMJ5EOtHjz5Cvu5A==",
+          "requires": {
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.53.0.tgz",
+          "integrity": "sha512-ubOcZT3rkVXSTwCHeIJevgBVV5GHnejz3hd+dFY9OcuK53oMZnFPS8SfJLgGG6PHfg30P8EurKv1VhWrbuuJDw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.53.0.tgz",
+          "integrity": "sha512-84nczaF0eZMRkZ7chJh7OZd4ekV31eWmw8LOTJ4RQeeRy+0eY8th23yKyt5TU+YgmMLrY0BVK7103BQAI/6ccQ==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.53.0",
+            "@aws-sdk/credential-provider-imds": "3.53.0",
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.53.0.tgz",
+          "integrity": "sha512-fJsxzjo4UMv2o6KYSvw8cwfDhAQiao3X+iY1lGNVKrcY2bnI4zW5pWYge94oIJXMyFjjg6k6Ek+JIvGLMFY0XA==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.53.0.tgz",
+          "integrity": "sha512-YbrqMpTi+ArL9qG+NIXPInmnjGwYu0lohiH5uyEMHAHolqg4vqdKBlXyZ7Pjls2Nka7px2UUfX/Ba2RIssBBMQ==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.53.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.53.1.tgz",
+      "integrity": "sha512-uAhjR/TAuXNct6BL/shVg2f/6Zg1EZoXTG8KIywfmLitiUF0PvYwfwSPtNohkz6czgTs/rtirAZHAQKi8jjieA==",
+      "requires": {
+        "@aws-crypto/sha1-browser": "2.0.0",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.53.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/credential-provider-node": "3.53.0",
+        "@aws-sdk/eventstream-serde-browser": "3.53.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.53.0",
+        "@aws-sdk/eventstream-serde-node": "3.53.0",
+        "@aws-sdk/fetch-http-handler": "3.53.0",
+        "@aws-sdk/hash-blob-browser": "3.53.0",
+        "@aws-sdk/hash-node": "3.53.0",
+        "@aws-sdk/hash-stream-node": "3.53.1",
+        "@aws-sdk/invalid-dependency": "3.53.0",
+        "@aws-sdk/md5-js": "3.53.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.53.0",
+        "@aws-sdk/middleware-content-length": "3.53.0",
+        "@aws-sdk/middleware-expect-continue": "3.53.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.53.0",
+        "@aws-sdk/middleware-host-header": "3.53.0",
+        "@aws-sdk/middleware-location-constraint": "3.53.0",
+        "@aws-sdk/middleware-logger": "3.53.0",
+        "@aws-sdk/middleware-retry": "3.53.0",
+        "@aws-sdk/middleware-sdk-s3": "3.53.0",
+        "@aws-sdk/middleware-serde": "3.53.0",
+        "@aws-sdk/middleware-signing": "3.53.0",
+        "@aws-sdk/middleware-ssec": "3.53.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/middleware-user-agent": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/node-http-handler": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/smithy-client": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "@aws-sdk/util-base64-node": "3.52.0",
+        "@aws-sdk/util-body-length-browser": "3.52.0",
+        "@aws-sdk/util-body-length-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+        "@aws-sdk/util-defaults-mode-node": "3.53.0",
+        "@aws-sdk/util-stream-browser": "3.53.0",
+        "@aws-sdk/util-stream-node": "3.53.0",
+        "@aws-sdk/util-user-agent-browser": "3.53.0",
+        "@aws-sdk/util-user-agent-node": "3.53.0",
+        "@aws-sdk/util-utf8-browser": "3.52.0",
+        "@aws-sdk/util-utf8-node": "3.52.0",
+        "@aws-sdk/util-waiter": "3.53.0",
+        "@aws-sdk/xml-builder": "3.52.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.53.0.tgz",
+          "integrity": "sha512-Xe7IX2mpf/qOjh1LrPnJ1UtiDw3cBlmy8n+Q2xSP5vaS/9IH0OMdQUveC9MV9HSgzICX+xzbPyUuSKc+4tufBQ==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.53.0.tgz",
+          "integrity": "sha512-X32YHHc5MO7xO4W3Ly8DeryieeEiDOsnl6ypBkfML7loO3M0ckvvL+HnNUR1J+HYyseEV7V93BsF/A1z5HmINQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.53.0",
+            "@aws-sdk/fetch-http-handler": "3.53.0",
+            "@aws-sdk/hash-node": "3.53.0",
+            "@aws-sdk/invalid-dependency": "3.53.0",
+            "@aws-sdk/middleware-content-length": "3.53.0",
+            "@aws-sdk/middleware-host-header": "3.53.0",
+            "@aws-sdk/middleware-logger": "3.53.0",
+            "@aws-sdk/middleware-retry": "3.53.0",
+            "@aws-sdk/middleware-serde": "3.53.0",
+            "@aws-sdk/middleware-stack": "3.53.0",
+            "@aws-sdk/middleware-user-agent": "3.53.0",
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/node-http-handler": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/smithy-client": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/url-parser": "3.53.0",
+            "@aws-sdk/util-base64-browser": "3.52.0",
+            "@aws-sdk/util-base64-node": "3.52.0",
+            "@aws-sdk/util-body-length-browser": "3.52.0",
+            "@aws-sdk/util-body-length-node": "3.52.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+            "@aws-sdk/util-defaults-mode-node": "3.53.0",
+            "@aws-sdk/util-user-agent-browser": "3.53.0",
+            "@aws-sdk/util-user-agent-node": "3.53.0",
+            "@aws-sdk/util-utf8-browser": "3.52.0",
+            "@aws-sdk/util-utf8-node": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.53.0.tgz",
+          "integrity": "sha512-MNG+Pmw/zZQ0kboZtsc8UEGM9pn8abjStDN0Yk67fwFAZMqz8sUHDtFXpa3gSXMrFqBwT+jMFXmIxqiq7XuAeA==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.53.0",
+            "@aws-sdk/credential-provider-node": "3.53.0",
+            "@aws-sdk/fetch-http-handler": "3.53.0",
+            "@aws-sdk/hash-node": "3.53.0",
+            "@aws-sdk/invalid-dependency": "3.53.0",
+            "@aws-sdk/middleware-content-length": "3.53.0",
+            "@aws-sdk/middleware-host-header": "3.53.0",
+            "@aws-sdk/middleware-logger": "3.53.0",
+            "@aws-sdk/middleware-retry": "3.53.0",
+            "@aws-sdk/middleware-sdk-sts": "3.53.0",
+            "@aws-sdk/middleware-serde": "3.53.0",
+            "@aws-sdk/middleware-signing": "3.53.0",
+            "@aws-sdk/middleware-stack": "3.53.0",
+            "@aws-sdk/middleware-user-agent": "3.53.0",
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/node-http-handler": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/smithy-client": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/url-parser": "3.53.0",
+            "@aws-sdk/util-base64-browser": "3.52.0",
+            "@aws-sdk/util-base64-node": "3.52.0",
+            "@aws-sdk/util-body-length-browser": "3.52.0",
+            "@aws-sdk/util-body-length-node": "3.52.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+            "@aws-sdk/util-defaults-mode-node": "3.53.0",
+            "@aws-sdk/util-user-agent-browser": "3.53.0",
+            "@aws-sdk/util-user-agent-node": "3.53.0",
+            "@aws-sdk/util-utf8-browser": "3.52.0",
+            "@aws-sdk/util-utf8-node": "3.52.0",
+            "entities": "2.2.0",
+            "fast-xml-parser": "3.19.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.53.0.tgz",
+          "integrity": "sha512-wAqP/xNx49H1dutHWHjhKduaKtAcDg2KoH25W6peW2qXZ6OfpVcxRIBbJE4Z0yGOmFFaxw0OeH3h2ptP7tdhGQ==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-config-provider": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.53.0.tgz",
+          "integrity": "sha512-ocqZ4w7y7eay2M+uUBAD6NkhikUPoajEFX1/7iMvEFMmS5MyzjuolHPNK7Hh8lFmPyoflxaMXJVKO8C1MguA/A==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.53.0.tgz",
+          "integrity": "sha512-aKc8POSqCi58566KhF1p8Sxt7LHehMnshyfQzNAOB7xshSxuWg41rxafnQU4Soq9Tz7q5bwkauR2CEUihv/TRg==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/url-parser": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.53.0.tgz",
+          "integrity": "sha512-g+UoJ1ikDrfpI1wHAhlrcBtX4OHxoLV6vakirpG27hhFwuMih565Q/Sjn3o5hLT8PBlWxwT2YeRuxCjtaL3cDA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.53.0",
+            "@aws-sdk/credential-provider-imds": "3.53.0",
+            "@aws-sdk/credential-provider-sso": "3.53.0",
+            "@aws-sdk/credential-provider-web-identity": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-credentials": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.53.0.tgz",
+          "integrity": "sha512-sy0NeuJHOBhe7XwxCX2y+YZAB4CqcHveyXJfT6mv7eY6bYQskkMTCPp2D586hSH3c6cfIsmvLSxNhNJApj1Atw==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.53.0",
+            "@aws-sdk/credential-provider-imds": "3.53.0",
+            "@aws-sdk/credential-provider-ini": "3.53.0",
+            "@aws-sdk/credential-provider-process": "3.53.0",
+            "@aws-sdk/credential-provider-sso": "3.53.0",
+            "@aws-sdk/credential-provider-web-identity": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-credentials": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.53.0.tgz",
+          "integrity": "sha512-nazHndueCa4y5jUM58OHSysb52E953r3VhmpCs0qIv1ZH5Ijs3kT/usbUq7Yms7pcpaUmpu00VZTc6IfOOC0GA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-credentials": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.53.0.tgz",
+          "integrity": "sha512-EongClNxdVw+O4y+S0mZFjNeLHv1ssdAnBM/9L1PfR6sH06eikVmU6isEN2quwoKBy9HRVPaIVF075Q8QIpipg==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-credentials": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.53.0.tgz",
+          "integrity": "sha512-YbysBkX3mbomHJZULxk/3jyQ7NWn6rZ68IDY28bmp8cNWajWeGzDxKmR4Y+c8gNiN2ziWjUZWfHcnZC056/79Q==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.53.0.tgz",
+          "integrity": "sha512-0CcEYarIAVAoGzu1ClO2xDq30Jii6AevDFJYR7M9yojqAMvwjP31DY4/qfPc2nCpSAd9dASR6vcx6r/RoIynVg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/querystring-builder": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-base64-browser": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.53.0.tgz",
+          "integrity": "sha512-0xK5PSUUVOPttvCLWrrUTmrKe7Fz6njPdBYvB3ESk1whXL+TY3syJj4em63Sq6yFyeuXdqyTzqfcs9fU2puWkA==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-buffer-from": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.53.0.tgz",
+          "integrity": "sha512-qp2qRFa1a/AjZRCe6MZCpbaXo5t4enGAtch/83fuH4rRkzVOctYox1gyTGTliHk28rjMREtSgZDQZojp5/5M5w==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.53.0.tgz",
+          "integrity": "sha512-CXANhpL2MAE2tPKmu0cOf4Fd99useIj5kgX6UA+HWg/ZbJ4qBg6Q4W/nYVt+OuukeqwEEbpt3wv0lKQ8k/vINQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.53.0.tgz",
+          "integrity": "sha512-w5qMAUgy52fvJGqzqruNJhv4BtkanE4I368zWiysmwXXL5xmpKs8TpkGqcSQw4g2wKS8MR2Yxh21LukHlsgAJw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.53.0.tgz",
+          "integrity": "sha512-jMME8OOyPHliHhVD3FaBQ+4X+FDCQovw6CYGqPdqP0JUuhR8E1LWKHV1+xRpkpOICKwBnIXrgD8/0NQo/+Z84A==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.53.0.tgz",
+          "integrity": "sha512-TKEdTLP//SjasunU3/yX7avXMxhIEDoSOaiwj77zEpPGF2NWcR99UFfqNLeJsRPCyzYScYo1JSuxIwgXHNIhyQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/service-error-classification": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.53.0.tgz",
+          "integrity": "sha512-b9AUXYqA5jaUTpWu7wPZz43RQnmy1WGPFVHd8CvcUzFdMzwJlQeH4wq+sEdZ1KtIsz6n6TmY7vobzrScgq3ftg==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/signature-v4": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.53.0.tgz",
+          "integrity": "sha512-jPoou51ULWN2PpvWkDF3wLKnTezyM33NBdF89mvfnI4++Za0/NpuL12636YqWLXt2CK87u8cA2Q+7Opob7KocA==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.53.0.tgz",
+          "integrity": "sha512-r3g2ytin1YbhXCDedMfR7ZSlt1B39GWA0+J04ZZzUdevtnS2VnkFNhsanO5os/WOpVUV7iqk/ncJgSpn9LI2DA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/signature-v4": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.53.0.tgz",
+          "integrity": "sha512-YanQOVUXGjm63GCZVRYPlPMl6niaWtVjE2C0+0lpCrJQYaUIrvKh27Ff40JLi3U0F89hmsYOO7yPQOPTbc9NBg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.53.0.tgz",
+          "integrity": "sha512-ClKxpFXoHLhdnDxyDRRVNaFYQnfylps7rk1wfbRLWb+FWQwKWBvLq5c5ZPvznBU8BvftDSkFtrY+7OLMlj6qxA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.53.0.tgz",
+          "integrity": "sha512-l00gDzU7n2WSIBHZPVW8/t6L0UD6qwtre5kuGKiv8ZkZKynPg9VV39IB/JZ7swp2uydbXuqxgDxFvqImvY3IyA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.53.0.tgz",
+          "integrity": "sha512-YqovPyn75gNzDSvPWQUTAEbwhr8PBdp1MQz65bB8p+qOlzQi1jGCyj1uHqG7qwVIlis9+bAfqpAqNDuYpdGsNg==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/querystring-builder": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.53.0.tgz",
+          "integrity": "sha512-qrVFYcOV/Da7/ozW2bDLDz0JQP0NLIn6/eNUwT2fqKVw9MWcrLf6xtyAJhCwckdUVOWS2HoBSyvEopa4mdh9Sw==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
+          "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.53.0.tgz",
+          "integrity": "sha512-oliOrup52985pSKOjHbbm7t3bGL0HTPs9UODhBuDpHE7l0pdWE1hv9YiU3FF5NUIF25VwbL83GYmL9R52GxZhA==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-uri-escape": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.53.0.tgz",
+          "integrity": "sha512-wEkS40w/wW4eBSnf7xt+m8InZFVzjLAzRYK1yPab2qfOIShpWgxg1ndqEP0eu14MvwdEfMPW9xU6J2AiWoxWng==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.53.0.tgz",
+          "integrity": "sha512-l5g8QncKk0ZmzQL7mWyQ6n5xWkd1XQJuoOfLZPBas9SJAyz7wanV5P3CG9PX6s1GVHWLC+2MafpIQ6+aH1x5cQ=="
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.53.0.tgz",
+          "integrity": "sha512-CUvCIrwiiWpJd/ldSA04RERXPsdvkuKW3+gBDIUREq4uc7co7Cml1/wbIJ0UOHAmJpDw82NDYqAUthYB1kbHrQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-hex-encoding": "3.52.0",
+            "@aws-sdk/util-uri-escape": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.53.0.tgz",
+          "integrity": "sha512-/mZn1/1/BXFgV5PwbGfXczbSyZFrhUEhWQzPG7x1NXLQh3kcSoHGDSONqFhqTeHWkfEXp1Tn0zUe7R4vAseFmQ==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.53.0.tgz",
+          "integrity": "sha512-lB0U5TkBDSdJK8h3noDkSG/P1cGnpSxOxBroMgPHA8Lrf5lmFRMvDXLXMhRDnTiqtsd/DpHDPyat91pfwLVEwA==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-credentials": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.53.0.tgz",
+          "integrity": "sha512-XP/3mYOmSn5KpWv+PnBTP2UExXb+hx1ugbH4Gkveshdq9KBlVnpV5eVgIwSAnKBsplScfsNMJ5EOtHjz5Cvu5A==",
+          "requires": {
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.53.0.tgz",
+          "integrity": "sha512-ubOcZT3rkVXSTwCHeIJevgBVV5GHnejz3hd+dFY9OcuK53oMZnFPS8SfJLgGG6PHfg30P8EurKv1VhWrbuuJDw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.53.0.tgz",
+          "integrity": "sha512-84nczaF0eZMRkZ7chJh7OZd4ekV31eWmw8LOTJ4RQeeRy+0eY8th23yKyt5TU+YgmMLrY0BVK7103BQAI/6ccQ==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.53.0",
+            "@aws-sdk/credential-provider-imds": "3.53.0",
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.53.0.tgz",
+          "integrity": "sha512-fJsxzjo4UMv2o6KYSvw8cwfDhAQiao3X+iY1lGNVKrcY2bnI4zW5pWYge94oIJXMyFjjg6k6Ek+JIvGLMFY0XA==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.53.0.tgz",
+          "integrity": "sha512-YbrqMpTi+ArL9qG+NIXPInmnjGwYu0lohiH5uyEMHAHolqg4vqdKBlXyZ7Pjls2Nka7px2UUfX/Ba2RIssBBMQ==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -408,6 +1557,118 @@
         }
       }
     },
+    "@aws-sdk/eventstream-marshaller": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.53.0.tgz",
+      "integrity": "sha512-Vt8OjC0hgF0rNcGPbMEROnM5SHODzRdQsG9Y+M2suWDkUqFoh8+6m4v9c/ej3iudAEydZDLcnpV9yGv/CTqceg==",
+      "requires": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-hex-encoding": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-browser": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.53.0.tgz",
+      "integrity": "sha512-B+nAlXet/NSEIzaN4fZYGwoFHBYtURuXUE+Ru4EaWyC8+vBEdeO4Vs9o/8mlZSHGiUn41QYYqiZvd+OKweTtBA==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.53.0",
+        "@aws-sdk/eventstream-serde-universal": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.53.0.tgz",
+      "integrity": "sha512-4O66c1aSgfdWfbr2pUJTONReVwA4oWQ/fRMhcAMhacqbPko5+3v0Iy/vOiVCm6Isa4K2kVpOUN0L+64niE7jag==",
+      "requires": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-node": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.53.0.tgz",
+      "integrity": "sha512-92rlY8M8+nU4mUm3j4gtJiv9HY2fGTGLSIGLukOXAUf7xuJ220L+9ZInS4ToiRgq+dOSt8cFPCxRVpQtNesBfA==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.53.0",
+        "@aws-sdk/eventstream-serde-universal": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-universal": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.53.0.tgz",
+      "integrity": "sha512-Y3OjTAKhDyz2UyLE0ATmDD3RFyBfJLWeBQkpJu7qICI0XYN2tmV1mCkQUtkT3e4s+UxnuUOa55YQpdUsQUWIDA==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "@aws-sdk/fetch-http-handler": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.52.0.tgz",
@@ -427,6 +1688,29 @@
         }
       }
     },
+    "@aws-sdk/hash-blob-browser": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.53.0.tgz",
+      "integrity": "sha512-A3xa0o1W9/tALw0/yoXyBKfxsMlzi1BvzEgCFUU2y914yBo62FiIf1E+BX42m9MfPJ87SD+l3O5QcptMVWvarw==",
+      "requires": {
+        "@aws-sdk/chunked-blob-reader": "3.52.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "@aws-sdk/hash-node": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.52.0.tgz",
@@ -437,6 +1721,27 @@
         "tslib": "^2.3.0"
       },
       "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/hash-stream-node": {
+      "version": "3.53.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.53.1.tgz",
+      "integrity": "sha512-y7pUc6EtkG3TscZR9dpR/BCauP/lRepU+Td43Oe9VUhD6l3lS3TuIHUwB7PEU7NeSU9iqWuflBVK/IBWXrfH3w==",
+      "requires": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -475,6 +1780,62 @@
         }
       }
     },
+    "@aws-sdk/md5-js": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.53.0.tgz",
+      "integrity": "sha512-+XbYdbxgWniyC7E4kqHC0z0Qsud/EMv9RuKghWLr7IwbUjfR7zix5+AVw3XR+FWrKrDAlyRBhyzG+60STliuiA==",
+      "requires": {
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-utf8-browser": "3.52.0",
+        "@aws-sdk/util-utf8-node": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.53.0.tgz",
+      "integrity": "sha512-q88eevXUkUWp6e/vHGnpt8/8TjscbfW6CWGpexj3DFWt3WZhEhExcoGwwszoL4FQfMFWBL+11EKNZm2orHqDwg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-arn-parser": "3.52.0",
+        "@aws-sdk/util-config-provider": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
+          "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "@aws-sdk/middleware-content-length": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.52.0.tgz",
@@ -492,6 +1853,103 @@
         }
       }
     },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.53.0.tgz",
+      "integrity": "sha512-aMKtfOX9b1yx0ER0QspN2jOR/Q1ucRYEaR46yOUPjdcMHHnGxuk3kimsyGqgFm2+pPJdi9FRd9S2eC/tNjYn8w==",
+      "requires": {
+        "@aws-sdk/middleware-header-default": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
+          "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.53.0.tgz",
+      "integrity": "sha512-g069Es0Sy3So2HRz+UAwaubFKkGuxwhEf6OS9pmovY2+2yfZBOLoQmf7jS50RgbxJcUDoI7uuKZrp0BcdLDgEg==",
+      "requires": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-crypto/crc32c": "2.0.0",
+        "@aws-sdk/is-array-buffer": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
+          "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-header-default": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.53.0.tgz",
+      "integrity": "sha512-eQLFdNBzydZoocnj7YDVO+AJZ3YhuImZ1GXzGsF9FN8IdSjuE4gwB8BQhG6vuUg3GVe+sI+7VUJT6h55OaDBXw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
+          "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "@aws-sdk/middleware-host-header": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.52.0.tgz",
@@ -502,6 +1960,27 @@
         "tslib": "^2.3.0"
       },
       "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.53.0.tgz",
+      "integrity": "sha512-HtBy8L3XNbovHLVh6wtIIThsbdTsX+jv09M9Cmmu80eM1WXw5Uu6lJX6FdIQXfMXBTZjnmHRL+72CxEtsets8g==",
+      "requires": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -546,6 +2025,51 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.53.0.tgz",
+      "integrity": "sha512-cq2NFixf5HBctPaUUMjV97M++q18e/WDrM61lN7eMHfdXW+TlYv4tVF9y9MaE7dpoNp7G0ORLsz05JdVdUI33g==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/signature-v4": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-arn-parser": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
+          "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.53.0.tgz",
+          "integrity": "sha512-CUvCIrwiiWpJd/ldSA04RERXPsdvkuKW3+gBDIUREq4uc7co7Cml1/wbIJ0UOHAmJpDw82NDYqAUthYB1kbHrQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-hex-encoding": "3.52.0",
+            "@aws-sdk/util-uri-escape": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
@@ -597,6 +2121,27 @@
         "tslib": "^2.3.0"
       },
       "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.53.0.tgz",
+      "integrity": "sha512-2p2QT3PNepUC5MwT+t0l9bf7MlRHw6DN6CLg4Dptgr3SFR2k8LjUp2S7dJqg4qrhXRiiO7lTZK57PaPPR90dFw==",
+      "requires": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -816,6 +2361,21 @@
         }
       }
     },
+    "@aws-sdk/util-arn-parser": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.52.0.tgz",
+      "integrity": "sha512-mMsoYJ70+BGkVpdfQbu942v4fAGzx+pIL8+QnQhzUmcU0HbNkI0vYliMWfzz7ka9CHgbijUI/ANKA319zgKtvA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "@aws-sdk/util-base64-browser": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.52.0.tgz",
@@ -992,6 +2552,48 @@
         }
       }
     },
+    "@aws-sdk/util-stream-browser": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.53.0.tgz",
+      "integrity": "sha512-oh+PVTeo7nvkuXwlrAy6TErTpzTRrtxaL+2ErTFiLFPPFKK2/0X0E12zoNB0DMaY48sRdkJmrlLbOtxGDS1rNg==",
+      "requires": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-stream-node": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.53.0.tgz",
+      "integrity": "sha512-Hubb2cvn2idlNsHkJ5v46wW+cvodLySGJCqTat5kUAoOxR20ZFG3P3R6InU85PAh54zZTRvURuD0UM0uPtIQYQ==",
+      "requires": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "@aws-sdk/util-uri-escape": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
@@ -1062,6 +2664,52 @@
       "integrity": "sha512-fujr7zeobZ2y5nnOnQZrCPPc+lCAhtNF/LEVslsQfd+AQ0bYWiosrKNetodQVWlfh10E2+i6/5g+1SBJ5kjsLw==",
       "requires": {
         "@aws-sdk/util-buffer-from": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.53.0.tgz",
+      "integrity": "sha512-WyiyHOzmiapbbwB8dtu7axRqu9u5+Mnp1/+k2Ia7cm0UMUTKLjdixPsaM89HNre3EMa8WHrDBnwyVmo/Khbq3w==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.53.0.tgz",
+          "integrity": "sha512-Xe7IX2mpf/qOjh1LrPnJ1UtiDw3cBlmy8n+Q2xSP5vaS/9IH0OMdQUveC9MV9HSgzICX+xzbPyUuSKc+4tufBQ==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.52.0.tgz",
+      "integrity": "sha512-GMdcxdwDZuIMlGnewdB48bpj8eqA3nubs3biy6vRFX8zhv8OqD+m5fMinoEwD8/MGqWE3WD7VZlbbdwYtNVWzQ==",
+      "requires": {
         "tslib": "^2.3.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "@awaitjs/express": "^0.6.3",
     "@aws-sdk/client-cognito-identity-provider": "^3.52.0",
+    "@aws-sdk/client-iam": "^3.53.0",
+    "@aws-sdk/client-s3": "^3.53.1",
     "argparse": "^1.0.10",
     "auspice": "2.34.0",
     "aws-sdk": "^2.908.0",

--- a/scripts/migrate-group
+++ b/scripts/migrate-group
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+const {ArgumentParser} = require("argparse");
+const IAM = require("@aws-sdk/client-iam");
+const S3 = require("@aws-sdk/client-s3");
+const {spawn} = require("child_process");
+const {Console} = require("console");
+const fs = require("fs");
+const os = require("os");
+const {basename, relative: relativePath, parse: parsePath} = require("path");
+const process = require("process");
+const {Transform} = require("stream");
+
+const {Group} = require("../src/groups");
+const {reportUnhandledRejectionsAtExit} = require("../src/utils/scripts");
+
+const AWS_ACCOUNT_ID = process.env.AWS_ACCOUNT_ID;
+if (!AWS_ACCOUNT_ID) throw new Error("AWS_ACCOUNT_ID env var required");
+
+const SCRIPTS = relativePath(".", __dirname);
+const REPO = relativePath(".", `${__dirname}/..`) || ".";
+
+
+function parseArgs() {
+  const argparser = new ArgumentParser({
+    usage: `%(prog)s [--dry-run | --wet-run] <name>`,
+    description: `
+      Migrate a Nextstrain Group from an old single-tenant bucket to the new
+      multi-tenant bucket.  The group must already be defined in
+      data/groups.json.
+    `,
+  });
+
+  argparser.addArgument("groupName", {metavar: "<name>", help: "Name of the Nextstrain Group"});
+  argparser.addArgument("--dry-run", {
+    help: "Go through the motions locally but don't actually make any changes on AWS or to local files.  This is the default.",
+    dest: "dryRun",
+    action: "storeTrue",
+    defaultValue: true,
+  });
+  argparser.addArgument("--wet-run", {
+    help: "Actually make changes on AWS.",
+    dest: "dryRun",
+    action: "storeFalse",
+  });
+
+  return argparser.parseArgs();
+}
+
+
+function main({groupName, dryRun = true}) {
+  // Canonicalizes name for us and ensures a data entry exists.
+  const group = new Group(groupName);
+
+  setupConsole({dryRun});
+
+  console.log(`Migrating Nextstrain Group ${group.name}`);
+
+  migrate({group, dryRun})
+    .then(finalSteps => {
+      console.group("\nMigration ready for the final (manual) steps!");
+      finalSteps.forEach(step => console.log(`- ${step}`));
+      console.groupEnd();
+    })
+    .catch(error => {
+      console.error("\n\n%s\n", error);
+      console.error("Migration FAILED.  See above for details.  It's typically safe to re-run this program after fixing the issue.");
+      process.exitCode = 1;
+    });
+}
+
+
+async function migrate({group, dryRun = true}) {
+  const oldBucket = group.bucket;
+
+  if (!oldBucket) throw new Error(`Group ${group.name} doesn't have a single-tenant bucket defined.`);
+
+  // Each automatic step can return remaining steps to be performed manually.
+  const remainingSteps = [
+    await deleteIAMResources({dryRun, group}),
+    await updateBucketPolicies({dryRun, oldBucket}),
+    await syncData({dryRun, group}),
+    await updateGroupsDataFile({dryRun, group}),
+    `Review local changes, commit, push, and deploy.`,
+    `Monitor deploy for success <https://dashboard.heroku.com/apps/nextstrain-server/activity>.`,
+    await updateServerPolicies({dryRun, oldBucket}),
+    `Delete bucket ${group.bucket} after short retention period (~1 month?)`,
+  ];
+
+  return remainingSteps.filter(s => s != null).flat();
+}
+
+
+async function syncData({dryRun = true, group}) {
+  const argv = [
+    "aws", "s3", "sync",
+    ...(dryRun
+      ? ["--dryrun"]
+      : []),
+    "--delete",
+    `s3://${group.bucket}/`,
+    `s3://nextstrain-groups/${group.name}/`,
+  ];
+  console.group(`\nRunning ${argv.join(" ")}`);
+  await run(argv);
+  console.groupEnd();
+}
+
+
+async function updateServerPolicies({dryRun = true, oldBucket}) {
+  const policyFiles = [
+    "aws/iam/policy/NextstrainDotOrgServerInstance.json",
+    "aws/iam/policy/NextstrainDotOrgServerInstanceDev.json",
+  ];
+
+  const updatedFiles = await updatePolicyFiles({dryRun, policyFiles, oldBucket});
+
+  return await syncPoliciesTodo({dryRun, policyFiles: updatedFiles});
+}
+
+
+async function updatePolicyFiles({dryRun = true, policyFiles, oldBucket}) {
+  const oldBucketArn = `arn:aws:s3:::${oldBucket}`;
+
+  console.group(`\nRemoving ${oldBucketArn} resources from local policy files`);
+
+  let updatedFiles = [];
+
+  for (const policyFile of policyFiles) {
+    console.group(`\n${policyFile}`);
+
+    const policy = readJSON(policyFile);
+    const newPolicy = {
+      ...policy,
+      Statement: policy.Statement.map(statement => ({
+        ...statement,
+        Resource: statement.Resource.filter(resource =>
+          resource !== oldBucketArn && !resource.startsWith(`${oldBucketArn}/`)
+        ),
+      }))
+    };
+
+    if (dryRun) {
+      const tmpDir = tempdir();
+      const tmpFile = `${tmpDir}/${basename(policyFile)}`;
+
+      writeJSON(tmpFile, newPolicy);
+      updatedFiles.push(tmpFile);
+
+      await diff(policyFile, tmpFile);
+    } else {
+      writeJSON(policyFile, newPolicy);
+      updatedFiles.push(policyFile);
+
+      await diff(policyFile);
+    }
+
+    console.groupEnd();
+  }
+
+  console.groupEnd();
+  return updatedFiles;
+}
+
+
+async function syncPoliciesTodo({dryRun = true, policyFiles}) {
+  return policyFiles.map(file => {
+    const policyName = parsePath(file).name;
+
+    const argv = [
+      `${SCRIPTS}/sync-iam-policy`,
+      ...(dryRun
+        ? ["--dry-run"]
+        : []),
+      `arn:aws:iam::${AWS_ACCOUNT_ID}:policy/${policyName}`,
+      file
+    ];
+    return `After deploy completes, run: ${argv.join(" ")}`;
+  });
+}
+
+
+async function updateBucketPolicies({dryRun = true, oldBucket}) {
+  const s3 = new S3.S3Client();
+
+  console.group(`\nUpdating bucket access policies`);
+
+  const deleteBucketPolicy = new S3.DeleteBucketPolicyCommand({
+    Bucket: oldBucket,
+    ExpectedBucketOwner: AWS_ACCOUNT_ID,
+  });
+
+  const putPublicAccessBlock = new S3.PutPublicAccessBlockCommand({
+    Bucket: oldBucket,
+    ExpectedBucketOwner: AWS_ACCOUNT_ID,
+    PublicAccessBlockConfiguration: {
+      BlockPublicAcls: true,
+      IgnorePublicAcls: true,
+      BlockPublicPolicy: true,
+      RestrictPublicBuckets: true,
+    },
+  });
+
+  console.log("Deleting bucket policy");
+  if (!dryRun) await s3.send(deleteBucketPolicy);
+
+  console.log("Blocking public access");
+  if (!dryRun) await s3.send(putPublicAccessBlock);
+
+  console.groupEnd();
+}
+
+
+async function deleteIAMResources({dryRun = true, group}) {
+  console.group("\nDiscovering IAM resources…");
+
+  const iam = new IAM.IAMClient();
+
+  // Names used for IAM groups and IAM users associated with a Nextstrain Group
+  const potentialNames = new Set([
+    group.bucket,
+    `nextstrain-${group.name.toLowerCase()}`,
+  ]);
+
+  const iamGroup = await findIAMGroup(iam, potentialNames);
+
+  if (!iamGroup) {
+    console.warn(`Unable to find IAM group matching any of: ${Array.from(potentialNames.values()).join(" ")}`);
+    return [`Review AWS Console for IAM groups, users, and policies associated with ${group.name}`];
+  }
+
+  const todo = [];
+
+  console.log(`Found IAM group ${iamGroup.GroupName}`);
+
+  /* Users
+   */
+  console.group("Members:");
+
+  for (const {UserName: username} of iamGroup.Members) {
+    const marked = potentialNames.has(username);
+    console.log(`- ${username}${marked ? " [suggested for manual deletion]" : ""}`);
+    if (marked) {
+      todo.push(`Delete IAM user ${username} <https://console.aws.amazon.com/iam/home#/users/${username}>`);
+    }
+  }
+  console.groupEnd();
+
+  /* Policies
+   */
+  const attachedPolicies = (await listIAMAttachedGroupPolicies(iam, iamGroup.GroupName))
+    .filter(({name, arn}) => name !== "SeeCloudFrontDistributions");
+
+  console.group("Detaching policies:");
+
+  for (const {name, arn} of attachedPolicies) {
+    console.log(`- ${name} [suggested for manual deletion]`);
+    todo.push(`Delete IAM policy ${name} <https://console.aws.amazon.com/iam/home#/policies/${arn}>`);
+
+    if (!dryRun) await iam.send(new IAM.DetachGroupPolicyCommand({GroupName: iamGroup.GroupName, PolicyArn: arn}));
+  }
+  console.groupEnd();
+
+  console.log(`Deleting IAM group ${iamGroup.GroupName}`);
+  if (!dryRun) await iam.send(new IAM.DeleteGroupCommand({GroupName: iamGroup.GroupName}));
+
+  console.groupEnd();
+
+  return todo;
+}
+
+
+async function findIAMGroup(client, potentialNames) {
+  const groups = await listIAMGroups(client);
+  const candidateGroups = groups.filter(g => potentialNames.has(g));
+
+  if (candidateGroups.length < 1) return;
+  if (candidateGroups.length > 1) throw new Error(`found more than one candidate IAM group: ${candidateGroups.join(" ")}`);
+
+  return await getIAMGroup(client, candidateGroups[0]);
+}
+
+
+async function listIAMGroups(client) {
+  return await collateGroupNames(IAM.paginateListGroups({client}, {}));
+}
+
+
+async function listIAMGroupsForUser(client, UserName) {
+  return await collateGroupNames(IAM.paginateListGroupsForUser({client}, {UserName}));
+}
+
+
+async function listIAMAttachedGroupPolicies(client, GroupName) {
+  return await collate(
+    IAM.paginateListAttachedGroupPolicies({client}, {GroupName}),
+    page => page.AttachedPolicies.map(p => ({name: p.PolicyName, arn: p.PolicyArn})),
+  );
+}
+
+
+async function collateGroupNames(paginator) {
+  return await collate(paginator, page => page.Groups.map(g => g.GroupName));
+}
+
+
+async function collate(paginator, xform = page => page) {
+  let collated = [];
+
+  for await (const page of paginator) {
+    collated = collated.concat(xform(page));
+  }
+  return collated;
+}
+
+
+async function getIAMGroup(client, GroupName) {
+  let group = {};
+
+  for await (const page of IAM.paginateGetGroup({client}, {GroupName})) {
+    group = {
+      ...group,
+      ...page.Group,
+      Members: [
+        ...(group.Members || []),
+        ...page.Users,
+      ],
+    };
+  }
+  return group;
+}
+
+
+async function updateGroupsDataFile({dryRun = true, group}) {
+  const dataFile = `${REPO}/data/groups.json`;
+
+  console.group(`\nRemoving group's "bucket" key from ${dataFile}`);
+
+  const newData = readJSON(dataFile).map(g => {
+    if (g.name === group.name) delete g.bucket;
+    return g;
+  });
+
+  if (dryRun) {
+    const tmpFile = `${tempdir()}/${basename(dataFile)}`;
+    writeJSON(tmpFile, newData);
+    await diff(dataFile, tmpFile);
+  } else {
+    writeJSON(dataFile, newData);
+    await diff(dataFile);
+  }
+  console.groupEnd();
+}
+
+
+/**
+ * Run `git diff` with the given arguments.
+ *
+ * @returns {boolean} true if differences were reported; false if not.
+ */
+async function diff(...args) {
+  try {
+    await run(["git", "diff", ...args]);
+  } catch (error) {
+    switch (error.code) {
+      case 0: // files are the same
+      case 1: // files are different
+        return error.code === 1;
+
+      default:
+        throw error;
+    }
+  }
+}
+
+
+/**
+ * Run a command with stdout and stderr sent to `console.log()` and
+ * `console.error()`.
+ *
+ * @param {string[]} argv
+ * @returns {{code, signal, argv}}
+ */
+async function run(argv) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(argv[0], argv.slice(1), {stdio: ["ignore", "pipe", "pipe"]});
+
+    proc.stdout.on("data", data => console.log(data.toString().replace(/\n$/, "")));
+    proc.stderr.on("data", data => console.error(data.toString().replace(/\n$/, "")));
+
+    proc.on("close", (code, signal) => {
+      const result = code !== 0 || signal != null
+        ? reject
+        : resolve;
+      return result({code, signal, argv});
+    });
+  });
+}
+
+
+/**
+ * Set up the global `console` object to prefix all output lines with an
+ * indication of the state of *dryRun*.
+ *
+ * @param {{dryRun: boolean}}
+ */
+function setupConsole({dryRun = true}) {
+  if (!dryRun) return;
+
+  const LinePrefixer = class extends Transform {
+    constructor(prefix) {
+      super();
+      this.prefix = prefix;
+    }
+    _transform(chunk, encoding, callback) {
+      // Prefix the beginning of the string and every internal newline, but not
+      // the last trailing newline.
+      this.push(chunk.toString().replace(/^|(?<=\n)(?!$)/g, this.prefix));
+      callback();
+    }
+  };
+
+  const stdout = new LinePrefixer("DRY RUN | ");
+  const stderr = new LinePrefixer("DRY RUN | ");
+
+  stdout.pipe(process.stdout);
+  stderr.pipe(process.stderr);
+
+  console = new Console({stdout, stderr});
+  process.stdout = stdout;
+  process.stderr = stderr;
+}
+
+
+/**
+ * Read file at *path* as JSON.
+ *
+ * @param {string} path
+ */
+function readJSON(path) {
+  return JSON.parse(fs.readFileSync(path));
+}
+
+/**
+ * Write *data* to file at *path* as JSON.
+ *
+ * @param {string} path
+ * @param {*} data
+ */
+function writeJSON(path, data) {
+  return fs.writeFileSync(path, JSON.stringify(data, null, 2) + "\n");
+}
+
+
+/**
+ * Create a temporary directory which will be cleaned up upon process exit.
+ */
+function tempdir() {
+  const dir = fs.mkdtempSync(`${os.tmpdir()}/migrate-group-`);
+  process.on("exit", () => fs.rmSync(dir, {recursive: true}));
+  return dir;
+}
+
+
+reportUnhandledRejectionsAtExit();
+main(parseArgs());


### PR DESCRIPTION
Does the "easy" stuff itself, preps the rest for performing manually and spits out a checklist.  Deleting IAM resources is a bear via the AWS API but easy via the AWS Console.  The two stage migration of steps before deploy and after deploy ensure that nextstrain.org can always "see" the Groups' data.  Removing the IAM group before copying the data helps avoid accidental changes in the midst of copying (although that also seems unlikely).  

I've tested this with the `test` and `test-private` Groups, but it'd also be good to test with a Group that's more "real". After merge, I'll test the whole process with `blab-private` and then `blab`.

- [ ] Migrate `blab-private` as a test
- [ ] Migrate `blab` as a test
