### PR TITLE
Remove `set-up` → `build` npm command alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "scripts": {
     "build": "./build.sh",
     "lint": "eslint --ext .js,.jsx .",
-    "set-up": "npm run build",
     "server": "node server.js",
     "start": "npm run server",
     "//test": "echo 'NODE_OPTIONS is required until this issue is resolved: https://github.com/facebook/jest/issues/9430 '",


### PR DESCRIPTION
### Description of proposed changes

This alias has been around since 84a45a8bb9b1a8c967b33ab6964ab24c793084ad and should be unused at this point.

### Related issue(s)

_N/A_

### Testing

- [ ] Checks pass