### PR TITLE
Prepare for adjusting the layout of the multi-tenant groups bucket

### DIFF
--- a/src/sources/groups.js
+++ b/src/sources/groups.js
@@ -108,6 +108,7 @@ class GroupSource extends Source {
             .map(object => object.Key)
             .filter(key => key.startsWith(this.prefix))
             .map(key => key.slice(this.prefix.length))
+            .filter(subKey => !subKey.startsWith("datasets/") && !subKey.startsWith("narratives/"))
         );
         return done();
       });


### PR DESCRIPTION
Ignore objects within each group's prefix starting with "datasets/" or
"narratives/".  These sub-prefixes are used in the new layout and during
a brief transition/testing period will have copies of the live data for
any groups already migrated to the multi-tenant bucket.  Ignoring them
avoids including them (as non-functional duplicate entries) in the
dataset and narrative listings (e.g. on an individual group's splash
page).

### Related issue(s)
Related to #562.

### Testing
- [x] Correctly ignores objects in the new layout for the `test-private` group, where I've manually adjusted the layout already. Other objects still correctly visible as datasets and narratives in listings.
- [x] Tests pass locally.