### PR TITLE
charon: Use new "sources" handlers for getDataset, getNarrative, and getSourceInfo requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
       - run: aws sts get-caller-identity
       - run: npm run test:ci
 
+      - if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: test/server.log
+
   # XXX TODO: It'd be nice to avoid the rebuild on Heroku and instead deploy
   # the artifacts (source code + generated files + node_modules/) already built
   # above.  This would dramatically reduce deploy times and move us closer to

--- a/package-lock.json
+++ b/package-lock.json
@@ -9262,6 +9262,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -9311,7 +9312,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -9349,7 +9351,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -9562,12 +9565,14 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
     },
     "axios": {
       "version": "0.19.2",
@@ -10290,6 +10295,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -10783,7 +10789,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "cfb": {
       "version": "1.2.2",
@@ -11089,6 +11096,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -11678,6 +11686,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -11822,7 +11831,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "denque": {
       "version": "1.4.1",
@@ -12044,6 +12054,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -12929,7 +12940,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -13034,7 +13046,8 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -13386,12 +13399,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -13650,6 +13665,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -13769,12 +13785,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -14224,6 +14242,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -14786,7 +14805,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -14835,7 +14855,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -17936,7 +17957,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "jsdom": {
       "version": "16.4.0",
@@ -18061,7 +18083,8 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -18077,7 +18100,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "0.5.1",
@@ -18097,6 +18121,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -19170,7 +19195,8 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -19741,7 +19767,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "picocolors": {
       "version": "1.0.0",
@@ -20036,7 +20063,8 @@
     "psl": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+      "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -20096,7 +20124,8 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "query-string": {
       "version": "4.3.4",
@@ -20655,9 +20684,10 @@
       }
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -20666,7 +20696,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -20676,9 +20706,21 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
       }
     },
     "request-promise-core": {
@@ -21442,6 +21484,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -22625,6 +22668,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -22633,7 +22677,8 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         }
       }
     },
@@ -22681,6 +22726,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -22688,7 +22734,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -23009,6 +23056,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "passport": "^0.4.0",
     "passport-oauth2": "^1.5.0",
     "passport-strategy": "^1.0.0",
-    "query-string": "^4.2.3",
     "raw-body": "^2.4.2",
     "react-icons": "^3.11.0",
     "request": "^2.88.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "passport-strategy": "^1.0.0",
     "raw-body": "^2.4.2",
     "react-icons": "^3.11.0",
-    "request": "^2.88.0",
     "session-file-store": "^1.3.1",
     "yaml-front-matter": "^4.0.0"
   },
@@ -80,6 +79,7 @@
     "http-proxy-middleware": "^1.3.1",
     "jest": "^26.4.2",
     "jest-extended": "^1.1.0",
+    "request": "^2.88.2",
     "start-server-and-test": "^1.11.4"
   },
   "cacheDirectories": [

--- a/src/app.js
+++ b/src/app.js
@@ -130,13 +130,22 @@ app.routeAsync("/charon/getAvailable")
   .getAsync(endpoints.charon.getAvailable);
 
 app.routeAsync("/charon/getDataset")
-  .getAsync(endpoints.charon.getDataset);
+  .getAsync(
+    endpoints.charon.setSourceFromPrefix,
+    endpoints.charon.setDatasetFromPrefix,
+    endpoints.charon.canonicalizeDatasetPrefix,
+    endpoints.charon.getDataset);
 
 app.routeAsync("/charon/getNarrative")
-  .getAsync(endpoints.charon.getNarrative);
+  .getAsync(
+    endpoints.charon.setSourceFromPrefix,
+    endpoints.charon.setNarrativeFromPrefix,
+    endpoints.charon.getNarrative);
 
 app.routeAsync("/charon/getSourceInfo")
-  .getAsync(endpoints.charon.getSourceInfo);
+  .getAsync(
+    endpoints.charon.setSourceFromPrefix,
+    endpoints.charon.getSourceInfo);
 
 app.routeAsync("/charon/*")
   .all((req) => {

--- a/src/endpoints/charon/getAvailable.js
+++ b/src/endpoints/charon/getAvailable.js
@@ -1,13 +1,12 @@
 const authz = require("../../authz");
 const {CommunitySource} = require("../../sources");
 const utils = require("../../utils");
-const queryString = require("query-string");
 const {splitPrefixIntoParts, joinPartsIntoPrefix} = require("../../utils/prefix");
 const metaSources = require("../../metaSources");
 
 /* handler for /charon/getAvailable requests */
 const getAvailable = async (req, res) => {
-  const prefix = queryString.parse(req.url.split('?')[1]).prefix || "";
+  const prefix = req.query.prefix || "";
   utils.verbose(`getAvailable prefix: "${prefix}"`);
 
   // `prefix=/groups` is special-cased as it is not backed by a single Source

--- a/src/endpoints/charon/getAvailable.js
+++ b/src/endpoints/charon/getAvailable.js
@@ -6,7 +6,7 @@ const metaSources = require("../../metaSources");
 
 /* handler for /charon/getAvailable requests */
 const getAvailable = async (req, res) => {
-  const prefix = req.query.prefix || "";
+  const prefix = req.query.prefix ?? "/";
   utils.verbose(`getAvailable prefix: "${prefix}"`);
 
   // `prefix=/groups` is special-cased as it is not backed by a single Source

--- a/src/endpoints/charon/getDataset.js
+++ b/src/endpoints/charon/getDataset.js
@@ -103,15 +103,6 @@ const getDataset = async (req, res) => {
 
   if (!query.prefix) throw new BadRequest("Required query parameter 'prefix' is missing");
 
-  /*
-   * "inrb-drc" was the first of the Nextstrain groups. Groups now live at
-   * `nextstrain.org/groups`, but we want to support old URLs for INRB DRC by
-   * redirecting requests from "/inrb-drc" to "/groups/inrb-drc".
-   */
-  if (query.prefix.startsWith('/inrb-drc')) {
-    return res.redirect("getDataset?prefix=/groups" + query.prefix);
-  }
-
   utils.log(`Getting (nextstrain) datasets for: ${req.url.split('?')[1]}`);
 
   // construct fetch URL

--- a/src/endpoints/charon/getDataset.js
+++ b/src/endpoints/charon/getDataset.js
@@ -1,5 +1,3 @@
-const queryString = require("query-string");
-
 const authz = require("../../authz");
 const utils = require("../../utils");
 const {canonicalizePrefix, parsePrefix} = require("../../utils/prefix");
@@ -101,7 +99,7 @@ const streamMainV2Dataset = async (res, dataset) => {
  * @param {Response} res
  */
 const getDataset = async (req, res) => {
-  const query = queryString.parse(req.url.split('?')[1]);
+  const query = req.query;
 
   if (!query.prefix) throw new BadRequest("Required query parameter 'prefix' is missing");
 

--- a/src/endpoints/charon/getDataset.js
+++ b/src/endpoints/charon/getDataset.js
@@ -12,11 +12,8 @@ const {BadRequest, NotFound, InternalServerError} = require("http-errors");
  * @param {*} datasetInfo
  * @param {*} query
  */
-const requestCertainFileType = async (res, req, additional, query) => {
+const requestCertainFileType = async (res, req, additional) => {
   const jsonData = await utils.fetchJSON(additional);
-  if (query.type === "tree") {
-    res.json({tree: jsonData});
-  }
   res.json(jsonData);
 };
 
@@ -154,7 +151,7 @@ const getDataset = async (req, res) => {
 
   if (query.type) {
     const url = await dataset.subresource(query.type).url();
-    return requestCertainFileType(res, req, url, query);
+    return requestCertainFileType(res, req, url);
   }
 
   try {

--- a/src/endpoints/charon/getDataset.js
+++ b/src/endpoints/charon/getDataset.js
@@ -1,21 +1,8 @@
-const authz = require("../../authz");
-const utils = require("../../utils");
-const {canonicalizePrefix, parsePrefix} = require("../../utils/prefix");
 const auspice = require("auspice");
-const request = require('request');
-const {BadRequest, NotFound, InternalServerError} = require("http-errors");
+const {NotFound, InternalServerError} = require("http-errors");
 
-/**
- *
- * @param {*} res
- * @param {*} datasetInfo
- * @param {*} query
- */
-const requestCertainFileType = async (res, req, additional) => {
-  const jsonData = await utils.fetchJSON(additional);
-  res.json(jsonData);
-};
-
+const utils = require("../../utils");
+const {sendDatasetSubresource} = require("../sources");
 
 /**
  * Fetch dataset in v1 format (meta + tree files), converting to v2 format
@@ -46,110 +33,18 @@ const sendV1Dataset = async (res, metaJsonUrl, treeJsonUrl) => {
   return res.send(datasetJson);
 };
 
-/**
- * Attempt to stream the main (v2) auspice dataset. This function (when `await`ed)
- * will finish streaming before returning.
- * @param {Object} res express response object
- * @param {Object} dataset
- * @returns {undefined} Returns undefined if streaming was successful
- * @throws {NotFound} Throws if the dataset didn't exist (or the streaming failed)
- */
-const streamMainV2Dataset = async (res, dataset) => {
-  const main = await dataset.subresource("main").url();
-  try {
-    await new Promise((resolve, reject) => {
-      let statusCode;
-      const req = request
-        .get(main)
-        .on('error', (err) => reject(err))
-        .on("response", (response) => {
-          statusCode = response.statusCode;
-          if (statusCode === 200) {
-            utils.verbose(`Successfully streaming ${main}.`);
-            req.pipe(res);
-          }
-        })
-        .on("end", () => {
-          if (statusCode===200) {
-            return resolve();
-          }
-          return reject(new NotFound());
-        });
-    });
-  } catch (err) {
-    throw err;
-  }
-};
-
-/**
- * Uses custom logic to match a "best guess" dataset from the client's *req* to
- * a dataset stored on nextstrain.org.
- *
- * If the request URL differs from the URL of the matched dataset, then it sends
- * the client a redirect to the new URL.
- *
- * If the URLs match, then it sends the client the requested dataset as a JSON
- * object.
- *
- * @param {Request} req
- * @param {Response} res
- */
 const getDataset = async (req, res) => {
-  const query = req.query;
-
-  if (!query.prefix) throw new BadRequest("Required query parameter 'prefix' is missing");
+  const type = req.query.type ?? "main";
 
   utils.log(`Getting (nextstrain) datasets for: ${req.url.split('?')[1]}`);
 
-  // construct fetch URL
-  let datasetInfo;
-  try {
-    datasetInfo = await parsePrefix(query.prefix, query);
-  } catch (err) {
-    throw new BadRequest(`Couldn't parse the prefix '${query.prefix}': ${err}`);
-  }
-
-  const {source, dataset, resolvedPrefix} = datasetInfo;
-
-  /* Authorization
-   *
-   * This is slightly more lenient than the handlers in endpoints/sources.js
-   * because here the authz check on "source" is delayed until after "dataset"
-   * is constructed and possibly resolved (instead of happening immediately
-   * upon source determination), but I don't think there's anything untoward
-   * lurking in the gap.
-   *   -trs, 5 Jan 2022
-   */
-  authz.assertAuthorized(req.user, authz.actions.Read, source);
-  authz.assertAuthorized(req.user, authz.actions.Read, dataset);
-
-  /* If we got a partial prefix and resolved it into a full one, redirect to
-   * that.  Auspice will notice and update its displayed URL appropriately.
-   */
-  if (resolvedPrefix !== await canonicalizePrefix(query.prefix)) {
-    // A absolute base is required but we won't use it, so use something bogus.
-    const resolvedUrl = new URL(req.originalUrl, "http://x");
-    resolvedUrl.searchParams.set("prefix", resolvedPrefix);
-
-    const relativeResolvedUrl = resolvedUrl.pathname + resolvedUrl.search;
-
-    utils.log(`Redirecting client to resolved dataset URL: ${relativeResolvedUrl}`);
-    res.redirect(relativeResolvedUrl);
-    return undefined;
-  }
-
-  if (query.type) {
-    const url = await dataset.subresource(query.type).url();
-    return requestCertainFileType(res, req, url);
-  }
-
   try {
     /* attempt to stream the v2 dataset */
-    return await streamMainV2Dataset(res, dataset);
+    return await sendDatasetSubresource(type)(req, res);
   } catch (errV2) {
     try {
       /* attempt to fetch the meta + tree JSONs, combine, and send */
-      return await sendV1Dataset(res, await dataset.subresource("meta").url(), await dataset.subresource("tree").url());
+      return await sendV1Dataset(res, await req.context.dataset.subresource("meta").url(), await req.context.dataset.subresource("tree").url());
     } catch (errV1) {
       throw errV2;
     }

--- a/src/endpoints/charon/getNarrative.js
+++ b/src/endpoints/charon/getNarrative.js
@@ -16,15 +16,6 @@ const getNarrative = async (req, res) => {
     throw new BadRequest(`Required query parameter 'type' has an unsupported value ('${query.type}').  Supported values are: ${Array.from(validTypes).join(', ')}`);
   }
 
-  /*
-   * "inrb-drc" was the first of the Nextstrain groups. Groups now live at
-   * `nextstrain.org/groups`, but we want to support old URLs for INRB DRC by
-   * redirecting requests from "/inrb-drc" to "/groups/inrb-drc".
-   */
-  if (prefix.startsWith('/inrb-drc')) {
-    return res.redirect("getNarrative?type=md&prefix=/groups" + prefix);
-  }
-
   const {source, prefixParts} = splitPrefixIntoParts(prefix);
 
   // Authorization

--- a/src/endpoints/charon/getNarrative.js
+++ b/src/endpoints/charon/getNarrative.js
@@ -1,50 +1,16 @@
-const fetch = require('node-fetch');
-const {BadRequest, NotFound} = require("http-errors");
+const {BadRequest} = require("http-errors");
 
-const authz = require("../../authz");
-const utils = require("../../utils");
-const {splitPrefixIntoParts} = require("../../utils/prefix");
+const {sendNarrativeSubresource} = require("../sources");
 
 const getNarrative = async (req, res) => {
   const query = req.query;
-  const prefix = query.prefix;
   const validTypes = new Set(["markdown", "md"]);
-
-  if (!prefix) throw new BadRequest("Required query parameter 'prefix' is missing");
 
   if (!validTypes.has((query.type || "").toLowerCase())) {
     throw new BadRequest(`Required query parameter 'type' has an unsupported value ('${query.type}').  Supported values are: ${Array.from(validTypes).join(', ')}`);
   }
 
-  const {source, prefixParts} = splitPrefixIntoParts(prefix);
-
-  // Authorization
-  authz.assertAuthorized(req.user, authz.actions.Read, source);
-
-  // Remove 'en' from nCoV narrative prefixParts
-  if (prefixParts[0] === 'ncov') {
-    const index = prefixParts.indexOf('en');
-    if (index >= 0) {
-      prefixParts.splice(index, 1);
-    }
-  }
-
-  // Generate the narrative's origin URL for fetching.
-  const narrative = source.narrative(prefixParts);
-
-  authz.assertAuthorized(req.user, authz.actions.Read, narrative);
-
-  const fetchURL = await narrative.subresource("md").url();
-
-  try {
-    utils.log(`Fetching narrative ${fetchURL} and streaming to client for parsing`);
-    const response = await fetch(fetchURL);
-    if (response.status !== 200) throw new Error();
-    const narrativeContents = await response.text();
-    return res.set("Content-Type", "text/markdown").send(narrativeContents);
-  } catch (err) {
-    throw new NotFound(`Failed to fetch ${fetchURL}`);
-  }
+  return await sendNarrativeSubresource("md")(req, res);
 };
 
 module.exports = {

--- a/src/endpoints/charon/getSourceInfo.js
+++ b/src/endpoints/charon/getSourceInfo.js
@@ -1,22 +1,8 @@
-const {BadRequest} = require("http-errors");
-
-const authz = require("../../authz");
-const {splitPrefixIntoParts} = require("../../utils/prefix");
-
 /**
  * Prototype implementation.
  */
 const getSourceInfo = async (req, res) => {
-  const query = req.query;
-
-  if (!query.prefix) throw new BadRequest("Required query parameter 'prefix' is missing");
-
-  const {source} = splitPrefixIntoParts(query.prefix);
-
-  // Authorization
-  authz.assertAuthorized(req.user, authz.actions.Read, source);
-
-  return res.json(await source.getInfo());
+  return res.json(await req.context.source.getInfo());
 };
 
 

--- a/src/endpoints/charon/getSourceInfo.js
+++ b/src/endpoints/charon/getSourceInfo.js
@@ -1,4 +1,3 @@
-const queryString = require("query-string");
 const {BadRequest} = require("http-errors");
 
 const authz = require("../../authz");
@@ -8,7 +7,7 @@ const {splitPrefixIntoParts} = require("../../utils/prefix");
  * Prototype implementation.
  */
 const getSourceInfo = async (req, res) => {
-  const query = queryString.parse(req.url.split('?')[1]);
+  const query = req.query;
 
   if (!query.prefix) throw new BadRequest("Required query parameter 'prefix' is missing");
 

--- a/src/endpoints/charon/index.js
+++ b/src/endpoints/charon/index.js
@@ -1,10 +1,60 @@
+const {BadRequest, isHttpError} = require("http-errors");
+
+const {splitPrefixIntoParts} = require("../../utils/prefix");
+const {setSource, setDataset, canonicalizeDataset, setNarrative} = require("../sources");
+
 require("./setAvailableDatasets"); // sets globals
 const getAvailable = require("./getAvailable").default;
 const getDataset = require("./getDataset").default;
 const getNarrative = require("./getNarrative").default;
 const getSourceInfo = require("./getSourceInfo").default;
 
+const setSourceFromPrefix = setSource(req => {
+  const prefix = req.query.prefix;
+  if (!prefix) throw new BadRequest("Required query parameter 'prefix' is missing");
+
+  try {
+    req.context.splitPrefixIntoParts = splitPrefixIntoParts(prefix);
+  } catch (err) {
+    if (!isHttpError(err)) {
+      throw new BadRequest(`Couldn't parse the prefix '${prefix}': ${err}`);
+    }
+    throw err;
+  }
+
+  return req.context.splitPrefixIntoParts.source;
+});
+
+const setDatasetFromPrefix = setDataset(req => req.context.splitPrefixIntoParts.prefixParts.join("/"));
+
+const canonicalizeDatasetPrefix = canonicalizeDataset((req, resolvedPrefix) => {
+  // A absolute base is required but we won't use it, so use something bogus.
+  const resolvedUrl = new URL(req.originalUrl, "http://x");
+  resolvedUrl.searchParams.set("prefix", resolvedPrefix);
+
+  return resolvedUrl.pathname + resolvedUrl.search;
+});
+
+const setNarrativeFromPrefix = setNarrative(req => {
+  const {prefixParts} = req.context.splitPrefixIntoParts;
+
+  // Remove 'en' from nCoV narrative prefixParts
+  if (prefixParts[0] === 'ncov') {
+    const index = prefixParts.indexOf('en');
+    if (index >= 0) {
+      prefixParts.splice(index, 1);
+    }
+  }
+
+  return prefixParts.join("/");
+});
+
 module.exports = {
+  setSourceFromPrefix,
+  setDatasetFromPrefix,
+  canonicalizeDatasetPrefix,
+  setNarrativeFromPrefix,
+
   getAvailable,
   getDataset,
   getNarrative,

--- a/src/endpoints/sources.js
+++ b/src/endpoints/sources.js
@@ -75,10 +75,14 @@ const canonicalizeDataset = (pathBuilder) => (req, res, next) => {
 
   if (dataset === resolvedDataset) return next();
 
+  const canonicalPath = pathBuilder.length >= 2
+    ? pathBuilder(req, resolvedDataset.pathParts.join("/"))
+    : pathBuilder(resolvedDataset.pathParts.join("/"));
+
   /* 307 Temporary Redirect preserves request method, unlike 302 Found, which
    * is important since this middleware function may be used in non-GET routes.
    */
-  return res.redirect(307, pathBuilder(resolvedDataset.pathParts.join("/")));
+  return res.redirect(307, canonicalPath);
 };
 
 
@@ -620,8 +624,23 @@ function copyHeaders(headerSource, headerNames) {
  * @returns {String} Path for {@link Source#dataset} or {@link Source#narrative}
  */
 
+/* Confused about the duplication below?  It's the documented way to handle
+ * overloaded (e.g. arity-dependent) function signatures.¹  Note that it relies
+ * on the "nestled" or "cuddled" end and start comment markers.
+ *   -trs, 16 June 2022
+ *
+ * ¹ https://github.com/jsdoc/jsdoc/issues/1017
+ */
 /**
  * @callback pathBuilder
+ *
+ * @param {String} path - Canonical path for the dataset within the context of
+ *   the current {@link Source}
+ * @returns {String} Fully-specified path to redirect to
+ *//**
+ * @callback pathBuilder
+ *
+ * @param {express.request} req
  * @param {String} path - Canonical path for the dataset within the context of
  *   the current {@link Source}
  * @returns {String} Fully-specified path to redirect to
@@ -677,4 +696,7 @@ module.exports = {
   getNarrative,
   putNarrative,
   deleteNarrative,
+
+  sendDatasetSubresource,
+  sendNarrativeSubresource,
 };

--- a/src/exceptions.js
+++ b/src/exceptions.js
@@ -32,19 +32,8 @@ class AuthnTokenTooOld extends NextstrainError {}
 class AuthzDenied extends NextstrainError {}
 
 
-/* Thrown when a valid Source object is asked to create a new Dataset object
- * without a dataset path.
- */
-class NoResourcePathError extends NextstrainError {
-  constructor(msg = "No resource path provided", ...rest) {
-    super(msg, ...rest);
-  }
-}
-
-
 module.exports = {
   AuthnRefreshTokenInvalid,
   AuthnTokenTooOld,
   AuthzDenied,
-  NoResourcePathError,
 };

--- a/src/sources/community.js
+++ b/src/sources/community.js
@@ -1,7 +1,6 @@
 /* eslint no-use-before-define: ["error", {"functions": false, "classes": false}] */
 const authz = require("../authz");
 const {fetch} = require("../fetch");
-const queryString = require("query-string");
 const {NotFound} = require('http-errors');
 const utils = require("../utils");
 const {Source, Dataset, Narrative} = require("./models");
@@ -58,7 +57,7 @@ class CommunitySource extends Source {
   }
 
   async availableDatasets() {
-    const qs = queryString.stringify({ref: await this.branch});
+    const qs = new URLSearchParams({ref: await this.branch});
     const response = await fetch(`https://api.github.com/repos/${this.repo}/contents/auspice?${qs}`, {headers: {authorization}});
 
     if (response.status === 404) throw new NotFound();
@@ -80,7 +79,7 @@ class CommunitySource extends Source {
   }
 
   async availableNarratives() {
-    const qs = queryString.stringify({ref: await this.branch});
+    const qs = new URLSearchParams({ref: await this.branch});
     const response = await fetch(`https://api.github.com/repos/${this.repo}/contents/narratives?${qs}`, {headers: {authorization}});
 
     if (response.status !== 200 && response.status !== 304) {

--- a/src/sources/community.js
+++ b/src/sources/community.js
@@ -161,12 +161,6 @@ class CommunityDataset extends Dataset {
     // name in the file basename.
     return [`auspice/${this.source.repoName}`, ...this.pathParts];
   }
-  get isRequestValidWithoutDataset() {
-    if (!this.pathParts.length) {
-      return true;
-    }
-    return false;
-  }
 }
 
 class CommunityNarrative extends Narrative {

--- a/src/sources/core.js
+++ b/src/sources/core.js
@@ -1,7 +1,6 @@
 /* eslint no-use-before-define: ["error", {"functions": false, "classes": false}] */
 const authz = require("../authz");
 const {fetch} = require("../fetch");
-const queryString = require("query-string");
 const {NotFound} = require('http-errors');
 const utils = require("../utils");
 const {Source, Dataset} = require("./models");
@@ -39,7 +38,7 @@ class CoreSource extends Source {
   }
 
   async availableNarratives() {
-    const qs = queryString.stringify({ref: this.branch});
+    const qs = new URLSearchParams({ref: this.branch});
     const response = await fetch(`https://api.github.com/repos/${this.repo}/contents?${qs}`, {headers: {authorization}});
 
     if (response.status === 404) throw new NotFound();

--- a/src/sources/models.js
+++ b/src/sources/models.js
@@ -1,7 +1,6 @@
 /* eslint no-use-before-define: ["error", {"functions": false, "classes": false}] */
 const authzTags = require("../authz/tags");
 const {fetch} = require("../fetch");
-const {NoResourcePathError} = require("../exceptions");
 
 /* The model classes here are the base classes for the classes defined in
  * ./core.js, ./community.js, ./groups.js, etc.
@@ -145,7 +144,7 @@ class Resource {
     // This inspects baseParts because some of the pathParts (above) may not
     // apply, which each Dataset/Narrative subclass determines for itself.
     if (!this.baseParts.length) {
-      throw new NoResourcePathError();
+      throw new Error(`no Resource path provided (${this.constructor.name}.baseParts is empty)`);
     }
   }
   get baseParts() {
@@ -236,10 +235,6 @@ class Dataset extends Resource {
    */
   resolve() {
     return this;
-  }
-
-  get isRequestValidWithoutDataset() {
-    return false;
   }
 
   get authzTags() {

--- a/src/utils/prefix.js
+++ b/src/utils/prefix.js
@@ -30,6 +30,8 @@ const sourceClassToName = new Map(
  * roundtrip losslessly.
  */
 const splitPrefixIntoParts = (prefix) => {
+  if (!prefix) throw new Error("'prefix' is null or empty");
+
   const prefixParts = prefix
     .replace(/^\//, '')
     .replace(/\/$/, '')
@@ -152,22 +154,6 @@ const joinPartsIntoPrefix = async ({source, prefixParts, isNarrative = false}) =
 };
 
 
-/* Parse the prefix (a path-like string specifying a source + dataset path)
- * with resolving of partial prefixes.  Prefixes are case-sensitive.
- */
-const parsePrefix = async (prefix) => {
-  const {source, prefixParts} = splitPrefixIntoParts(prefix);
-
-  const dataset = source.dataset(prefixParts).resolve();
-
-  // If prefixParts was partially-specified (an alias), we want to display the
-  // resolved prefix.
-  const resolvedPrefix = await joinPartsIntoPrefix({source, prefixParts: dataset.pathParts});
-
-  return ({source, dataset, resolvedPrefix});
-};
-
-
 /* Round-trip prefix through split/join to canonicalize it for comparison.
  */
 const canonicalizePrefix = async (prefix) =>
@@ -177,6 +163,5 @@ const canonicalizePrefix = async (prefix) =>
 module.exports = {
   splitPrefixIntoParts,
   joinPartsIntoPrefix,
-  parsePrefix,
   canonicalizePrefix,
 };

--- a/test/auspice_client_requests.json
+++ b/test/auspice_client_requests.json
@@ -9,7 +9,7 @@
   {
     "name": "Check that the dataset request for /flu redirects to a specific dataset",
     "url": "/charon/getDataset?prefix=/flu",
-    "expectStatusCode": 302,
+    "expectStatusCode": 307,
     "responseIsJson": false,
     "redirectsTo": "/charon/getDataset?prefix=flu%2Fseasonal%2Fh3n2%2Fha%2F2y"
   },

--- a/test/auspice_client_requests.json
+++ b/test/auspice_client_requests.json
@@ -26,9 +26,9 @@
     "responseIsJson": true
   },
   {
-    "name": "Check getDataset API call for a community source with no default datasets returns 204 (No Content)",
+    "name": "Check getDataset API call for a community source with no default datasets returns 404",
     "url": "/charon/getDataset?prefix=/community/jameshadfield/scratch",
-    "expectStatusCode": 204
+    "expectStatusCode": 404
   },
   {
     "name": "Check that getAvailable API call for a community source with datasets lists them",

--- a/test/auspice_client_requests.test.js
+++ b/test/auspice_client_requests.test.js
@@ -34,8 +34,9 @@ async function testResponseIsJson(res) {
 }
 
 function testRedirect(res, expectedRedirectAddress) {
-  if (res.status!==302) {
-    throw Error(`Test asked to check redirect address, but statusCode wasn't 302`);
+  const validStatuses = new Set([301, 302, 303, 307, 308]);
+  if (!validStatuses.has(res.status)) {
+    throw Error(`Test asked to check redirect address, but statusCode wasn't one of: ${[...validStatuses].join(" ")}`);
   }
   expect(res.headers.get("Location")).toEqual(expectedRedirectAddress);
 }


### PR DESCRIPTION
### Description of proposed changes
Several related changes, all detailed in commit messages, but the top-line change is a consolidation of code paths between our Charon endpoints' handlers and the new "sources" handlers powering the RESTful API endpoints.

Resolves #150.

### Testing
- [x] CI passes locally
- [x] CI passes on GitHub (wtf)
- [x] Poking around locally doesn't find any issues