### PR TITLE
Add endpoint for the Nextstrain CLI standalone archive installers

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -342,6 +342,9 @@ app.route(["/users", "/users/:name"])
 app.routeAsync("/cli/download/:version/:assetSuffix")
   .getAsync(endpoints.cli.download);
 
+app.routeAsync("/cli/installer/:os")
+  .getAsync(endpoints.cli.installer);
+
 app.route("/cli")
   .get((req, res) => res.redirect("https://docs.nextstrain.org/projects/cli/"));
 

--- a/src/endpoints/cli.js
+++ b/src/endpoints/cli.js
@@ -41,6 +41,23 @@ const download = async (req, res) => {
 };
 
 
+const installer = (req, res) => {
+  const os = req.params.os;
+  switch (os) {
+    case "linux":
+    case "mac":
+      return res.redirect("https://github.com/nextstrain/cli/raw/master/bin/standalone-installer-unix");
+
+    case "windows":
+      return res.redirect("https://github.com/nextstrain/cli/raw/master/bin/standalone-installer-windows");
+
+    default:
+      throw new NotFound(`No installer for OS: ${os}`);
+  }
+};
+
+
 module.exports = {
   download,
+  installer,
 };


### PR DESCRIPTION
Currently these resolve through redirects to GitHub where the installers
are served directly out of the CLI's repo.¹  This will make maintenance
and updates easier, and the indirection of the nextstrain.org endpoints
allows us to swap things around behind the scenes as necessary later.

Planned to be used by forthcoming updates to a) our installation docs²
and b) the self-upgrade instructions of the CLI itself (when already
running a standalone install).

¹ https://github.com/nextstrain/cli/pull/217
² https://github.com/nextstrain/docs.nextstrain.org/pull/123

### Testing
- [x] Manually tested redirects work
- [ ] CI passes