### PR TITLE
Resolve 503s from Heroku's routing layer

### DIFF
--- a/src/endpoints/sources.js
+++ b/src/endpoints/sources.js
@@ -352,6 +352,11 @@ function receiveSubresource(subresourceExtractor) {
 
     authz.assertAuthorized(req.user, authz.actions.Write, subresource.resource);
 
+    /* Notify the client they can continue sending the request body now that
+     * we're past authz.
+     */
+    if (req.expectsContinue) res.writeContinue();
+
     /* Proxy the data through us:
      *
      *    client (browser, CLI, etc) ⟷ us (nextstrain.org) ⟷ upstream source


### PR DESCRIPTION
# Description

See commit messages for details.

Resolves #564.

# Deploy

- [ ] Merge, monitor deploy to canary, and verify behaviour on next.nextstrain.org
- [ ] `heroku labs:enable http-end-to-end-continue -a nextstrain-canary`
- [ ] Verify behaviour again on next.nextstrain.org
- [ ] Promote canary to prod
- [ ] `heroku labs:enable http-end-to-end-continue -a nextstrain-server`
- [ ] Verify behaviour on nextstrain.org
- [ ] Resolve https://github.com/nextstrain/cli/issues/189