### PR TITLE
Add RESTful API for managing Groups members

### DIFF
--- a/aws/iam/main.tf
+++ b/aws/iam/main.tf
@@ -37,7 +37,11 @@ resource "aws_iam_policy" "server" {
   name        = local.server_policy_name
   description = local.server_policy_description
 
-  policy = file("${path.module}/policy/${local.server_policy_name}.json")
+  policy = templatefile(
+    "${path.module}/policy/${local.server_policy_name}.tftpl.json", {
+      COGNITO_USER_POOL_ID = var.COGNITO_USER_POOL_ID
+    }
+  )
 }
 
 moved {

--- a/aws/iam/policy/NextstrainDotOrgServerInstance-testing.tftpl.json
+++ b/aws/iam/policy/NextstrainDotOrgServerInstance-testing.tftpl.json
@@ -18,7 +18,16 @@
       ],
       "Resource": [
         "arn:aws:s3:::nextstrain-groups"
-      ]
+      ],
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "blab/*",
+            "test/*",
+            "test-private/*"
+          ]
+        }
+      }
     },
     {
       "Sid": "MultitenantBucketObjectActions",
@@ -30,7 +39,21 @@
         "s3:DeleteObject"
       ],
       "Resource": [
-        "arn:aws:s3:::nextstrain-groups/*"
+        "arn:aws:s3:::nextstrain-groups/blab/*",
+        "arn:aws:s3:::nextstrain-groups/test/*",
+        "arn:aws:s3:::nextstrain-groups/test-private/*"
+      ]
+    },
+    {
+      "Sid": "CognitoUserPoolActions",
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:AdminAddUserToGroup",
+        "cognito-idp:AdminRemoveUserFromGroup",
+        "cognito-idp:ListUsersInGroup"
+      ],
+      "Resource": [
+        "arn:aws:cognito-idp:us-east-1:827581582529:userpool/${COGNITO_USER_POOL_ID}"
       ]
     }
   ]

--- a/aws/iam/policy/NextstrainDotOrgServerInstance.tftpl.json
+++ b/aws/iam/policy/NextstrainDotOrgServerInstance.tftpl.json
@@ -18,16 +18,7 @@
       ],
       "Resource": [
         "arn:aws:s3:::nextstrain-groups"
-      ],
-      "Condition": {
-        "StringLike": {
-          "s3:prefix": [
-            "blab/*",
-            "test/*",
-            "test-private/*"
-          ]
-        }
-      }
+      ]
     },
     {
       "Sid": "MultitenantBucketObjectActions",
@@ -39,9 +30,19 @@
         "s3:DeleteObject"
       ],
       "Resource": [
-        "arn:aws:s3:::nextstrain-groups/blab/*",
-        "arn:aws:s3:::nextstrain-groups/test/*",
-        "arn:aws:s3:::nextstrain-groups/test-private/*"
+        "arn:aws:s3:::nextstrain-groups/*"
+      ]
+    },
+    {
+      "Sid": "CognitoUserPoolActions",
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:AdminAddUserToGroup",
+        "cognito-idp:AdminRemoveUserFromGroup",
+        "cognito-idp:ListUsersInGroup"
+      ],
+      "Resource": [
+        "arn:aws:cognito-idp:us-east-1:827581582529:userpool/${COGNITO_USER_POOL_ID}"
       ]
     }
   ]

--- a/aws/iam/variable-COGNITO_USER_POOL_ID.tf
+++ b/aws/iam/variable-COGNITO_USER_POOL_ID.tf
@@ -1,0 +1,1 @@
+../variable-COGNITO_USER_POOL_ID.tf

--- a/aws/variable-COGNITO_USER_POOL_ID.tf
+++ b/aws/variable-COGNITO_USER_POOL_ID.tf
@@ -1,0 +1,4 @@
+variable "COGNITO_USER_POOL_ID" {
+  type        = string
+  description = "Id of the Cognito user pool for this environment"
+}

--- a/docs/api-restful.rst
+++ b/docs/api-restful.rst
@@ -293,6 +293,16 @@ The following group settings endpoints exist::
 
     {GET, HEAD, PUT, DELETE, OPTIONS} /groups/{name}/settings/overview
 
+The following group membership endpoints exist::
+
+    {GET, HEAD, OPTIONS} /groups/{name}/settings/members
+
+    {GET, HEAD, OPTIONS} /groups/{name}/settings/roles
+
+    {GET, HEAD, OPTIONS} /groups/{name}/settings/roles/{role}/members
+
+    {GET, HEAD, PUT, DELETE, OPTIONS} /groups/{name}/settings/roles/{role}/members/{username}
+
 .. _motivation:
 
 Motivation

--- a/env/production/terraform.tf
+++ b/env/production/terraform.tf
@@ -52,6 +52,8 @@ module "iam" {
   }
 
   env = "production"
+
+  COGNITO_USER_POOL_ID = module.cognito.COGNITO_USER_POOL_ID
 }
 
 moved {

--- a/env/testing/terraform.tf
+++ b/env/testing/terraform.tf
@@ -46,4 +46,6 @@ module "iam" {
   }
 
   env = "testing"
+
+  COGNITO_USER_POOL_ID = module.cognito.COGNITO_USER_POOL_ID
 }

--- a/src/app.js
+++ b/src/app.js
@@ -348,6 +348,21 @@ app.routeAsync("/groups/:groupName/settings/overview")
   .optionsAsync(optionsGroup)
 ;
 
+app.routeAsync("/groups/:groupName/settings/members")
+  .getAsync(endpoints.groups.listMembers);
+
+app.routeAsync("/groups/:groupName/settings/roles")
+  .getAsync(endpoints.groups.listRoles);
+
+app.routeAsync("/groups/:groupName/settings/roles/:roleName/members")
+  .getAsync(endpoints.groups.listRoleMembers);
+
+app.routeAsync("/groups/:groupName/settings/roles/:roleName/members/:username")
+  .getAsync(endpoints.groups.getRoleMember)
+  .putAsync(endpoints.groups.putRoleMember)
+  .deleteAsync(endpoints.groups.deleteRoleMember)
+;
+
 app.route("/groups/:groupName/settings/*")
   .all(() => { throw new NotFound(); });
 

--- a/src/cognito.js
+++ b/src/cognito.js
@@ -1,0 +1,85 @@
+/**
+ * Cognito user pool (IdP) management.
+ *
+ * @module cognito
+ */
+/* eslint-disable no-await-in-loop */
+import {
+  CognitoIdentityProviderClient,
+  AdminAddUserToGroupCommand,
+  AdminRemoveUserFromGroupCommand,
+  paginateListUsersInGroup,
+  UserNotFoundException,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { COGNITO_USER_POOL_ID } from "./config.js";
+import { NotFound } from "./httpErrors.js";
+
+
+const REGION = COGNITO_USER_POOL_ID.split("_")[0];
+
+const cognito = new CognitoIdentityProviderClient({ region: REGION });
+
+
+/**
+ * Retrieve AWS Cognito users in a Cognito group.
+ *
+ * @param {string} name - Name of the AWS Cognito group
+ * @yields {object} user, see <https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-cognito-identity-provider/interfaces/usertype.html>
+ */
+export async function* listUsersInGroup(name) {
+  const paginator = paginateListUsersInGroup({client: cognito}, {
+    UserPoolId: COGNITO_USER_POOL_ID,
+    GroupName: name,
+  });
+
+  for await (const page of paginator) {
+    yield* page.Users;
+  }
+}
+
+
+/**
+ * Add an AWS Cognito user to a Cognito group.
+ *
+ * @param {string} username
+ * @param {string} group - Name of the AWS Cognito group
+ * @throws {NotFound} if username is unknown
+ */
+export async function addUserToGroup(username, group) {
+  try {
+    await cognito.send(new AdminAddUserToGroupCommand({
+      UserPoolId: COGNITO_USER_POOL_ID,
+      Username: username,
+      GroupName: group,
+    }));
+  } catch (err) {
+    if (err instanceof UserNotFoundException) {
+      throw new NotFound(`unknown user: ${username}`);
+    }
+    throw err;
+  }
+}
+
+
+/**
+ * Remove an AWS Cognito user from a Cognito group.
+ *
+ * @param {string} username
+ * @param {string} group - Name of the AWS Cognito group
+ * @throws {NotFound} if username is unknown
+ */
+export async function removeUserFromGroup(username, group) {
+  try {
+    await cognito.send(new AdminRemoveUserFromGroupCommand({
+      UserPoolId: COGNITO_USER_POOL_ID,
+      Username: username,
+      GroupName: group,
+    }));
+  } catch (err) {
+    if (err instanceof UserNotFoundException) {
+      throw new NotFound(`unknown user: ${username}`);
+    }
+    throw err;
+  }
+}

--- a/src/utils/iterators.js
+++ b/src/utils/iterators.js
@@ -1,0 +1,39 @@
+/**
+ * Iterator utilities.
+ *
+ * @module utils.iterators
+ */
+
+
+/**
+ * Maps a function over any iterable, including async ones.
+ *
+ * If the iterable has a "map" property, it's called directly.
+ *
+ * @param {Object} it - [Iterable object]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol}, e.g. an array, Set, Map, generator, async generator, etc.
+ * @param {Function} fn - Synchronous mapping function taking an element and returning a mapped value.
+ * @returns {Array}
+ */
+export async function map(it, fn) {
+  if (it.map) return it.map(x => fn(x));
+
+  const array = [];
+  for await (const x of it) {
+    /* Apply fn() as we go to avoid keeping all of the untransformed and
+     * potentially large elements in memory at once.
+     */
+    array.push(fn(x));
+  }
+  return array;
+}
+
+
+/**
+ * Consume an potentially-async iterable into an array.
+ *
+ * @param {Object} it - [Iterable object]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol}, e.g. an array, Set, Map, generator, async generator, etc.
+ * @returns {Array}
+ */
+export async function slurp(it) {
+  return await map(it, x => x);
+}

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -59,9 +59,15 @@ class Index extends React.Component {
     let bannerTitle, bannerContents;
     // Set up a banner if dataset doesn't exist
     if (this.state.nonExistentPath) {
-      bannerTitle = this.state.nonExistentPath.startsWith("narratives/")
-        ? `The narrative "nextstrain.org/groups/${groupName}/${this.state.nonExistentPath}" doesn't exist.`
-        : `The dataset "nextstrain.org/groups/${groupName}/${this.state.nonExistentPath}" doesn't exist.`;
+      if (this.state.nonExistentPath.startsWith("narratives/")) {
+        bannerTitle = `The narrative "nextstrain.org/groups/${groupName}/${this.state.nonExistentPath}" doesn't exist.`;
+      }
+      else if (this.state.nonExistentPath.startsWith("settings/")) {
+        bannerTitle = `The setting "nextstrain.org/groups/${groupName}/${this.state.nonExistentPath}" doesn't exist.`;
+      }
+      else {
+        bannerTitle = `The dataset "nextstrain.org/groups/${groupName}/${this.state.nonExistentPath}" doesn't exist.`;
+      }
       bannerContents = `Here is the page for the "${groupName}" Nextstrain Group.`;
     }
     // Set up a banner or update the existing one if the group doesn't exist


### PR DESCRIPTION
### Description of proposed changes
Adds RESTful API endpoints for listing/adding/removing existing users to group membership roles.

Things to address later:

- [ ] Currently no way to invite new users. Need to sort out the desired interface/mechanism for this. [Discussion](https://github.com/nextstrain/nextstrain.org/pull/581#discussion_r956509505).

- [ ] Automated tests for these endpoints/functions now that we have a shiny new testing environment (#598, #656, #657)

- [x] Currently this branch is missing a good, safe solution for dev and testing of these API endpoints.  I really don't want to grant all dev/test instances (local, GitHub Actions, Heroku review apps, etc) permissions to modify all groups, but AWS IAM policies don't support a finer resource specificity than the user pool, so we can't use the same approach we do with S3 buckets and prefix-scoping.

  Given these conflicting constraints, a separate dev-only user pool seems most appropriate, but that's a bit more initial work to setup and more ongoing work to manage/keep relevant over time.  I'm a little loathe to address that now or as a prerequisite for this work, but I also don't like not having a dev/testing story here.

   We're rapidly reaching (or are at?) the point where I really want separate dev vs. prod AWS accounts controlled by Terraform or CloudFormation something.

### Testing
- [x] Manual testing of endpoints
- [ ] ~Add new tests~
- [x] Local tests pass
- [x] CI passes

### After merge

- [ ] Deploy `env/production` Terraform config