### PR TITLE
sources: Accept application/octet-stream for dataset JSONs

### DIFF
--- a/src/sources/models.js
+++ b/src/sources/models.js
@@ -254,6 +254,14 @@ class DatasetSubresource extends Subresource {
     this.mediaType,
     "application/json; q=0.9",
     "text/plain; q=0.1",
+
+    /* The only type used by media.githubusercontent.com for objects in Git
+     * LFS, important for Community on GitHub datasets.  Anecodotally, this is
+     * also commonly used by (poorly-configured) static web servers for .json
+     * files, which we might encounter with /fetch/… datasets.
+     *   -trs, 20 July 2022
+     */
+    "application/octet-stream; q=0.01",
   ].join(", ")
 
   get baseName() {


### PR DESCRIPTION
…as the lowest priority media type (i.e. we'll use it grudgingly).

This media type is the only one used by the media.githubusercontent.com
endpoint which provides access to objects in Git LFS for Community on
GitHub datasets.

Resolves <https://github.com/nextstrain/nextstrain.org/issues/575>.

### Testing
- [x] Repro'd issue locally then confirmed this resolved it.
- [x] Tests pass locally
- [x] Linting passes locally
- [ ] CI passes