### PR TITLE
Add endpoint for downloading Nextstrain CLI assets from its latest release

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -337,6 +337,14 @@ app.route(["/users", "/users/:name"])
   .get((req, res) => res.redirect("/whoami"));
 
 
+/* CLI convenience endpoints, e.g. downloads of release assets.
+ *
+ * Include "/latest/" path segment to leave room for supporting arbitrary
+ * (non-latest) versions in the future.
+ */
+app.routeAsync("/cli/download/latest/:assetSuffix")
+  .getAsync(endpoints.cli.download);
+
 /* JSON Schemas.
  *
  * Our schemas identity themselves using nextstrain.org URLs so that we can

--- a/src/app.js
+++ b/src/app.js
@@ -338,12 +338,13 @@ app.route(["/users", "/users/:name"])
 
 
 /* CLI convenience endpoints, e.g. downloads of release assets.
- *
- * Include "/latest/" path segment to leave room for supporting arbitrary
- * (non-latest) versions in the future.
  */
-app.routeAsync("/cli/download/latest/:assetSuffix")
+app.routeAsync("/cli/download/:version/:assetSuffix")
   .getAsync(endpoints.cli.download);
+
+app.route("/cli")
+  .get((req, res) => res.redirect("https://docs.nextstrain.org/projects/cli/"));
+
 
 /* JSON Schemas.
  *

--- a/src/endpoints/cli.js
+++ b/src/endpoints/cli.js
@@ -1,0 +1,34 @@
+const {BadRequest, InternalServerError, NotFound} = require("http-errors");
+const {fetch} = require("../fetch");
+
+
+const authorization = process.env.GITHUB_TOKEN
+  ? `token ${process.env.GITHUB_TOKEN}`
+  : "";
+
+
+const download = async (req, res) => {
+  const assetSuffix = req.params.assetSuffix;
+  if (!assetSuffix) throw new BadRequest();
+
+  const response = await fetch("https://api.github.com/repos/nextstrain/cli/releases/latest", {headers: {authorization}});
+
+  if (response.status !== 200) {
+    throw new InternalServerError(`upstream said: ${response.status} ${response.statusText}`);
+  }
+
+  const release = await response.json();
+  const assetName = `nextstrain-cli-${release.tag_name}-${assetSuffix}`;
+  const asset = release.assets.find(a => a.name === assetName);
+
+  if (!asset) {
+    throw new NotFound(`latest release (${release.name}) contains no asset matching ${assetName}`);
+  }
+
+  return res.redirect(asset.browser_download_url);
+};
+
+
+module.exports = {
+  download,
+};

--- a/src/endpoints/index.js
+++ b/src/endpoints/index.js
@@ -1,10 +1,12 @@
 const charon = require("./charon");
+const cli = require("./cli");
 const sources = require("./sources");
 const static_ = require("./static");
 const users = require("./users");
 
 module.exports = {
   charon,
+  cli,
   sources,
   static: static_,
   users,


### PR DESCRIPTION
### Description of proposed changes
This is makes it much easier to do without knowing the actual version of
the latest release, as the asset names contain the version (as is
proper).  I expect the endpoint to be used by short standalone installer
scripts¹ and other automation which would benefit from using the
standalone installation archives, e.g. by fetching one of:

    https://nextstrain.org/cli/download/latest/standalone-x86_64-unknown-linux-gnu.tar.gz
    https://nextstrain.org/cli/download/latest/standalone-x86_64-apple-darwin.tar.gz
    https://nextstrain.org/cli/download/latest/standalone-x86_64-pc-windows-msvc.zip

Going through a nextstrain.org endpoint instead of using GitHub's API
directly also provides such automation an increase in future
compatibility potential since nextstrain.org can act as a
translation/insulation layer for future changes.

¹ Such as <https://gist.github.com/tsibley/4d4263128da4f156e2af5f099937bda6#file-unix>.

### Related issue(s)
Related to https://github.com/nextstrain/docs.nextstrain.org/pull/123

### Testing
- [x] Manually tested endpoint; works great
- [x] CI passes
