### PR TITLE
authn: Touch sessions after setting cookie.domain and before manually re-saving

### DIFF
--- a/src/authn/index.js
+++ b/src/authn/index.js
@@ -305,6 +305,7 @@ function setup(app) {
       if (req.session?.cookie && req.session.cookie.domain !== SESSION_COOKIE_DOMAIN) {
         utils.verbose(`Updating session cookie domain to ${SESSION_COOKIE_DOMAIN} (was ${req.session.cookie.domain})`);
         req.session.cookie.domain = SESSION_COOKIE_DOMAIN;
+        req.session.touch();
         return req.session.save(next);
       }
       return next();


### PR DESCRIPTION
### Description of proposed changes

Fixes "authn: Share our session cookie across nextstrain.org and
subdomains" (6be074e) for sessions which have a stored "cookie.expires"
property in the past.

Such sessions were receiving HTTP 500 errors because the manual
session.save() added by that commit caused connect-redis to recalculate
the Redis key TTL based on "session.cookie.expires - now" which
evaluated to an invalid negative value.  express-session always touches
the session, updating its cookie.expires (in our case based on the
maxAge value we configure), before the implicit save at the end of the
request (if a save will happen).  Do the same when we manually re-save.

Sessions are able to get a cookie.expires that's in the past because we
configure express-session with {rolling: true, resave: false}.  This
means the cookie is sent to the browser on every response with a new
expires (prolonging its life) and the session key in the store (Redis)
is touched (prolonging its life), but the actual session data (including
the cookie details) is only re-saved to the store when the session is
actually modified (and cookie modifications don't count).  This issue
didn't arise in development and testing because you need to have a very
specific kind of session and in local dev a FileStore is usually used
instead of Redis, which has different behaviour.  (FileStore re-saves
the session cookie data on touch.)

See also my unrefined debugging notes¹ for more details.

¹ https://github.com/tsibley/blab-standup/blob/master/2022-04-07.md#7-april-2022

### Related issue(s)
Fixes bug introduced by #500.

### Testing
Tested by reproducing the bug locally and then confirming this fixes it, both for logged in and logged out sessions.

Tomorrow I'll plan to merge and wait for this to deploy to the canary, and hopefully we can get one of the users affected today (from office hours?) to try it out then and confirm it works for them before promoting to production.