### PR TITLE
Show full command name in note to use lsof

### DIFF
--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ const server = http.createServer(app)
     if (err.code === 'EADDRINUSE') {
       utils.error(`Port ${app.get('port')} is currently in use by another program.
       You must either close that program or specify a different port by setting the shell variable
-      "$PORT". Note that on MacOS / Linux, "lsof -n -i :${app.get('port')} | grep LISTEN" should
+      "$PORT". Note that on MacOS / Linux, "lsof +c0 -n -i :${app.get('port')} | grep LISTEN" should
       identify the process currently using the port.`);
     }
     utils.error(`Uncaught error in app.listen(). Code: ${err.code}`);


### PR DESCRIPTION
### Description of proposed changes

This can be expected to show for anyone using macOS >=12 [where AirPlay Receiver uses port 5000 by default][1]. However, the old lsof command truncates the command name:

```
% lsof -n -i :5000 | grep LISTEN
ControlCe 687 vlin   16u  IPv4 0x80682f2dbd9b4293      0t0  TCP *:commplex-main (LISTEN)
ControlCe 687 vlin   17u  IPv6 0x80682f242196ef0b      0t0  TCP *:commplex-main (LISTEN)
```

Adding `+c0` shows the full name:

```
% lsof +c0 -n -i :5000 | grep LISTEN
ControlCenter                687 vlin   16u  IPv4 0x80682f2dbd9b4293      0t0  TCP *:commplex-main (LISTEN)
ControlCenter                687 vlin   17u  IPv6 0x80682f242196ef0b      0t0  TCP *:commplex-main (LISTEN)
```

which can then be used in an internet query for "why is ControlCenter listening on port 5000?"

[1]: https://developer.apple.com/forums/thread/682332

### Related issue(s)

_N/A_

### Testing

- [x] tested on macOS
- [x] tested on Linux (using GitHub Codespace)