### PR TITLE
Unauthorized vs. Forbidden error responses

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -439,8 +439,9 @@ app.useAsync(async (err, req, res, next) => {
         return res.redirect("/login");
       }
       err = new Unauthorized(err.message); // eslint-disable-line no-param-reassign
+    } else {
+      err = new Forbidden(err.message); // eslint-disable-line no-param-reassign
     }
-    err = new Forbidden(err.message); // eslint-disable-line no-param-reassign
   }
 
   /* Browser-like clients get JSON if they explicitly ask for it (regardless of

--- a/src/authn/bearer.js
+++ b/src/authn/bearer.js
@@ -42,8 +42,6 @@ var passport = require('passport-strategy')
  * Options:
  *
  *   - `realm`  authentication realm, defaults to "Users"
- *   - `scope`  list of scope values indicating the required scope of the access
- *              token for accessing the requested resource
  *   - `passReqToCallback` pass `req` to the `verify` callback with the
  *                         signature `verify(req, token, done)` (defaults to
  *                         false)
@@ -80,9 +78,6 @@ function Strategy(options, verify) {
   this.name = 'bearer';
   this._verify = verify;
   this._realm = options.realm || 'Users';
-  if (options.scope) {
-    this._scope = (Array.isArray(options.scope)) ? options.scope : [ options.scope ];
-  }
   this._passReqToCallback = options.passReqToCallback;
   this._passIfMissing = options.passIfMissing === undefined ? false : options.passIfMissing;
 }
@@ -149,9 +144,6 @@ Strategy.prototype.authenticate = function(req) {
  */
 Strategy.prototype._challenge = function(code, desc, uri) {
   var challenge = 'Bearer realm="' + this._realm + '"';
-  if (this._scope) {
-    challenge += ', scope="' + this._scope.join(' ') + '"';
-  }
   if (code) {
     challenge += ', error="' + code + '"';
   }

--- a/test/auspice_client_requests.json
+++ b/test/auspice_client_requests.json
@@ -61,7 +61,7 @@
   {
     "name": "Check getSourceInfo API for a (private) nextstrain groups splash page",
     "url": "/charon/getSourceInfo?prefix=/groups/blab-private/",
-    "expectStatusCode": 403
+    "expectStatusCode": 401
   },
   {
     "name": "Check getAvailable API for a (public) nextstrain group",
@@ -139,7 +139,7 @@
   {
     "name": "Attempt to access a private Nextstrain Group when not logged in",
     "url": "/charon/getAvailable?prefix=/groups/blab-private",
-    "expectStatusCode": 403
+    "expectStatusCode": 401
   },
   {
     "name": "Get Source Info for a group which doesn't exist",


### PR DESCRIPTION
The intent was for AuthzDenied errors to be translated to 401 Unauthorized and 403 Forbidden responses depending on the context, but this distinction was accidentally lost in "Handle authz failures in the app-wide error handler" (https://github.com/nextstrain/nextstrain.org/commit/fe2e5bd1bb3e5c8a5832692d384fbfdd918b70c7).  What were throws became assignments to "err" without corresponding changes to keep the control flow the same.

Also includes a small authn simplification I noticed while confirming some details of the 401 responses.

### Testing
On prod:
```
$ curl -sI https://nextstrain.org/groups/nextflu-private/ | head -n1
HTTP/1.1 403 Forbidden

$ curl -sI https://nextstrain.org/groups/nextflu-private/ -H "Authorization: Bearer $(ini ~/.nextstrain/secrets authn id_token)" | head -n1
HTTP/1.1 403 Forbidden
```

On this branch:
```
$ curl -sI localhost:5000/groups/nextflu-private/ | head -n1
HTTP/1.1 401 Unauthorized

$ curl -sI localhost:5000/groups/nextflu-private/ -H "Authorization: Bearer $(ini ~/.nextstrain/secrets authn id_token)" | head -n1
HTTP/1.1 403 Forbidden
```

(My user is not part of the `nextflu-private` group.)