### PR TITLE
provision-group: Set client region based on the Cognito User Pool

### DIFF
--- a/scripts/provision-group
+++ b/scripts/provision-group
@@ -20,8 +20,9 @@ const {reportUnhandledRejectionsAtExit} = require("../src/utils/scripts");
 
 
 const COGNITO_USER_POOL_ID = "us-east-1_Cg5rcTged";
+const REGION = COGNITO_USER_POOL_ID.split("_")[0];
 
-const cognito = new CognitoIdentityProviderClient();
+const cognito = new CognitoIdentityProviderClient({ region: REGION });
 
 const STATUS_CREATED = Symbol("created");
 const STATUS_UPDATED = Symbol("updated");


### PR DESCRIPTION
They have to match for this code to work, so deriving the region makes
most sense here and avoids problems with mismatched regions or missing
regions from ambient AWS config/env.

### Testing
- [x] Works locally regardless of `AWS_REGION` now
- [x] CI passes