### PR TITLE
sources: Bypass CloudFront for core and staging source S3 buckets

### DIFF
--- a/src/sources/core.js
+++ b/src/sources/core.js
@@ -12,7 +12,7 @@ const authorization = process.env.GITHUB_TOKEN
 
 class CoreSource extends Source {
   get name() { return "core"; }
-  async baseUrl() { return "http://data.nextstrain.org/"; }
+  async baseUrl() { return "https://nextstrain-data.s3.amazonaws.com/"; }
   get repo() { return "nextstrain/narratives"; }
   get branch() { return "master"; }
 
@@ -87,7 +87,7 @@ class CoreSource extends Source {
 
 class CoreStagingSource extends CoreSource {
   get name() { return "staging"; }
-  async baseUrl() { return "http://staging.nextstrain.org/"; }
+  async baseUrl() { return "https://nextstrain-staging.s3.amazonaws.com/"; }
   get repo() { return "nextstrain/narratives"; }
   get branch() { return "staging"; }
 }

--- a/src/sources/models.js
+++ b/src/sources/models.js
@@ -24,9 +24,7 @@ const {NoResourcePathError} = require("../exceptions");
  *
  * A concrete example:
  *
- * CoreSource (in ./core.js) represents a Cloudfront distribution
- * (https://data.nextstrain.org) in front of an S3 bucket
- * (s3://nextstrain-data).
+ * CoreSource (in ./core.js) represents an S3 bucket (s3://nextstrain-data).
  *
  *   const coreSource = new CoreSource()
  *
@@ -44,16 +42,16 @@ const {NoResourcePathError} = require("../exceptions");
  * These Subresources can be retrieved at the following URLs, which you obtain
  * using the Subresource.url() method:
  *
- *   https://data.nextstrain.org/flu_seasonal_h3n2_ha_2y.json
- *   https://data.nextstrain.org/flu_seasonal_h3n2_ha_2y_tip-frequencies.json
+ *   https://nextstrain-data.s3.amazonaws.com/flu_seasonal_h3n2_ha_2y.json
+ *   https://nextstrain-data.s3.amazonaws.com/flu_seasonal_h3n2_ha_2y_tip-frequencies.json
  *
  * Typically, the URL for a specific Subresource is composed from details in
  * the Source, Resource, and Subresource instances.  For example:
  *
- *   https://data.nextstrain.org/flu_seasonal_h3n2_ha_2y_tip-frequencies.json
- *   \_________________________/ \_____________________/ \__________________/
- *          from Source               from Dataset              from
- *                                                        DatasetSubresource
+ *   https://nextstrain-data.s3.amazonaws.com/flu_seasonal_h3n2_ha_2y_tip-frequencies.json
+ *   \______________________________________/ \_____________________/ \__________________/
+ *                from Source                      from Dataset              from
+ *                                                                     DatasetSubresource
  *
  * The actual URL construction varies between implementations but is broadly
  * similar.


### PR DESCRIPTION
It seems that ostensibly the main reason for going through CloudFront
for requests from the nextstrain.org server → S3¹ is that it's cheaper
(and maybe faster).

While this is true for requests from the internet, our Heroku dynos run
on AWS EC2 in us-east-1 (the same region as our S3 buckets) and thus are
(AFAIK) treated as free internal requests for the purposes of pricing.
I don't believe CloudFront marks down data egress back into AWS
separately from other egress like S3, and CloudFront also has more
expensive per-request pricing than S3, esp. for our most common requests
(GET).  That said, CloudFront has higher free tier quotas for both
bandwidth and requests, so it's hard to know the net balance of the two
services without our request/egress numbers for S3 ⟷ Heroku (which we
don't have and can't easily acquire without a better story for logging
and metrics¹).

Re: speed, given that the nextstrain.org server is a fixed point in
network space rather than a moving set of users around the world (i.e.
the nextstrain.org *users*), it's hard to see how CloudFront could
improve response speed by *adding* a layer of indirection.

All of that said, the biggest actual win gained by removing CloudFront
is that it means removing a caching layer and the chance for bugs due to
stale data (particularly read-after-write inconsistency issues).  In
this regard, I don't think CloudFront is helping, and by itself this
makes the switch worth it to me.

¹ See https://github.com/nextstrain/nextstrain.org/issues/511

### Testing
- [x] CI passes
- [x] Poking around the review app works as expected
- [ ] A good followup would be for someone with billing access (that I don't have) to see if there's a noticeable change in S3/CloudFront charges before/after this change.