### PR TITLE
Refresh user info

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ nextstrain.org
     :maxdepth: 2
 
     authz
+    sessions
     routing
     infrastructure
     glossary

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -30,6 +30,11 @@ Deploys to the production app are performed by manually [promoting](https://devc
     It protects the session data stored in browser cookies.
     Changing this will invalidate all existing sessions and forcibly logout people.
 
+  - `SESSION_ENCRYPTION_KEYS` must be set to a URL query param string encoding pairs of key names and base64-encoded key material.
+    These keys protect sensitive data in the session (such as authn tokens) when session data is "at rest" (such as in Redis).
+    You may prepend new keys to use for new sessions (i.e. key rotation) but do not drop old keys or old sessions will be unusable and people will be forcibly logged out.
+    Keys must be 256 bits in length.
+
   - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are tied to the `nextstrain.org` AWS IAM user.
     These credentials allow the backend web server limited access to private S3 buckets.
 

--- a/docs/sessions.rst
+++ b/docs/sessions.rst
@@ -1,0 +1,226 @@
+========
+Sessions
+========
+
+Each request has an associated session object (``req.session``).  If the
+session object is modified during the request, then a *persistent* session is
+established at the end of the request by sending a cookie to the browser and
+setting a key in Redis (see :ref:`session-storage`).  If unmodified, the
+session object is considered ephemeral and not stored.
+
+Persistent sessions are currently only established when initiating interactive
+login.  While in most cases login is then completed successfully and the
+session becomes an *authenticated* session (i.e. it's associated with a logged
+in user), some unauthenticated sessions do exist.
+
+The rest of this document applies to *persistent* sessions (not ephemeral
+sessions), primarily those that are *authenticated*.
+
+
+Contents
+========
+
+Sessions primarily contain:
+
+User authn tokens
+    OAuth2 id, access, and refresh tokens provided by Cognito after interactive
+    login and renewed automatically as needed by us.  If available, then the
+    tokens are used to reconstruct the request user object (``req.user``) and
+    the session-stored user object is ignored.
+
+    Managed by our own authn layer.
+
+User object
+    Serialized representation of the request user object (``req.user``), if the
+    session is authenticated.  User objects undergo a separate
+    serialization/deserialization step before session
+    serialization/deserialization.  Only used to reconstruct the ``req.user``
+    if the session predates storing user tokens.
+
+    Managed by ``passport`` (e.g. by calling ``req.login(…)``).
+
+Cookie metadata
+    Details about the last cookie sent to the browser.
+
+    Managed mostly by the ``express-session`` middleware.
+
+
+.. _session-storage:
+
+Storage
+=======
+
+Client
+------
+
+Session ids are stored in the browser in a ``nextstrain.org-session`` cookie.
+Ids are signed using a secret known only to the server
+(:envvar:`SESSION_SECRET`) to prevent tampering.
+
+Server
+------
+
+Session objects are stored in Redis under keys like
+``nextstrain.org-session:${session.id}``.  Objects are serialized/deserialized
+as JSON.
+
+.. note::
+    If Redis is not configured (e.g. in local development), then sessions are
+    stored on the filesystem under :file:`sessions/{session.id}.json`.
+
+
+Lifetime
+========
+
+Sessions have a rolling expiration of 30 days, reset on each request.  TTLs are
+applied to both the cookie and to the Redis keys.
+
+.. note::
+    While a session's TTL is updated on every request, the serialized session
+    objects themselves are only updated when necessary to avoid unnecessary
+    writes.
+
+
+Security
+========
+
+Client
+------
+
+The primary client-side risks to sessions are:
+
+- Session hijacking (theft of cookie)
+- Confused deputy attacks, clickjacking, etc. (abuse of cookie)
+
+In order to lower the risk of these, the session cookie is marked with several
+attributes that together minimize its visiblity/use:
+
+- ``Secure`` to forbid transmission over HTTP and require HTTPS
+  (`reference <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#secure>`__)
+
+- ``HttpOnly`` to forbid access by JavaScript
+  (`reference <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#httponly>`__)
+
+- ``SameSite=Lax`` to forbid transmission in cross-site subrequests (e.g. when
+  embedded in an iframe on another site) but permit transmission on navigation
+  (e.g. when clicking a link to nextstrain.org from another site)
+  (`reference <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#lax>`__)
+
+However, the cookie is also marked with one attribute that **broadens** its
+visibility a bit:
+
+- ``Domain=nextstrain.org`` to allow transmission to all subdomains of
+  nextstrain.org (e.g. share sessions across next.nextstrain.org and
+  nextstrain.org)
+  (`reference <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value>`__)
+
+The risk added by the ``Domain`` attribute is because the cookie will also be
+sent to subdomains hosted by third-party services, like docs.nextstrain.org,
+support.nextstrain.org, and others.  While we do "trust" these providers, they
+increase the surface area for potential session hijacking via cookie theft.
+One big mitigation is that the cookie is HTTPS-only, so client-side JavaScript
+injections via those providers (which are much much more likely than
+server-side injections) still couldn't access the cookie.  All together, this
+added risk seems acceptable and worth the UX improvement of session sharing.
+
+Future protections
+^^^^^^^^^^^^^^^^^^
+
+To remove the third-party subdomain risk, we could:
+
+- move our internal services off the user-facing domain (e.g. use
+  support.nextstrain-team.org or support.nextstrain.dev instead).
+  
+- accomplish session portability another way (e.g. explicit SSO by
+  next.nextstrain.org against nextstrain.org as an IdP instead of implicit SSO
+  via session sharing).
+
+
+Server
+------
+
+The primary server-side risks to sessions (excluding authn/authz bugs) are
+theft or leakage of sensitive session data from Redis.  Sensitive data stored
+in sessions includes:
+
+Session ids
+    Sensitive because they would form the basis for session hijacking or session
+    fixation.
+
+User authn tokens
+    Sensitive because they have the future potential to (although do not
+    currently) provide access to:
+
+    - nextstrain.org to see private data or make changes to data (but currently
+      Bearer authn is only accepted for the Nextstrain CLI's client id)
+
+    - our AWS Cognito user pool to modify the user's own Cognito record (but
+      currently the ``aws.cognito.signin.user.admin`` scope is not granted)
+
+    They also embed some private user info like email and name (and potentially
+    phone, if set).
+
+Access to this stored data requires authentication with a long random password.
+Data is protected in transit between the nextstrain.org server and Redis by
+TLS.  The Redis instance listens on a public IP and uses a self-signed cert,
+neither of which are ideal, but unfortunately these are out of our immediate
+control.
+
+Layered protections exist to reduce the consequences of session data leakage,
+theft, or modification (e.g. by a breach of our Redis instance) if it did
+happen:
+
+- Direct re-use of the session ids in Redis is not possible since session ids
+  in cookies must be signed using a secret known only to the server
+  (:envvar:`SESSION_SECRET`).
+
+- Authn tokens are encrypted at rest in Redis using symmetric AES-GCM
+  encryption with 256-bit keys known only to the server
+  (:envvar:`SESSION_ENCRYPTION_KEYS`) and derived data keys.  Encryption
+  context is used to ensure that the encrypted keys can't be copied from one
+  session to another by someone who can modify session data.  See the comments
+  at the top of :file:`src/cryptography.js` for more details on the encryption
+  choices.
+
+Future protections
+^^^^^^^^^^^^^^^^^^
+
+To remove the unnecessary risks of Redis listening on a public IP and using a
+TLS cert we cannot verify, we'd have to (in rough order of increasing effort):
+
+- pay for Heroku's VPC feature, Private Spaces, which is Enterprise-only (and
+  thus likely $$$).
+
+- switch PaaS providers away from Heroku to Render or Fly.io, both of which
+  support internal-only services and offer managed Redis (but lose some nice
+  Heroku features, like pipelines/promotion).
+
+- run Redis ourselves as a sidecar dyno on Heroku and setup our own VPC overlay
+  network with something like Tailscale.
+
+None of these seem worth it at the current time all things considered.
+
+
+Environment variables
+=====================
+
+.. envvar:: SESSION_SECRET
+
+    Must be set to a long, securely-generated string.  It protects the session
+    data stored in browser cookies.  Changing this will invalidate all existing
+    sessions and forcibly logout people.
+
+    Outside of production mode, this env var is **ignored** and the secret is
+    an insecure fixed string.
+
+.. envvar:: SESSION_ENCRYPTION_KEYS
+
+    Must be set to a URL query param string encoding pairs of key names and
+    base64-encoded key material.  These keys protect sensitive data in the
+    session (such as authn tokens) when session data is "at rest" (such as in
+    Redis).  You may prepend new keys to use for new sessions (i.e. key
+    rotation) but do not drop old keys or old sessions will be unusable and
+    people will be forcibly logged out.  Keys must be 256 bits in length.
+
+    Outside of production mode, if this env var is not provided then a randomly
+    generated key is used.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,41 @@
 /* eslint-disable quote-props */
 module.exports = {
+  /* Run tests in a normal Node environment, not a fake browser (JSDOM)
+   * environment.  This is a Node app after all.  But this also fixes an
+   * long-known issue where Jest breaks the Node stdlib by providing a Buffer
+   * that's not a subclass of Uint8Array, see:
+   *
+   *    https://github.com/facebook/jest/issues/4422
+   *
+   * This subclass relationship is relied on by many things dealing with
+   * Buffers and typed arrays, including the @aws-crypto/… libraries.
+   *
+   * A suggested workaround from the issue discussion is to add:
+   *
+   *    globals: {"Uint8Array": Uint8Array}
+   *
+   * to the Jest config, and at first this appears to work if you run a single
+   * affected test file.  However, it doesn't work when running multiple test
+   * files unless the --runInBand option is also used, implicating the worker
+   * subprocess system.
+   *
+   * The Jest config docs give a clue here:
+   *
+   *    In addition, the globals object must be json-serializable, so it can't
+   *    be used to specify global functions…
+   *
+   * This means the workaround above shouldn't be expected to work at all, even
+   * though it happens to work for single test files (presumably because
+   * they're run in the same process and thus skip serialization so the value
+   * is preserved?).
+   *
+   * Adding to the confusion, Node is the default testEnvironment for recent
+   * versions of Jest (at least 28.x), but not the version we're using here
+   * (26.x).  Being explicit won't hurt when we upgrade, but this difference
+   * led me astray for a bit.
+   *   -trs, 20 May 2022
+   */
+  "testEnvironment": "node",
   "testMatch": [
     "**/*.test.js"
   ],

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+/* eslint-disable quote-props */
+module.exports = {
+  "testMatch": [
+    "**/*.test.js"
+  ],
+  "globals": {
+    "BASE_URL": "http://localhost:5000"
+  },
+  "setupFilesAfterEnv": [
+    "jest-extended/all"
+  ]
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,72 @@
       "resolved": "https://registry.npmjs.org/@awaitjs/express/-/express-0.6.3.tgz",
       "integrity": "sha512-x7N92+Rmy/WHEaXXunV2ArVa/AqzkJlouc8pokuVF9h6DeUtbkPaEKVYKMDEFs2u5Hbw2XfwGVyLf69yr2UG5g=="
     },
+    "@aws-crypto/cache-material": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/cache-material/-/cache-material-3.1.0.tgz",
+      "integrity": "sha512-fC59BV0YoxSSzI8bIAWLjaKrP52iOqey0NSvsZ5/kV/UwJp8VtDfD7UC5UneORQh1luRw8ZnC0kx0wHbqG/+iw==",
+      "requires": {
+        "@aws-crypto/material-management": "^3.1.0",
+        "@aws-crypto/serialize": "^3.1.0",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@aws-crypto/caching-materials-manager-node": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-3.1.0.tgz",
+      "integrity": "sha512-1cb/XVb43RRq1PYdzBPyycfH+1ASZ6DfQ2GbSLFrMgPLvhnxoyyv+Bd5QlvViIREn3xIXa1gupeGJz6BaayFXQ==",
+      "requires": {
+        "@aws-crypto/cache-material": "^3.1.0",
+        "@aws-crypto/material-management-node": "^3.1.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@aws-crypto/client-node": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-3.1.1.tgz",
+      "integrity": "sha512-WdbYBxbB5onE4LVab5q7fByNiAAmL4Y+pGCaDOl6RLLH17xHBfyQHHeG+5+Xloygh/aWR42So8LhLPhGmral3g==",
+      "requires": {
+        "@aws-crypto/caching-materials-manager-node": "^3.1.0",
+        "@aws-crypto/decrypt-node": "^3.1.0",
+        "@aws-crypto/encrypt-node": "^3.1.1",
+        "@aws-crypto/kms-keyring-node": "^3.1.0",
+        "@aws-crypto/material-management-node": "^3.1.0",
+        "@aws-crypto/raw-aes-keyring-node": "^3.1.0",
+        "@aws-crypto/raw-rsa-keyring-node": "^3.1.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
     "@aws-crypto/crc32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
@@ -42,6 +108,103 @@
         }
       }
     },
+    "@aws-crypto/decrypt-node": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-3.1.0.tgz",
+      "integrity": "sha512-F0TlNkdy11m1BCfhPQAXvdKHg82tAeOIc+tYXCL6ND/I3zh0F8oqVdr5oIuv4B6aIOgSSnAym0ctbAs8jw3pBA==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^3.1.0",
+        "@aws-crypto/serialize": "^3.1.0",
+        "@types/duplexify": "^3.6.0",
+        "duplexify": "^4.1.1",
+        "readable-stream": "^3.6.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "duplexify": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+          "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@aws-crypto/encrypt-node": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-3.1.1.tgz",
+      "integrity": "sha512-LfB6LC1DhpsMCN2M24SgtR9m8CC2lTyO5w5mBWCsk+8h4BvhQXcgfruvHabGfDn4L+2Lr97nT9/THstNCuVVyg==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^3.1.0",
+        "@aws-crypto/serialize": "^3.1.0",
+        "@types/duplexify": "^3.6.0",
+        "duplexify": "^4.1.1",
+        "readable-stream": "^3.6.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "duplexify": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+          "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@aws-crypto/hkdf-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/hkdf-node/-/hkdf-node-3.0.0.tgz",
+      "integrity": "sha512-boeNV9G3Jk6W5Q9Zcj8yGqIOoQ2PwB+yvA/xFUazlu6qTtGRTviqkVx0Bf6r68KrkvmIY/9STN0mlF9q3jzPcQ==",
+      "requires": {
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
     "@aws-crypto/ie11-detection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
@@ -54,6 +217,145 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/kms-keyring": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring/-/kms-keyring-3.1.0.tgz",
+      "integrity": "sha512-Z7hlnLs+8tz4XeRY6ZLccJ0TC7E1YJHLj5RuirZf/80tVmk9yJuicquLzev/5n2f0a01t7U4oyO2n8ahN81Isw==",
+      "requires": {
+        "@aws-crypto/material-management": "^3.1.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@aws-crypto/kms-keyring-node": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-3.1.0.tgz",
+      "integrity": "sha512-8SVn+Vz0HU3FXfHc6jdm4yvrAVssN7t5F9s3zzvKdb8w8u7vLpzZiLEw5TonmZD4KwBqG4YbciTX8wtXx3PUIw==",
+      "requires": {
+        "@aws-crypto/kms-keyring": "^3.1.0",
+        "@aws-crypto/material-management-node": "^3.1.0",
+        "aws-sdk": "^2.650.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@aws-crypto/material-management": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management/-/material-management-3.1.0.tgz",
+      "integrity": "sha512-bkxu2wr+Wk2KXpN/mDaGFbx2j5UoqqACAEecWzTpP8XafW9z8rzdVqtDp/3hUeytXrS0w+UwFtZQw1A946C5Ow==",
+      "requires": {
+        "asn1.js": "^5.3.0",
+        "bn.js": "^5.1.1",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@aws-crypto/material-management-node": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-3.1.0.tgz",
+      "integrity": "sha512-QX4JUqVydtskQbsKgd9JgTjzmrgYVaTOeguoV2KGz9TfqT//GDFUAL9jI6x20FdPH0A5D6BfgAAXzcUqjSWN5g==",
+      "requires": {
+        "@aws-crypto/hkdf-node": "^3.0.0",
+        "@aws-crypto/material-management": "^3.1.0",
+        "@aws-crypto/serialize": "^3.1.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@aws-crypto/raw-aes-keyring-node": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-3.1.0.tgz",
+      "integrity": "sha512-td1BH2OJks1PMkuHrMcwPJwVmyzsCrj1H9vqNnuw26dz9ZIdW8+e8DTv68WWUoCv43Qc6osmnGsTy7JjvGPzMQ==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^3.1.0",
+        "@aws-crypto/raw-keyring": "^3.1.0",
+        "@aws-crypto/serialize": "^3.1.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@aws-crypto/raw-keyring": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-keyring/-/raw-keyring-3.1.0.tgz",
+      "integrity": "sha512-GIZvpQ7eEXeV0FOZ5Tvwzz5t4dMmigjs739Dypt6q5Er02zQUB2OVmteLJH6p33j11zLaD1AGW6Yq22gy2+NDQ==",
+      "requires": {
+        "@aws-crypto/material-management": "^3.1.0",
+        "@aws-crypto/serialize": "^3.1.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@aws-crypto/raw-rsa-keyring-node": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-3.1.0.tgz",
+      "integrity": "sha512-3EPnGm0l8Ui29p+jYctKaJAHv381MHvnjcPGw2ZGaVL+HAve+5WSL9JjwK8gOXoRot7ntt1KC1nBBmI+cj/G0g==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^3.1.0",
+        "@aws-crypto/raw-keyring": "^3.1.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@aws-crypto/serialize": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/serialize/-/serialize-3.1.0.tgz",
+      "integrity": "sha512-Dn1cZLudJrRAmwA95iVNo5ocKCX2sFvJe+cGVWPuj54qyF2gLfKQGWq20DWsu5Y7sSemp9NYbWsHD4/sesKnfw==",
+      "requires": {
+        "@aws-crypto/material-management": "^3.1.0",
+        "asn1.js": "^5.3.0",
+        "bn.js": "^5.1.1",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -8021,6 +8323,14 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/duplexify": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.1.tgz",
+      "integrity": "sha512-n0zoEj/fMdMOvqbHxmqnza/kXyoGgJmEpsXjpP+gEqE1Ye4yNqc7xWipKnUoMpWhMuzJQSfK2gMrwlElly7OGQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -8090,6 +8400,11 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw=="
+    },
+    "@types/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
     },
     "@types/minimatch": {
       "version": "3.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10174,6 +10174,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "bfj": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
@@ -19583,6 +19593,12 @@
       "requires": {
         "find-up": "^2.1.0"
       }
+    },
+    "platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9236,6 +9236,17 @@
         "private": "^0.1.8",
         "slash": "^1.0.0",
         "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "babel-eslint": {
@@ -9735,6 +9746,15 @@
         "lodash": "^4.17.4"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -9906,6 +9926,14 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "http-errors": {
           "version": "1.7.2",
@@ -10647,6 +10675,16 @@
         "on-headers": "~1.0.1",
         "safe-buffer": "5.1.2",
         "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "compression-webpack-plugin": {
@@ -11203,11 +11241,18 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "decamelize": {
@@ -11863,6 +11908,17 @@
       "requires": {
         "debug": "^2.6.9",
         "resolve": "^1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-module-utils": {
@@ -11873,6 +11929,17 @@
       "requires": {
         "debug": "^2.6.8",
         "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-filenames": {
@@ -11900,6 +11967,15 @@
         "resolve": "^1.11.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -12167,6 +12243,14 @@
         "to-regex": "^3.0.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -12277,6 +12361,14 @@
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
           "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "mime-db": {
           "version": "1.40.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
@@ -12334,6 +12426,14 @@
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
           "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "depd": {
           "version": "2.0.0",
@@ -12687,6 +12787,14 @@
         "unpipe": "~1.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "parseurl": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -20358,6 +20466,21 @@
         "statuses": "~1.5.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
         "http-errors": {
           "version": "1.7.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
@@ -20559,6 +20682,14 @@
         "use": "^3.1.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "content-type": "^1.0.4",
     "cookie": "^0.4.2",
     "cors": "^2.8.5",
+    "debug": "^4.3.4",
     "express": "^4.17.1",
     "express-naked-redirect": "^0.1.2",
     "express-session": "^1.16.2",

--- a/package.json
+++ b/package.json
@@ -84,16 +84,5 @@
   "cacheDirectories": [
     "node_modules",
     "static-site/node_modules"
-  ],
-  "jest": {
-    "testMatch": [
-      "**/*.test.js"
-    ],
-    "globals": {
-      "BASE_URL": "http://localhost:5000"
-    },
-    "setupFilesAfterEnv": [
-      "jest-extended/all"
-    ]
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@awaitjs/express": "^0.6.3",
+    "@aws-crypto/client-node": "^3.1.1",
     "@aws-sdk/client-cognito-identity-provider": "^3.52.0",
     "@aws-sdk/client-iam": "^3.53.0",
     "@aws-sdk/client-s3": "^3.53.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.3",
     "babel-plugin-lodash": "^3.2.11",
+    "benchmark": "^2.1.4",
     "eslint": "^5.14.1",
     "eslint-config-airbnb": "^15.1.0",
     "eslint-config-defaults": "^7.0.1",

--- a/src/authn/index.js
+++ b/src/authn/index.js
@@ -361,7 +361,9 @@ function setup(app) {
     (req, res) => {
       // We can trust this value from the session because we are the only ones
       // in control of it.
-      res.redirect(req.session.afterLoginReturnTo || "/");
+      const afterLoginReturnTo = req.session.afterLoginReturnTo;
+      delete req.session.afterLoginReturnTo;
+      res.redirect(afterLoginReturnTo || "/");
     }
   );
 

--- a/src/authn/index.js
+++ b/src/authn/index.js
@@ -407,7 +407,10 @@ function authnWithToken(req, res, next) {
  */
 function authnWithSession(req, res, next) {
   const authenticate = passport.authenticate(STRATEGY_SESSION, (err, user) => {
-    if (err) return next(err);
+    if (err) {
+      utils.verbose(`Failed to deserialize user from session (${err}); leaving session intact but ignoring user`);
+      return next();
+    }
     if (user) {
       /* Mark the request as being authenticated with a session, which is
        * strongly indicative of a browser client (as API clients use tokens).

--- a/src/authn/index.js
+++ b/src/authn/index.js
@@ -1,6 +1,7 @@
 // Server handlers for authentication (authn).  Authorization (authz) is done
 // in the server's charon handlers.
 //
+const assert = require("assert").strict;
 const querystring = require("querystring");
 const session = require("express-session");
 const Redis = require("ioredis");
@@ -198,6 +199,16 @@ function setup(app) {
      * above predate that property.
      *   -trs, 18 March 2022
      */
+
+    /* Check the final user object is the right shape.  This would be better
+     * with types and TypeScript, or even a validation library, but asserts are
+     * ok for now in the absence of either of those.
+     */
+    assert(typeof user.username === "string");
+    assert(Array.isArray(user.groups));
+    assert(user.authzRoles instanceof Set);
+    assert(user.flags instanceof Set);
+    assert(Array.isArray(user.cognitoGroups));
 
     return done(null, user);
   });

--- a/src/authn/session.js
+++ b/src/authn/session.js
@@ -1,0 +1,84 @@
+const {keyringFromParamString, encrypt, decrypt, randomKey} = require("../cryptography");
+
+
+const PRODUCTION = process.env.NODE_ENV === "production";
+
+const SESSION_ENCRYPTION_KEYS = process.env.SESSION_ENCRYPTION_KEYS;
+
+if (PRODUCTION && !SESSION_ENCRYPTION_KEYS) {
+  throw new Error("SESSION_ENCRYPTION_KEYS required in production mode");
+}
+
+const KEYRING = keyringFromParamString(SESSION_ENCRYPTION_KEYS || `RANDOM=${randomKey()}`);
+
+
+/**
+ * Decrypts and returns the encrypted tokens stored in the given session
+ * object.
+ *
+ * If there are no tokens in the session, then returns null.
+ *
+ * @param {Object} session - typically req.session
+ * @returns {{idToken, accessToken, refreshTokens}|null}
+ */
+async function getTokens(session) {
+  if (session?.encryptedTokens) {
+    const context = {sid: session.id};
+    const decryptedTokens = JSON.parse(await decrypt(KEYRING, session.encryptedTokens, context));
+
+    // Return just the three tokens, regardless of other keys that might be present.
+    const {idToken, accessToken, refreshToken} = decryptedTokens;
+    return {idToken, accessToken, refreshToken};
+  }
+  return null;
+}
+
+
+/**
+ * Encrypts and stores the given tokens in the given session object.
+ *
+ * If the tokens object is null, then any existing tokens in the session object
+ * are removed.
+ *
+ * @param {Object} session - typically req.session
+ * @param {{idToken, accessToken, refreshTokens}|null} tokens - if null, removes any existing tokens from the session
+ */
+async function setTokens(session, tokens) {
+  if (tokens) {
+    /* Encryption context to bind this message to this session.  For example,
+     * this prevents coyping of the encrypted tokens from one session to
+     * another.
+     */
+    const context = {sid: session.id};
+
+    // Set just the three tokens, regardless of other keys that might be present.
+    const {idToken, accessToken, refreshToken} = tokens;
+
+    session.encryptedTokens = await encrypt(KEYRING, JSON.stringify({
+      idToken,
+      accessToken,
+      refreshToken,
+    }), context);
+  } else {
+    delete session.encryptedTokens;
+  }
+}
+
+
+/**
+ * Removes any existing tokens stored in the given session object.
+ *
+ * Equivalent to `setTokens(session, null)`.
+ *
+ * @param {Object} session - typically req.session
+ */
+async function deleteTokens(session) {
+  return await setTokens(session, null);
+}
+
+
+module.exports = {
+  getTokens,
+  setTokens,
+  deleteTokens,
+};

--- a/src/cryptography.js
+++ b/src/cryptography.js
@@ -1,0 +1,189 @@
+/**
+ * Cryptographic building blocks for encrypting our data at rest.
+ *
+ * The primary use case for this module is encrypting some data in sessions
+ * when at rest in Redis.  When adding other usages, please evaluate if the
+ * tradeoffs/choices made by this module are right for the new use case!
+ *
+ * This module uses the AWS Cryptography SDK (@aws-crypto/… modules) because:
+ *
+ *  - it stood out in a sea of options on NPM as presumably more trustworthy,
+ *    robust, and correct than other cryptography libraries by various unknown
+ *    authors
+ *
+ *  - it goes to great lengths to implement best practices while still allowing
+ *    a spectrum of safe choices based on your own tradeoffs/needs
+ *
+ *  - as an official AWS product, it appears well maintained
+ *
+ *  - the explanatory documentation and examples are superb (although the API
+ *    reference docs are terrible/non-existent)
+ *
+ * Note that although the SDK supports and is primarily intended for use with
+ * AWS's Key Management Service (KMS), we don't actually use KMS here.  The
+ * code we call never interacts with an AWS service.  Instead, we rely on
+ * locally-stored keys provided directly (e.g. SESSION_ENCRYPTION_KEYS).  While
+ * it would be lovely to use KMS to securely store and automatically rotate our
+ * keys, it seems wildy infeasible to be making (potentially multiple) network
+ * calls to KMS for each request to nextstrain.org with an authenticated
+ * session.
+ *
+ * The wrapping and data algorithm suites are chosen for the following
+ * properties:
+ *
+ *   - Symmetric encryption using AES-GCM with 256-bit keys (AES256_GCM_IV12_TAG16)
+ *   - Data key derivation with HKDF and SHA-384 (HKDF_SHA384)
+ *   - No signing (ECDSA_*)
+ *   - No key commitments (COMMIT_KEY)
+ *
+ * We opt out of the defaults of signing and key commitments because they both
+ * add significant overhead to the encrypt/decrypt time and (to a lesser
+ * degree) the encrypted message size.  Since we decrypt on ~every request with
+ * a session, it's important to be as fast as possible!  These security
+ * features are also not exceptionally useful for our use case, as they
+ * primarily protect against modifications of the ciphertext by external
+ * parties but we're not exchanging the data with anyone other than ourselves.
+ * In rough benchmarking, the encrypt() and decrypt() routines provided by this
+ * module with the algorithm choices above each take <1ms.
+ *
+ * See the AWS Cryptography SDK docs¹ for more information on these properties.
+ * The concept guide² is a particularly helpful place to start and get oriented
+ * before reading further reference material.
+ *
+ * ¹ https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/
+ * ² https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/concepts.html
+ *
+ * @module cryptography
+ */
+
+const assert = require("assert").strict;
+const awsCrypto = require("@aws-crypto/client-node");
+const {randomBytes} = require("crypto");
+
+
+/* These must be changed with care.  Blithely changing them could make existing
+ * ciphertexts undecryptable.
+ */
+const KEY_LENGTH_BITS = 256;
+const KEY_COMMITMENT_POLICY = awsCrypto.CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT;
+const WRAPPING_SUITE = awsCrypto.RawAesWrappingSuiteIdentifier.AES256_GCM_IV12_TAG16_NO_PADDING;
+const DATA_SUITE = awsCrypto.AlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA256;
+
+
+const {
+  encrypt: _encrypt,
+  decrypt: _decrypt,
+} = awsCrypto.buildClient(KEY_COMMITMENT_POLICY);
+
+
+/**
+ * Construct a keyring from one or more AES 256-bit keys.
+ *
+ * The first key specified will be used for encryption.  All keys will be
+ * considered (in order) for decryption.  This allows for key rotation over
+ * time.
+ *
+ * @param {String} keyParamString - A URL query param string encoding pairs of
+ *    key names and base64-encoded key material
+ * @returns {Object}
+ */
+function keyringFromParamString(keyParamString) {
+  const keyParams = Array.from((new URLSearchParams(keyParamString)).entries());
+
+  // Decryption with any key passed in.
+  const children = keyParams.map(([keyName, encodedKey]) => {
+    assert(typeof encodedKey === "string");
+
+    const keyBytes = new Uint8Array(Buffer.from(encodedKey, "base64"));
+
+    assert(keyBytes.byteLength * 8 === KEY_LENGTH_BITS, "invalid key size");
+
+    return new awsCrypto.RawAesKeyringNode({
+      /* Namespace part of key identifier disambiguates the name part.  Not
+       * super useful in our context, but required.  Embedded (unencrypted) in
+       * every encrypted message output (along with keyName), so keep it short!
+       * "N" for Nextstrain.
+       */
+      keyNamespace: "N",
+      keyName,
+      unencryptedMasterKey: keyBytes,
+      wrappingSuite: WRAPPING_SUITE,
+    });
+  });
+
+  // Encryption with the first key.
+  const generator = children[0];
+
+  return new awsCrypto.MultiKeyringNode({generator, children});
+}
+
+
+/**
+ * Encrypts the given plaintext with the given keyring.
+ *
+ * @param {Object} keyring - A keyring object, e.g. from {@link keyringFromParamString}
+ * @param {String|Buffer} plaintext
+ * @param {Object} [context] - Associated data (key/value pairs of strings) that
+ *   contextualizes this plaintext to prevent context shifts; not encrypted!
+ * @returns {String} base64-encoded encrypted message (ciphertext)
+ */
+async function encrypt(keyring, plaintext, context) {
+  const {result: encryptedMessage} = await _encrypt(
+    keyring,
+    plaintext,
+    {
+      suiteId: DATA_SUITE,
+      encryptionContext: context,
+    }
+  );
+  return encryptedMessage.toString("base64");
+}
+
+
+/**
+ * Decrypts the given encrypted message (ciphertext) with the given keyring.
+ *
+ * If a context object is given, the encrypted message's context will be
+ * verified to contain the same key/value pairs.
+ *
+ * @param {Object} keyring - A keyring object, e.g. from {@link keyringFromParamString}
+ * @param {String|Buffer} ciphertext - An encrypted message from {@link encrypt}.
+ *   Presumed to be in a base64-encoded string representation, though a Buffer is
+ *   also accepted.
+ * @param {Object} [context] - Associated data (key/value pairs of strings) that
+ *   contextualizes the plaintext to prevent context shifts; not encrypted!
+ * @returns {String} plaintext
+ */
+async function decrypt(keyring, ciphertext, context) {
+  const {plaintext, messageHeader: {encryptionContext}} =
+    await _decrypt(keyring, Buffer.from(ciphertext, "base64"));
+
+  if (context) {
+    for (const key of Object.keys(context)) {
+      assert(encryptionContext[key] === context[key], "encrypted message context does not match decryption context");
+    }
+  }
+
+  return plaintext.toString();
+}
+
+
+/**
+ * Generate a suitable encryption key from random bytes.
+ *
+ * Useful for testing and local development.
+ *
+ * @param {Number} [byteLength] - length of key in bytes
+ */
+function randomKey(byteLength = KEY_LENGTH_BITS / 8) {
+  return Buffer.from(randomBytes(byteLength)).toString("base64url");
+}
+
+
+module.exports = {
+  KEY_LENGTH_BITS,
+  keyringFromParamString,
+  encrypt,
+  decrypt,
+  randomKey,
+};

--- a/src/endpoints/sources.js
+++ b/src/endpoints/sources.js
@@ -533,6 +533,11 @@ async function proxyResponseBodyFromUpstream(req, res, upstreamReq) {
   if (res.get("Content-Encoding") === "gzip" && !req.acceptsEncodings("gzip")) {
     res.removeHeader("Content-Encoding");
     res.removeHeader("Content-Length");
+
+    // Weaken any strong ETag since we're now modifying response body
+    const etag = res.get("ETag");
+    if (etag && !etag.startsWith("W/")) res.set("ETag", `W/${etag}`);
+
     await pipeline(upstreamRes.body, zlib.createGunzip(), res);
   } else {
     await pipeline(upstreamRes.body, res);

--- a/src/exceptions.js
+++ b/src/exceptions.js
@@ -8,6 +8,13 @@ class NextstrainError extends Error {
 }
 
 
+/**
+ * Thrown when a token renewal attempt is made with an invalid refresh token.
+ * See {@link module:./authn.renewTokens}.
+ */
+class AuthnRefreshTokenInvalid extends NextstrainError {}
+
+
 /* Thrown when a user is not authorized to do something.  Turned into an
  * appropriate HTTP response by our server-wide error handler.
  */
@@ -25,6 +32,7 @@ class NoResourcePathError extends NextstrainError {
 
 
 module.exports = {
+  AuthnRefreshTokenInvalid,
   AuthzDenied,
   NoResourcePathError,
 };

--- a/src/exceptions.js
+++ b/src/exceptions.js
@@ -15,6 +15,17 @@ class NextstrainError extends Error {
 class AuthnRefreshTokenInvalid extends NextstrainError {}
 
 
+/**
+ * Thrown when a token is unacceptably old, e.g. when it was issued at a time
+ * known to be before our staleness horizon for the user.
+ *
+ * Typically triggers a renewal attempt like an expired token would.
+ *
+ * See {@link module:./authn.verifyToken}.
+ */
+class AuthnTokenTooOld extends NextstrainError {}
+
+
 /* Thrown when a user is not authorized to do something.  Turned into an
  * appropriate HTTP response by our server-wide error handler.
  */
@@ -33,6 +44,7 @@ class NoResourcePathError extends NextstrainError {
 
 module.exports = {
   AuthnRefreshTokenInvalid,
+  AuthnTokenTooOld,
   AuthzDenied,
   NoResourcePathError,
 };

--- a/src/redis.js
+++ b/src/redis.js
@@ -1,0 +1,68 @@
+/**
+ * Redis is used for storing user sessions (see ./authn/index.js).
+ *
+ * The production Redis instance is configured for both volatile (expiring) and
+ * non-volatile data using the "volatile-ttl" eviction policy.  User sessions
+ * are volatile (but often long-lived) and have a rolling expiration identical
+ * to the session cookie's.
+ *
+ * If you're storing more data in Redis, note that keys will default to
+ * non-volatile unless an expiration is set.
+ *
+ * @module redis
+ * @see module:authn
+ * @see https://redis.io/docs/manual/eviction/
+ */
+
+const Redis = require("ioredis");
+const utils = require("./utils");
+
+
+/**
+ * Global Redis client/connection shared by the app.
+ *
+ * Connection is made at app start if `REDIS_URL` is defined in the
+ * environment, such as in our Heroku deployments.  Otherwise remains null.
+ */
+const REDIS = process.env.REDIS_URL
+  ? herokuRedisClient(process.env.REDIS_URL)
+  : null;
+
+
+function herokuRedisClient(urlStr) {
+  const url = new URL(urlStr);
+
+  // Heroku Redis' TLS socket is documented to be on the next port up.  The
+  // scheme for secure redis:// URLs is rediss://.
+  if (url.protocol === "redis:") {
+    utils.verbose(`Rewriting Redis URL <${scrubUrl(url)}> to use TLS`);
+    url.protocol = "rediss:";
+    url.port = Number(url.port) + 1;
+  }
+
+  const client = new Redis(url.toString(), {
+    tls: {
+      // It is pretty frustrating that Heroku doesn't provide verifiable
+      // certs.  Although we're not using the Heroku Redis buildpack, the
+      // issue is documented here nicely
+      // <https://github.com/heroku/heroku-buildpack-redis/issues/15>.
+      rejectUnauthorized: false
+    }
+  });
+
+  client.scrubbedUrl = scrubUrl(url);
+
+  return client;
+}
+
+
+function scrubUrl(url) {
+  const scrubbedUrl = new URL(url);
+  scrubbedUrl.password = "XXXXXX";
+  return scrubbedUrl;
+}
+
+
+module.exports = {
+  REDIS,
+};

--- a/src/redis.js
+++ b/src/redis.js
@@ -1,16 +1,19 @@
 /**
- * Redis is used for storing user sessions (see ./authn/index.js).
+ * Redis is used for storing user sessions (see ./authn/index.js) and user
+ * staleness timestamps (see ./user.js).
  *
  * The production Redis instance is configured for both volatile (expiring) and
  * non-volatile data using the "volatile-ttl" eviction policy.  User sessions
  * are volatile (but often long-lived) and have a rolling expiration identical
- * to the session cookie's.
+ * to the session cookie's.  Staleness timestamps are volatile with a short
+ * TTL.
  *
  * If you're storing more data in Redis, note that keys will default to
  * non-volatile unless an expiration is set.
  *
  * @module redis
  * @see module:authn
+ * @see module:user
  * @see https://redis.io/docs/manual/eviction/
  */
 

--- a/src/user.js
+++ b/src/user.js
@@ -48,6 +48,19 @@ async function userStaleBefore(username) {
  * @see userStaleBefore
  */
 async function markUserStaleBeforeNow(username) {
+  /* Keying on usernames, instead of say the "sub" (subject) attribute of a
+   * user, makes this API more ergonomic and avoids needing to convert from
+   * username → sub in contexts where we only have username (e.g. a request
+   * from the group owner to modify the membership role of another user in the
+   * group).  One pitfall of usernames is that they can be re-used after
+   * deletion (unlike "sub" values), but that is not a concern for this "stale
+   * before" functionality.
+   *
+   * We can always convert this to use "sub" in the future if we think it's
+   * worth it and are already taking the hit of a Cognito ListUsers API call
+   * for other needs.
+   *   -trs, 8 June 2022
+   */
   const now = Math.ceil(Date.now() / 1000);
   if (REDIS) {
     /* The TTL must be greater than the maximum lifetime of an id/access token

--- a/src/user.js
+++ b/src/user.js
@@ -1,0 +1,71 @@
+/**
+ * User management.
+ *
+ * @module user
+ */
+
+const {REDIS} = require("./redis");
+
+
+/**
+ * Transient, in-memory "store" for userStaleBefore timestamps when Redis isn't
+ * available (e.g. in local dev).
+ */
+const userStaleBeforeTransientStore = new Map();
+
+
+/**
+ * Get the "stale before" timestamp for the given user.
+ *
+ * User tokens issued before this timestamp should be considered stale: their
+ * claims may not reflect the most current user information and they should be
+ * renewed.
+ *
+ * @param {String} username
+ * @returns {Number|null} timestamp
+ * @see markUserStaleBeforeNow
+ */
+async function userStaleBefore(username) {
+  const timestamp = REDIS
+    ? parseInt(await REDIS.get(`userStaleBefore:${username}`), 10)
+    : userStaleBeforeTransientStore.get(username);
+
+  return Number.isInteger(timestamp)
+    ? timestamp
+    : null;
+}
+
+
+/**
+ * Set the "stale before" timestamp for the given user to the current time.
+ *
+ * This timestamp should be set whenever the app makes a change to a user's
+ * information in Cognito, such as modifying a user's group memberships or
+ * updating a user's email address.
+ *
+ * @param {String} username
+ * @returns {Boolean} True if set succeeded; false if not.
+ * @see userStaleBefore
+ */
+async function markUserStaleBeforeNow(username) {
+  const now = Math.ceil(Date.now() / 1000);
+  if (REDIS) {
+    /* The TTL must be greater than the maximum lifetime of an id/access token
+     * or any other cached user data.  AWS Cognito limits the maximum lifetime
+     * of id/access tokens to 24 hours, and those tokens are the only cached
+     * user data we're using this timestamp for currently.  Set expiration to
+     * 25 hours to avoid any clock jitter issues.
+     *   -trs, 10 May 2022
+     */
+    const result = await REDIS.set(`userStaleBefore:${username}`, now, "EX", 25 * 60 * 60);
+    return result === "OK";
+  }
+  userStaleBeforeTransientStore.set(username, now);
+  return true;
+}
+
+
+module.exports = {
+  userStaleBefore,
+  markUserStaleBeforeNow,
+};

--- a/test/authn.test.js
+++ b/test/authn.test.js
@@ -1,0 +1,97 @@
+const {randomKey} = require("../src/cryptography");
+
+
+/* Allow each test() to require() modules separately so we can explicitly test
+ * require-time behaviours.
+ */
+/* eslint-disable global-require */
+beforeEach(() => {
+  jest.resetModules();
+});
+
+
+test("SESSION_ENCRYPTION_KEYS required in production", () => {
+  process.env.NODE_ENV = "production";
+
+  expect(() => require("../src/authn/session"))
+    .toThrow("SESSION_ENCRYPTION_KEYS required in production");
+
+  process.env.SESSION_ENCRYPTION_KEYS = `a=${randomKey()}`;
+
+  expect(() => require("../src/authn/session"))
+    .toBeDefined();
+});
+
+
+test("roundtrip encrypted tokens", async () => {
+  const {getTokens, setTokens, deleteTokens} = require("../src/authn/session");
+
+  const session = {
+    id: "0xABADCAFE",
+  };
+
+  await expect(getTokens(session))
+    .resolves.toBeNull();
+
+  // Set when prior values don't exist
+  await setTokens(session, {
+    idToken: "foo",
+    accessToken: "bar",
+    refreshToken: "baz",
+    otherToken: "bam",
+  });
+
+  await expect(getTokens(session))
+    .resolves.toEqual({
+      idToken: "foo",
+      accessToken: "bar",
+      refreshToken: "baz",
+      // no otherToken
+    });
+
+  // Set again when prior values do exist
+  await setTokens(session, {
+    idToken: "id",
+    accessToken: "access",
+    refreshToken: "refresh",
+    otherToken: "other",
+  });
+
+  await expect(getTokens(session))
+    .resolves.toEqual({
+      idToken: "id",
+      accessToken: "access",
+      refreshToken: "refresh",
+      // no otherToken
+    });
+
+  await deleteTokens(session);
+
+  await expect(getTokens(session))
+    .resolves.toBeNull();
+});
+
+
+test("session id must match", async () => {
+  const {getTokens, setTokens} = require("../src/authn/session");
+
+  const session = {
+    id: "0xABADCAFE",
+  };
+
+  await setTokens(session, {
+    idToken: "foo",
+    accessToken: "bar",
+    refreshToken: "baz",
+    otherToken: "bam",
+  });
+
+  /* Change session id, mimicking the encrypted tokens being copied from their
+   * original session to another.
+   */
+  session.id = "0x8BADF00D";
+
+  await expect(getTokens(session))
+    .rejects
+    .toThrow("encrypted message context does not match decryption context");
+});

--- a/test/cryptography.test.js
+++ b/test/cryptography.test.js
@@ -1,0 +1,101 @@
+const {keyringFromParamString, encrypt, decrypt, randomKey} = require("../src/cryptography");
+
+
+/* See comments in jest.config.js.  If this test fails, then something's amiss
+ * and the tests below are hopeless.
+ */
+test("Buffer is subclass of Uint8Array", () => {
+  expect(Buffer.from("foo") instanceof Uint8Array)
+    .toBeTrue();
+});
+
+
+test("keyring construction", () => {
+  const keyring = keyringFromParamString(`a=${randomKey()}&b=${randomKey()}&c=${randomKey()}`);
+
+  expect(keyring.children)
+    .toHaveLength(3);
+
+  expect(keyring.generator)
+    .toStrictEqual(keyring.children[0]);
+});
+
+
+test("encrypt/decrypt roundtrip", async () => {
+  const plaintext = "'Twas brillig, and the slithy toves";
+
+  const keyring = keyringFromParamString(`a=${randomKey()}`);
+  const ciphertext = await encrypt(keyring, plaintext);
+
+  expect(ciphertext)
+    .toMatch(/^[A-Za-z0-9+/=]+$/); // base64
+
+  await expect(decrypt(keyring, ciphertext))
+    .resolves
+    .toStrictEqual(plaintext);
+});
+
+
+test("key rotation", async () => {
+  const plaintext = "Did gyre and gimble in the wabe";
+
+  const keyA = `a=${randomKey()}`;
+  const keyB = `b=${randomKey()}`;
+
+  // Encrypt with key A
+  const keyringA = keyringFromParamString(keyA);
+  const ciphertext = await encrypt(keyringA, plaintext);
+
+  // Decrypt after rotating primary key to B
+  const keyringBA = keyringFromParamString(`${keyB}&${keyA}`);
+
+  await expect(decrypt(keyringBA, ciphertext))
+    .resolves
+    .toStrictEqual(plaintext);
+
+  // Decrypt fails if we don't retain key A
+  const keyringB = keyringFromParamString(keyB);
+
+  await expect(decrypt(keyringB, ciphertext))
+    .rejects
+    .toThrow("unencryptedDataKey has not been set");
+});
+
+
+test("invalid key size", () => {
+  expect(() => keyringFromParamString(`a=${randomKey(8)}`))
+    .toThrow("invalid key size");
+
+  expect(() => keyringFromParamString(`a=${randomKey(512)}`))
+    .toThrow("invalid key size");
+});
+
+
+test("encrypt/decrypt context", async () => {
+  const plaintext = "All mimsy were the borogoves";
+
+  const keyring = keyringFromParamString(`a=${randomKey()}`);
+  const ciphertext = await encrypt(keyring, plaintext, {testing: "yes", poem: "Jabberwocky"});
+
+  expect(ciphertext)
+    .toMatch(/^[A-Za-z0-9+/=]+$/); // base64
+
+  // Matching full context
+  await expect(decrypt(keyring, ciphertext, {testing: "yes", poem: "Jabberwocky"}))
+    .resolves
+    .toStrictEqual(plaintext);
+
+  // Matching subset context
+  await expect(decrypt(keyring, ciphertext, {testing: "yes"}))
+    .resolves
+    .toStrictEqual(plaintext);
+
+  // Mismatching contexts
+  await expect(decrypt(keyring, ciphertext, {testing: "no"}))
+    .rejects
+    .toThrow("encrypted message context does not match decryption context");
+
+  await expect(decrypt(keyring, ciphertext, {something: "else"}))
+    .rejects
+    .toThrow("encrypted message context does not match decryption context");
+});


### PR DESCRIPTION
### Description of proposed changes
Implements a system (in two parts) for keeping user information in sessions up-to-date and fresh, as I described in https://github.com/nextstrain/nextstrain.org/issues/81#issuecomment-1051420579.

This will enable us to implement group member management endpoints in the RESTful API and have the user data be consistent.

See commit messages for full details.

### Related issue(s)
Fixes #81.
Incorporates #535.

### Before deploy

- [ ] Set `SESSION_ENCRYPTION_KEYS`
- [ ] Adjust token lifetimes for "nextstrain.org prod" client in Cognito.
- [ ] Decide what to do about old sessions.

### Testing
For the session change, I tested the following scenarios locally:

- New login
- No renewal required
- Successful renewal

- Failed renewal
  
  Outcome: user logged out but session preserved.  May be redirected to login page if req is for private resource.  If last login was recent enough, IdP may remember and issue new login automatically.

- Other failure (bug, service issue, network issue, etc.)

  Outcome: sparse Internal Server Error page.  Not friendly, but there's no super friendly outcome here.

  Could destroy the session when these failures happen, which would log out the affected user and make the site browseable to them in public mode (assuming other bits of the site aren't broken).  Is this more or less friendly than preserving their session and awaiting a fix from us?  This would presumably be a high priority incident if it occurred.  (Like the previous recent issue with sessions which we resolved temporarily by rolling back before rolling out a fix.)

- Two simultaneous reqs with valid sessions that needed token renewal.

  Outcome: two token renewal requests, both saved to session, last one in "wins".

  Good enough I suppose.

- Old session, sans tokens.

  No change. (Expected for now.)

For the "stale before" change, i tested against a local Redis instance by manually setting the timestamps:

- Sessions auto-renew when stale.
- API clients get 401 and prompt for renewal when stale.