### PR TITLE
Switch Nextstrain CLI setup in the GitHub Actions workflows to our new shared action

### DIFF
--- a/.github/workflows/update-dataset-listings.yml
+++ b/.github/workflows/update-dataset-listings.yml
@@ -14,12 +14,10 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 14
+    - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
     - name: update dataset listings # currently just /staging and /influenza use these
       run: |
         npm ci
-        python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install nextstrain-cli
-        PATH="$HOME/.local/bin:$PATH"
         ./scripts/collect-datasets.js --keyword flu
         nextstrain remote upload s3://nextstrain-data data/datasets_influenza.json
         ./scripts/collect-datasets.js --keyword staging

--- a/.github/workflows/update-search.yml
+++ b/.github/workflows/update-search.yml
@@ -20,12 +20,10 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 14
+    - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
     - name: update sars-cov-2 search
       run: |
         npm ci
-        python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install nextstrain-cli
-        PATH="$HOME/.local/bin:$PATH"
         ./scripts/collect-search-results.js --pathogen sars-cov-2
         nextstrain remote upload s3://nextstrain-data ./data/search_sars-cov-2.json
       env:


### PR DESCRIPTION
Resolves issues with system Python described in
<https://github.com/nextstrain/cli/issues/171>, but also makes future
maintenance easier by standardizing and centralizing how `nextstrain` is
installed.

Before merging:

- [x] Merge https://github.com/nextstrain/.github/pull/17
- [ ] Drop tip `tmp!` commit on this branch