### PR TITLE
Forbid underscores in resource (dataset, narrative) paths

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 /static-site/public/
 node_modules/
 /auspice-client/dist/
+/docs/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
-public/
+/static-site/public/
 node_modules/
-dist/
+/auspice-client/dist/

--- a/src/sources/fetch.js
+++ b/src/sources/fetch.js
@@ -46,6 +46,11 @@ class UrlDefinedSource extends Source {
 }
 
 class UrlDefinedDataset extends Dataset {
+  // eslint-disable-next-line no-unused-vars
+  assertValidPathParts(pathParts) {
+    // Override check for underscores (_), as we want to allow arbitrary
+    // external URLs.
+  }
   get baseName() {
     return this.baseParts.join("/");
   }
@@ -80,6 +85,11 @@ class UrlDefinedDatasetSubresource extends DatasetSubresource {
 }
 
 class UrlDefinedNarrative extends Narrative {
+  // eslint-disable-next-line no-unused-vars
+  assertValidPathParts(pathParts) {
+    // Override check for underscores (_), as we want to allow arbitrary
+    // external URLs.
+  }
   get baseName() {
     return this.baseParts.join("/");
   }

--- a/test/auspice_client_requests.json
+++ b/test/auspice_client_requests.json
@@ -163,5 +163,45 @@
     "name": "Unknown charon address should 404",
     "url": "/charon/unknown",
     "expectStatusCode": 404
+  },
+  {
+    "name": "Underscores aren't permitted for core datasets",
+    "url": "/charon/getDataset?prefix=/flu/seasonal/h3n2_ha_2y",
+    "expectStatusCode": 400
+  },
+  {
+    "name": "Underscores aren't permitted for staging datasets",
+    "url": "/charon/getDataset?prefix=/staging/flu/seasonal/h3n2_ha_2y",
+    "expectStatusCode": 400
+  },
+  {
+    "name": "Underscores aren't permitted for community datasets (but in repo is ok)",
+    "url": "/charon/getDataset?prefix=/community/nextstrain/enterovirus_d68/genome_2022-02-18",
+    "expectStatusCode": 400
+  },
+  {
+    "name": "Underscores aren't permitted for group datasets",
+    "url": "/charon/getDataset?prefix=/groups/blab/ncov_19B",
+    "expectStatusCode": 400
+  },
+  {
+    "name": "Underscores aren't permitted for core narratives",
+    "url": "/charon/getNarrative?prefix=/narratives/ncov_sit-rep/2020-08-14",
+    "expectStatusCode": 400
+  },
+  {
+    "name": "Underscores aren't permitted for staging narratives",
+    "url": "/charon/getNarrative?prefix=/staging/narratives/test_fixture/intro-to-narratives",
+    "expectStatusCode": 400
+  },
+  {
+    "name": "Underscores aren't permitted for community narratives (but in repo is ok)",
+    "url": "/charon/getNarrative?prefix=/community/narratives/nextstrain/community-test/nested_intro-to-narratives",
+    "expectStatusCode": 400
+  },
+  {
+    "name": "Underscores aren't permitted for group narratives",
+    "url": "/charon/getNarrative?prefix=/groups/blab/narratives/test_fixture",
+    "expectStatusCode": 400
   }
 ]


### PR DESCRIPTION
Underscores worked because of an implementation detail about how we're backing those files that is leaking through.  The presence of underscores breaks many assumptions made by nextstrain.org and Auspice, a minor example of which is Auspice's dataset selector.  Other broken assumptions could lead to more serious breakage, such "confused deputy" problems resulting in authz bugs (though I don't think this is the case currently).

Note that /fetch/… paths are allowed to contain underscores, as these are resolved to external resources.

Resolves <https://github.com/nextstrain/nextstrain.org/issues/432>.
Related to <https://github.com/nextstrain/nextstrain.org/pull/517>.

### Testing

- [x] Added failing tests, then made them pass
- [x] Checks pass
- [x] `npm run test:ci` passes locally
- [x] `npm run lint` passes locally