### PR TITLE
Gracefully handle session deserialization errors

### DIFF
--- a/src/authn/index.js
+++ b/src/authn/index.js
@@ -361,7 +361,9 @@ function setup(app) {
     (req, res) => {
       // We can trust this value from the session because we are the only ones
       // in control of it.
-      res.redirect(req.session.afterLoginReturnTo || "/");
+      const afterLoginReturnTo = req.session.afterLoginReturnTo;
+      delete req.session.afterLoginReturnTo;
+      res.redirect(afterLoginReturnTo || "/");
     }
   );
 

--- a/src/authn/index.js
+++ b/src/authn/index.js
@@ -407,7 +407,10 @@ function authnWithToken(req, res, next) {
  */
 function authnWithSession(req, res, next) {
   const authenticate = passport.authenticate(STRATEGY_SESSION, (err, user) => {
-    if (err) return next(err);
+    if (err) {
+      utils.verbose(`Failed to deserialize user from session (${err}); leaving session intact but ignoring user`);
+      return next();
+    }
     if (user) {
       /* Mark the request as being authenticated with a session, which is
        * strongly indicative of a browser client (as API clients use tokens).

--- a/src/authn/index.js
+++ b/src/authn/index.js
@@ -1,6 +1,7 @@
 // Server handlers for authentication (authn).  Authorization (authz) is done
 // in the server's charon handlers.
 //
+const assert = require("assert").strict;
 const querystring = require("querystring");
 const session = require("express-session");
 const Redis = require("ioredis");
@@ -198,6 +199,16 @@ function setup(app) {
      * above predate that property.
      *   -trs, 18 March 2022
      */
+
+    /* Check the final user object is the right shape.  This would be better
+     * with types and TypeScript, or even a validation library, but asserts are
+     * ok for now in the absence of either of those.
+     */
+    assert(typeof user.username === "string");
+    assert(Array.isArray(user.groups));
+    assert(user.authzRoles instanceof Set);
+    assert(user.flags instanceof Set);
+    assert(Array.isArray(user.cognitoGroups));
 
     return done(null, user);
   });


### PR DESCRIPTION
### Description of proposed changes
See individual commits for details. The primary goal here is to make session deserialization issues less fatal so that a) bugs we introduce don't have as much of an impact on users (e.g. they can still use public resources without having to wipe cookies or switch browsers) and that b) older versions of this codebase can co-exist with sessions created by newer versions. This last point is important, as I want to retain the ability to rollback from session-changing deploys gone wrong without new sessions poisoning the rollback.

To that end, I will rebase #537 on top of this and re-push it. My plan is then to deploy this first and then deploy #537.

### Testing
- Manually tested various deserialization error states (missing keys hitting the new asserts, not JSON at all, etc).
- Logged in and out via OAuth2
- Logged in via Bearer auth