### PR TITLE
Canary deploys and user flag for auto-redirection

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -20,6 +20,10 @@ Deploys to the production app are performed by manually [promoting](https://devc
 
 ### Environment variables
 
+  - `NODE_ENV` is used to condition behaviour between production and non-production environments, following the widely-used convention set by Express.
+    Its value affects not just the explicit conditionals in this repo but also Express and other layers in our dependencies.
+    All our Heroku apps [run under `NODE_ENV=production`](https://devcenter.heroku.com/articles/nodejs-support#runtime-behavior).
+
   - `SESSION_SECRET` must be set to a long, securely generated string.
     It protects the session data stored in browser cookies.
     Changing this will invalidate all existing sessions and forcibly logout people.

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -2,7 +2,7 @@
 
 ## Domains
 
-**nextstrain.org** and **dev.nextstrain.org** are [hosted on Heroku](#heroku).
+**nextstrain.org**, **next.nextstrain.org**, and **dev.nextstrain.org** are [hosted on Heroku](#heroku).
 
 **data.nextstrain.org** is an AWS CloudFronted S3 bucket, [`nextstrain-data`](#nextstrain-data).
 
@@ -12,8 +12,11 @@
 
 ## Heroku
 
-The production Heroku app is [`nextstrain-server`](https://dashboard.heroku.com/apps/nextstrain-server), which is part of a [Heroku app pipeline of the same name](https://dashboard.heroku.com/pipelines/38f67fc7-d93c-40c6-a182-501da2f89d9d).
-Deploys of `master` happen automatically after Travis CI tests are successful.
+We use a [Heroku pipeline named `nextstrain-server`](https://dashboard.heroku.com/pipelines/38f67fc7-d93c-40c6-a182-501da2f89d9d) to manage multiple related apps.
+The production app serving **nextstrain.org** is [`nextstrain-server`](https://dashboard.heroku.com/apps/nextstrain-server).
+The canary app serving **next.nextstrain.org** is [`nextstrain-canary`](https://dashboard.heroku.com/apps/nextstrain-canary).
+Deploys of `master` to the canary app happen automatically after Travis CI tests are successful.
+Deploys to the production app are performed by manually [promoting](https://devcenter.heroku.com/articles/pipelines#promoting) the canary's current release to production.
 
 ### Environment variables
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -41,6 +41,10 @@ Deploys to the production app are performed by manually [promoting](https://devc
     If not provided, requests to the GitHub API are unauthenticated.
     The token we use in production is associated with the `nextstrain-bot` GitHub user.
 
+  - `CANARY_ORIGIN` is the origin of a canary deployment to redirect to for users who are opted-in to the `canary` flag (the `!flags/canary` Cognito group).
+    Redirection does not happen if this variable is not defined or if the request's origin already matches this variable's value.
+    In production we set this to `https://next.nextstrain.org`.
+
 ### Redis add-on
 
 The [Heroku Redis](https://elements.heroku.com/addons/heroku-redis) add-on is attached to our `nextstrain-server` and `nextstrain-dev` apps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17697,6 +17697,11 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
+    "lodash.partition": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
+      "integrity": "sha1-o45GtzRp4EILDaEhLmbUFL42S6Q="
+    },
     "lodash.range": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.1.7.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10816,9 +10816,9 @@
       }
     },
     "cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -12377,6 +12377,11 @@
             "mime-types": "~2.1.24",
             "negotiator": "0.6.2"
           }
+        },
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
         },
         "mime-db": {
           "version": "1.40.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "iso-639-1": "^2.1.0",
     "jose": "npm:jose-node-cjs-runtime@^3.11.3",
     "js-yaml": "^4.0.0",
+    "lodash.partition": "^4.6.0",
     "make-fetch-happen": "https://github.com/tsibley/make-fetch-happen/tarball/882cb8bdb9f017268c4f0f2ce41b4df6f7ff9be9",
     "marked": "^0.7.0",
     "mime": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "compression": "^1.7.3",
     "connect-redis": "^4.0.3",
     "content-type": "^1.0.4",
+    "cookie": "^0.4.2",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-naked-redirect": "^0.1.2",

--- a/src/app.js
+++ b/src/app.js
@@ -69,6 +69,16 @@ app.use(middleware.rejectParentTraversals);
  */
 app.use((req, res, next) => {
   req.context = {};
+
+  // Set the app's origin centrally so other handlers can use it
+  //
+  // We can trust the HTTP Host header (req.hostname) because we're always
+  // running behind name-based virtual hosting on Heroku.  A forged Host header
+  // will be rejected by Heroku and never make it to us.
+  req.context.origin = PRODUCTION
+    ? `${req.protocol}://${req.hostname}`
+    : `${req.protocol}://${req.hostname}:${req.app.get("port")}`;
+
   next();
 });
 

--- a/src/app.js
+++ b/src/app.js
@@ -8,7 +8,7 @@ const cors = require('cors');
 const {addAsync} = require("@awaitjs/express");
 const {Forbidden, NotFound, Unauthorized} = require("http-errors");
 
-const production = process.env.NODE_ENV === "production";
+const PRODUCTION = process.env.NODE_ENV === "production";
 
 const authn = require("./authn");
 const endpoints = require("./endpoints");
@@ -50,12 +50,12 @@ const app = addAsync(express());
 
 app.set("json replacer", jsonReplacer);
 
-app.locals.production = production;
-app.locals.gatsbyDevUrl = production ? null : process.env.GATSBY_DEV_URL;
+app.locals.production = PRODUCTION;
+app.locals.gatsbyDevUrl = PRODUCTION ? null : process.env.GATSBY_DEV_URL;
 
 // In production, trust Heroku as a reverse proxy and Express will use request
 // metadata from the proxy.
-if (production) app.enable("trust proxy");
+if (PRODUCTION) app.enable("trust proxy");
 
 app.use(sslRedirect()); // redirect HTTP to HTTPS
 app.use(compression()); // send files (e.g. res.json()) using compression (if possible)
@@ -90,7 +90,7 @@ redirects.setup(app);
 
 /* Charon API used by Auspice.
  */
-if (!production) {
+if (!PRODUCTION) {
   // allow cross-origin from the gatsby dev server
   app.use("/charon", cors({origin: 'http://localhost:8000'}));
 }

--- a/src/authn/bearer.js
+++ b/src/authn/bearer.js
@@ -44,6 +44,9 @@ var passport = require('passport-strategy')
  *   - `realm`  authentication realm, defaults to "Users"
  *   - `scope`  list of scope values indicating the required scope of the access
  *              token for accessing the requested resource
+ *   - `passReqToCallback` pass `req` to the `verify` callback with the
+ *                         signature `verify(req, token, done)` (defaults to
+ *                         false)
  *   - `passIfMissing` instead of failing, pass if no `Authorization` header was
  *                     present in the request (defaults to false)
  *

--- a/src/authn/index.js
+++ b/src/authn/index.js
@@ -36,8 +36,8 @@ const COGNITO_JWKS = createRemoteJWKSet(new URL(`${COGNITO_USER_POOL_URL}/.well-
 const COGNITO_BASE_URL = "https://login.nextstrain.org";
 
 const COGNITO_CLIENT_ID = PRODUCTION
-  ? "rki99ml8g2jb9sm1qcq9oi5n"    // prod client limited to nextstrain.org
-  : "6q7cmj0ukti9d9kdkqi2dfvh7o"; // dev client limited to localhost and heroku dev instances
+  ? "rki99ml8g2jb9sm1qcq9oi5n"    // prod client limited to nextstrain.org (and next. and dev.)
+  : "6q7cmj0ukti9d9kdkqi2dfvh7o"; // dev client limited to localhost
 
 /* Registered clients to accept for Bearer tokens.
  *

--- a/src/authn/index.js
+++ b/src/authn/index.js
@@ -171,16 +171,18 @@ function setup(app) {
       user.authzRoles = new Set(user.authzRoles);
     }
 
-    /* Update existing sessions that pre-date the presence of authzRoles.  When
-     * authzRoles is absent, "groups" is the unparsed set of Cognito groups.
-     */
-    if (!("authzRoles" in user)) {
-      const {groups, authzRoles} = parseCognitoGroups(user.groups || []);
-      utils.verbose(`Upgrading groups and authzRoles of user object for ${user.username}`);
+    const update = (originalCognitoGroups, reason) => {
+      const {groups, authzRoles} = parseCognitoGroups(originalCognitoGroups);
+      utils.verbose(`Updating user object for ${user.username}: ${reason}`);
       user.groups = groups;
       user.authzRoles = authzRoles;
       user[RESAVE_TO_SESSION] = true;
-    }
+    };
+
+    /* Update existing sessions that pre-date the presence of authzRoles.  When
+     * authzRoles is absent, "groups" is the unparsed set of Cognito groups.
+     */
+    if (!("authzRoles" in user)) update(user.groups || [], "missing authzRoles");
 
     return done(null, user);
   });

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,4 +1,6 @@
+const cookie = require("cookie");
 const {BadRequest} = require("http-errors");
+const utils = require("./utils");
 
 
 /**
@@ -36,6 +38,31 @@ const rejectParentTraversals = (req, res, next) => {
 };
 
 
+/**
+ * Copies a request cookie from *oldName* to *newName*.
+ *
+ * Modifies the HTTP Cookie header in `req.headers` to make it appear as if the
+ * same data was sent for both cookie names.
+ *
+ * The copy only happens if the old cookie is sent and the new cookie is not.
+ */
+const copyCookie = (oldName, newName) => (req, res, next) => {
+  const rawCookies = cookie.parse(req.headers.cookie ?? "", {decode: String});
+
+  const oldCookie = rawCookies[oldName];
+  const newCookie = rawCookies[newName];
+
+  if (oldCookie && !newCookie) {
+    utils.verbose(`Copying cookie ${oldName} to ${newName}`);
+    // Appending is safe because we know there is an existing cookie already
+    req.headers.cookie += `; ${newName}=${oldCookie}`;
+  }
+
+  return next();
+};
+
+
 module.exports = {
   rejectParentTraversals,
+  copyCookie,
 };


### PR DESCRIPTION
### Description of proposed changes
Implements #485 and #492.

The former was mostly done on the Heroku side, but is described in updated doc here in https://github.com/nextstrain/nextstrain.org/commit/2e78f0f9123552f5bda1c363d6f99c73cdb9f666.

The latter is https://github.com/nextstrain/nextstrain.org/commit/9ed028ce3214e1d795e24e958c9d5654d1f3b5f3 which makes use of the more general groundwork laid in the earlier commits.

### Testing

- [x] Tested locally by hand in many configurations and with old sessions.
- [x] Test deploy on dev.nextstrain.org with next.nextstrain.org
- [x] Appears to be some funkiness related to interaction with existing host-only cookies and new domain-wide cookies. Need to dig more next week.

### Deploy
- [x] Set `CANARY_ORIGIN` on nextstrain-server and nextstrain-canary
- [ ] Add some folks to `!flags/canary`
- [ ] Remove `CANARY_ORIGIN` from nextstrain-dev after testing this PR