### PR TITLE
Use Node.js version 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18'
       - run: node --version
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/update-dataset-listings.yml
+++ b/.github/workflows/update-dataset-listings.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '18'
     - run: npm ci
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
     # configure AWS necessary for `collect-datasets.js` and `nextstrain remote upload`

--- a/.github/workflows/update-search.yml
+++ b/.github/workflows/update-search.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '18'
     - run: npm ci
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
     # configure AWS necessary for `collect-search-results.js` and `nextstrain remote upload`

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "repository": "github:nextstrain/nextstrain.org",
   "homepage": "https://nextstrain.org",
   "engines": {
-    "node": "^14",
-    "npm": "^6.14"
+    "node": "^18",
+    "npm": "^8.6.0"
   },
   "scripts": {
     "build": "./build.sh",

--- a/static-site/package.json
+++ b/static-site/package.json
@@ -11,8 +11,8 @@
   "license": "MIT",
   "main": "n/a",
   "engines": {
-    "node": "^14",
-    "npm": "^6.14"
+    "node": "^18",
+    "npm": "^8.6.0"
   },
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
### Description of proposed changes

Although the current version (14) is still in active LTS status, the latest LTS version comes with performance improvements [[1]]. The performance improvements from version 16 should also apply [[2]].

Also update the npm version to a minimum of 8.6.0 since it corresponds with Node.js 18.0.0 per https://nodejs.org/en/download/releases/.

[1]: https://nodejs.org/en/blog/release/v18.0.0/
[2]: https://nodejs.org/en/blog/release/v16.0.0/

### Related issue(s)

_N/A_

### Tasks

- [ ] Merge before this PR: https://github.com/nextstrain/auspice/pull/1560
- [ ] Check `npm install` and build outputs for any dependency compatibility issues

### Testing

- [ ] Checks pass
- [ ] Manually test preview build