### PR TITLE
Include "nextclade" as top-level path for Auspice

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -157,6 +157,7 @@ const coreBuildPaths = [
   "/mers",
   "/mumps",
   "/ncov",
+  "/nextclade",
   "/tb",
   "/WNV",
   "/yellow-fever",


### PR DESCRIPTION
Including this allows posting nextclade reference trees to https://nextstrain.org/nextclade/sars-cov-2, etc...
