### PR TITLE
Deploy to Heroku from CI after tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,72 @@ jobs:
           aws-secret-access-key: ${{ secrets.DEV_SERVER_AWS_SECRET_ACCESS_KEY }}
       - run: aws sts get-caller-identity
       - run: npm run test:ci
+
+  # XXX TODO: It'd be nice to avoid the rebuild on Heroku and instead deploy
+  # the artifacts (source code + generated files + node_modules/) already built
+  # above.  This would dramatically reduce deploy times and move us closer to
+  # "deploy what you tested", but it may also run into platform compatibility
+  # issues given CI is building on a different platform (arch + OS + sys libs)
+  # than Heroku's dynos and some deps are compiled.  But should try it and see!
+  # Or do our build above inside a Heroku buildpack…
+  #   -trs, 2 May 2022
+  deploy:
+    if: |2
+         github.repository == 'nextstrain/nextstrain.org'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/master'
+
+    # Wait for "test" job above to pass.
+    needs: test
+
+    # Only one "deploy" job at a time.
+    concurrency: deploy
+
+    # Name a GitHub environment configuration¹ to auto-create deployment
+    # records in GitHub based on this job's progress/status.  Also grants
+    # access to environment-specific secrets.
+    #
+    # The URL is specific to this deployment, not the environment (i.e. an
+    # environment have deployments at different URLs).
+    #
+    # ¹ https://github.com/nextstrain/nextstrain.org/settings/environments
+    environment:
+      name: heroku
+      url: https://next.nextstrain.org
+
+    # Deploy steps
+    runs-on: ubuntu-latest
+    env:
+      HEROKU_APP: nextstrain-canary
+    steps:
+      - name: Login to Heroku
+        run: echo "machine api.heroku.com login $HEROKU_USER password $HEROKU_TOKEN" >> ~/.netrc
+        env:
+          HEROKU_USER: "${{ secrets.HEROKU_USER }}"
+          HEROKU_TOKEN: "${{ secrets.HEROKU_TOKEN }}"
+
+      - name: Define Heroku build source
+        run: |
+          jq --null-input '{
+            "source_blob": {
+              "url": "https://github.com/\(env.GITHUB_REPOSITORY)/archive/\(env.GITHUB_SHA).tar.gz",
+              "version": env.GITHUB_SHA
+            }
+          }' | tee build-source.json
+
+      - name: Start Heroku build
+        run: |
+          curl https://api.heroku.com/apps/"$HEROKU_APP"/builds \
+            --fail --silent --show-error --location --netrc \
+            --data-binary @build-source.json \
+            --header 'Content-Type: application/json' \
+            --header 'Accept: application/vnd.heroku+json; version=3' \
+              | tee build.json
+
+      - name: Monitor Heroku build
+        run: |
+          curl "$(jq -r .output_stream_url build.json)" \
+            --fail --silent --show-error --location
+
+      - name: Logout of Heroku
+        run: sed -i -e '/^machine api\.heroku\.com/d' ~/.netrc


### PR DESCRIPTION
Restores auto-deploy of master to the canary app since Heroku (as of
today) still doesn't have an ETA for restoration of their GitHub
integration.¹

¹ https://status.heroku.com/incidents/2413

### Setup

- [x] Created ["heroku" environment](https://github.com/nextstrain/nextstrain.org/settings/environments/482814264/edit) for this repo to hold `HEROKU_USER` and `HEROKU_TOKEN` secrets for the deploy job. Token is associated with [an API authorization](https://dashboard.heroku.com/account/applications#authorizations) I created in the Heroku service account. The environment includes branch-based protection rules to only allow workflows running in context of `master`.

### Testing

- [x] [Confirmed](https://github.com/nextstrain/nextstrain.org/actions/runs/2265097904) that the deploy job worked when temporarily adjusted to run on this branch instead of `master` (with the environment protection rules temporarily adjusted too).
- [x] [Confirmed](https://github.com/nextstrain/nextstrain.org/actions/runs/2265280093) that the environment protection rules work as expected. For example, the deploy job was blocked when the CI workflow ran in the context of this branch, `trs/ci/deploy`, but the environment was configured to only allowed deploys from the context of `master`.
- [x] [Confirmed](https://github.com/nextstrain/nextstrain.org/actions/runs/2265318621) that the deploy job is skipped on non-master branch pushes and non-push events (the final expected configuration of the workflow).
- [x] Reviewed workflow logs above to ensure nothing secret or too sensitive is disclosed, since these logs are available to any logged in GitHub user. Information revealed includes several Heroku ids (app id, build id, user id) and the Heroku build logs. I believe all are non-sensitive, and I tested (using an unaffiliated Heroku user) that having the various ids doesn't give you Heroku API access to those resources.