### PR TITLE
Remind us to promote the canary to production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,5 +99,6 @@ jobs:
           curl "$(jq -r .output_stream_url build.json)" \
             --fail --silent --show-error --location
 
-      - name: Logout of Heroku
+      - if: always()
+        name: Logout of Heroku
         run: sed -i -e '/^machine api\.heroku\.com/d' ~/.netrc

--- a/.github/workflows/remind-to-promote.yml
+++ b/.github/workflows/remind-to-promote.yml
@@ -1,0 +1,59 @@
+name: remind to promote
+
+on:
+  # Run every hour (a little before the top of the hour), but note that
+  # scripts/remind-to-promote may choose not to check at certain times.
+  schedule:
+    - cron: '48 * * * *'
+
+  # Manually triggered using GitHub's UI
+  workflow_dispatch:
+
+jobs:
+  remind-to-promote:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+      - run: npm ci
+
+        # This cache entry could get evicted if we don't access it for 7 days
+        # or if total cache size for this repo exceeds 10 GB¹, but that seems
+        # unlikely to happen and worse case we see duplicate messages in Slack
+        # until we resolve it.
+        #   -trs, 21 Oct 2022
+        #
+        # ¹ https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+      - uses: actions/cache@v3
+        with:
+          key: remind-to-promote-state-hash
+          path: remind-to-promote-state-hash
+
+      - name: Check if a promotion reminder is appropriate
+        run: ./scripts/remind-to-promote --check | tee remind-to-promote-state
+        env:
+          HEROKU_TOKEN: ${{ secrets.HEROKU_TOKEN_READ_PROTECTED }}
+
+      - id: state-check
+        name: Compare new state to cached state
+        run: |
+          if [[ ! -s remind-to-promote-state ]] || sha256sum --check remind-to-promote-state-hash; then
+            echo should-send=no | tee "$GITHUB_OUTPUT"
+          else
+            echo should-send=yes | tee "$GITHUB_OUTPUT"
+          fi
+
+      - name: Send reminder
+        if: steps.state-check.outputs.should-send == 'yes'
+        run: ./scripts/remind-to-promote --send < remind-to-promote-state
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          SLACK_CHANNEL: C01LCTT7JNN #nextstrain-dev
+
+      - name: Updated cached state with new state
+        run: sha256sum remind-to-promote-state | tee remind-to-promote-state-hash

--- a/package-lock.json
+++ b/package-lock.json
@@ -17262,6 +17262,12 @@
         }
       }
     },
+    "luxon": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
+      "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw==",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "http-proxy-middleware": "^1.3.1",
     "jest": "^27.5.1",
     "jest-extended": "^1.1.0",
+    "luxon": "^3.0.4",
     "request": "^2.88.2",
     "start-server-and-test": "^1.11.4"
   },

--- a/scripts/provision-group.js
+++ b/scripts/provision-group.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 /* eslint-disable no-await-in-loop */
+/* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 import { ArgumentParser } from 'argparse';
 
 import {
@@ -11,7 +12,7 @@ import {
   AdminUpdateUserAttributesCommand,
   CreateGroupCommand,
   paginateAdminListGroupsForUser,
-} from '@aws-sdk/client-cognito-identity-provider'; // eslint-disable-line import/no-extraneous-dependencies
+} from '@aws-sdk/client-cognito-identity-provider';
 
 import fs from 'fs';
 import yaml from 'js-yaml';

--- a/scripts/remind-to-promote
+++ b/scripts/remind-to-promote
@@ -1,0 +1,1 @@
+remind-to-promote.js

--- a/scripts/remind-to-promote.js
+++ b/scripts/remind-to-promote.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 import {ArgumentParser} from "argparse";
 import {DateTime} from "luxon";
 import fetch from "node-fetch";

--- a/scripts/remind-to-promote.js
+++ b/scripts/remind-to-promote.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+import {ArgumentParser} from "argparse";
+import {DateTime} from "luxon";
+import fetch from "node-fetch";
+import process from "process";
+import readStream from "raw-body";
+
+const pipeline = "38f67fc7-d93c-40c6-a182-501da2f89d9d";
+const staging = "nextstrain-canary";
+const production = "nextstrain-server";
+
+
+function parseArgs() {
+  const argparser = new ArgumentParser();
+
+  argparser.addArgument("--check", {
+    help: "Check mode",
+    action: "storeConst",
+    dest: "mode",
+    constant: "check",
+  });
+
+  argparser.addArgument("--send", {
+    help: "Send mode",
+    action: "storeConst",
+    dest: "mode",
+    constant: "send",
+  });
+
+  argparser.addArgument("--grace-period", {
+    help: `Grace period (in days) during which not to remind after a release to ${staging}`,
+    metavar: "<days>",
+    dest: "gracePeriod",
+    type: "int",
+    defaultValue: 7,
+  });
+
+  const args = argparser.parseArgs();
+
+  if (!args.mode) args.mode = "check";
+
+  return args;
+}
+
+
+async function main({mode, gracePeriod}) {
+  switch (mode) {
+    case "check":
+      await check({gracePeriod});
+      break;
+
+    case "send":
+      await send();
+      break;
+
+    default:
+      throw new Error(`Unknown mode of operation: ${mode}`);
+  }
+}
+
+
+async function check({gracePeriod}) {
+  const now = DateTime.now();
+
+  // Don't run when no one's around.  We'll keep being invoked every hour and
+  // will eventually start passing this check again.
+  if (!isThereAnybodyOutThere(now)) {
+    console.warn(`No one's around; skipping check.`);
+    return;
+  }
+
+  // Fetch latest releases of all apps in the pipeline
+  const pipelineReleases = await heroku(`/pipelines/${pipeline}/latest-releases`);
+
+  // Find staging and production app releases
+  const stagingRelease = pipelineReleases.find(r => r.app.name === staging);
+  const productionRelease = pipelineReleases.find(r => r.app.name === production);
+
+  if (!stagingRelease) throw new Error(`Unable to find release for ${staging} in ${JSON.stringify(pipelineReleases)}`);
+  if (!productionRelease) throw new Error(`Unable to find release for ${production} in ${JSON.stringify(pipelineReleases)}`);
+
+  const stagingSlugId = stagingRelease.slug.id;
+  const productionSlugId = productionRelease.slug.id;
+
+  // Is there anything to promote?
+  if (stagingSlugId === productionSlugId) {
+    console.warn(`Nothing to promote.`);
+    return;
+  }
+
+  const stagingReleasedAt = DateTime.fromISO(stagingRelease.created_at);
+  const stagingReleasedAgo = now.diff(stagingReleasedAt);
+
+  const stagingReleasedAgoHumanized =
+    stagingReleasedAgo
+      .shiftTo("days", "hours", "minutes")
+      .normalize()
+      .toHuman({unitDisplay: "short"});
+
+  const daysSinceStagingReleased = stagingReleasedAgo.as("days");
+
+  console.warn(`${staging} slug: ${stagingSlugId} (${stagingReleasedAgoHumanized} ago)`);
+  console.warn(`${production} slug: ${productionSlugId}`);
+
+  // Is it ok to stew a bit longer?
+  if (daysSinceStagingReleased <= gracePeriod) {
+    console.warn(`Still in the grace period (${gracePeriod}d); skipping output.`);
+    return;
+  }
+
+  // Fetch both slugs for comparison
+  const [stagingSlug, productionSlug] = await Promise.all([
+    heroku(`/apps/${staging}/slugs/${stagingSlugId}`),
+    heroku(`/apps/${production}/slugs/${productionSlugId}`),
+  ]);
+
+  console.warn(`${staging} commit: ${stagingSlug.commit}`);
+  console.warn(`${production} commit: ${productionSlug.commit}`);
+
+  console.log(
+    JSON.stringify({
+      config: {
+        pipeline,
+        staging,
+        production,
+      },
+      staging: {
+        slug: stagingSlug.id,
+        commit: stagingSlug.commit,
+        releasedAgo: stagingReleasedAgo.toISO(),
+      },
+      production: {
+        slug: productionSlug.id,
+        commit: productionSlug.commit,
+      },
+    }, null, 2)
+  );
+}
+
+
+async function send() {
+  const state = JSON.parse(await readStream(process.stdin, {encoding: 'utf-8'}));
+
+  const msg = `
+Changes are lingering on <https://next.nextstrain.org|next.nextstrain.org>.
+
+<https://github.com/nextstrain/nextstrain.org/compare/${state.production.commit}...${state.staging.commit}|Review the changes> and promote (if appropriate) via the <https://dashboard.heroku.com/pipelines/${state.config.pipeline}|Heroku Dashboard>.
+  `;
+
+  console.warn(`Sending to ${process.env.SLACK_CHANNEL}:\n\n${msg}`);
+
+  const url = "https://slack.com/api/chat.postMessage";
+  const response = await fetch(
+    url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.SLACK_TOKEN}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({
+        channel: process.env.SLACK_CHANNEL,
+        text: msg,
+        icon_emoji: ":bird:",
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`POST ${url} failed: ${response.status} ${response.statusText}`);
+  }
+
+  console.warn(await response.json());
+}
+
+
+function isThereAnybodyOutThere(now) {
+  // If we're not running under automation (e.g. CI), then assume we're being
+  // manually invoked by someone and always want to run.
+  if (!process.env.CI) return true;
+
+  const timezones = [
+    "America/Los_Angeles",
+    "Europe/Zurich",
+    "Pacific/Auckland",
+  ];
+
+  const workingDays = new Set([1, 2, 3, 4, 5]);
+  const workingHours = new Set([9, 10, 11, 12, 13, 14, 15, 16, 17]);
+
+  for (const tz of timezones) {
+    const local = now.setZone(tz);
+
+    if (workingDays.has(local.weekday) && workingHours.has(local.hour)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+
+async function heroku(path) {
+  const url = new URL(path, "https://api.heroku.com");
+  const response = await fetch(
+    url, {
+      headers: {
+        Authorization: `Bearer ${process.env.HEROKU_TOKEN}`,
+        Accept: "application/vnd.heroku+json; version=3",
+      }
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`GET ${url} failed: ${response.status} ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+
+await main(parseArgs());


### PR DESCRIPTION
…if we're tardy about it.

### Changes outside PR

- Generated a [`read-protected` scoped](https://devcenter.heroku.com/articles/oauth#scopes) Heroku API token for our Heroku bot user
- Added the token as a `HEROKU_TOKEN_READ_PROTECTED` GitHub org-level secret for Actions
- Created a ["Nextstrain Bot" Slack app](https://api.slack.com/apps/A047F02PTE2) and ["installed" it into our Slack org](https://bedfordlab.slack.com/apps/A047F02PTE2-nextstrain-bot) in order to generate [a suitable bot token](https://api.slack.com/apps/A047F02PTE2/oauth?).
- Added the bot token as a `SLACK_TOKEN` GitHub org-level secret for Actions

### Testing

- [x] Checks pass
- [x] Manually invoke to test ([workflow runs](https://github.com/nextstrain/nextstrain.org/actions/workflows/remind-to-promote.yml), [Slack message from last run](https://bedfordlab.slack.com/archives/C02LTGS6NLQ/p1666391445716149))

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
