### PR TITLE
docs: Install nextstrain.sphinx.theme extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ extensions = [
     'recommonmark',
     'sphinx_markdown_tables',
     'sphinx.ext.intersphinx',
+    'nextstrain.sphinx.theme',
 ]
 
 intersphinx_mapping = {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-nextstrain-sphinx-theme
+nextstrain-sphinx-theme >=2022.5
 recommonmark
 sphinx
 sphinx-markdown-tables


### PR DESCRIPTION
## Description of proposed changes

The new extension has sphinx_copybutton pre-installed and configured. This change enables it here.
This also makes it easier to configure other extensions across multiple docs projects.

## Related issue(s)

https://github.com/nextstrain/sphinx-theme/issues/30

## Testing

- [ ] copy button works on RTD preview build