### PR TITLE
scripts/collect-search-results: Update `fileToUrl`

### DIFF
--- a/scripts/collect-search-results.js
+++ b/scripts/collect-search-results.js
@@ -32,7 +32,7 @@ async function main({args}) {
       outputFilename = `search_sars-cov-2.json`;
       ({datasets, strainMap, dateUpdated} = await collectFromBucket({
         BUCKET: `nextstrain-data`,
-        fileToUrl: (filename) => `https://nextstrain.org/${filename.replace('.json', '').replace('_', '/')}`,
+        fileToUrl: (filename) => `https://nextstrain.org/${filename.replace('.json', '').replace(/_/g, '/')}`,
         inclusionTest: (fn) => {
           return (fn.startsWith("ncov_") && !fn.endsWith("_gisaid.json") && !fn.endsWith("_zh.json"));
         }
@@ -44,7 +44,7 @@ async function main({args}) {
       outputFilename = `search_seasonal-flu.json`;
       ({datasets, strainMap, dateUpdated} = await collectFromBucket({
         BUCKET: `nextstrain-data`,
-        fileToUrl: (filename) => `https://nextstrain.org/${filename.replace('.json', '').replace('_', '/')}`,
+        fileToUrl: (filename) => `https://nextstrain.org/${filename.replace('.json', '').replace(/_/g, '/')}`,
         inclusionTest: (filename) => filename.startsWith("flu_seasonal_")
       }));
       break;


### PR DESCRIPTION
### Description of proposed changes

Replace all instances of underscore in the filename to create the URL. Never noticed this issue before, but now the underscores in the URLs lead to a BadRequest error since we explicitly forbid underscores in the resource path in #611.

### Testing

Tested locally for both SARS-CoV-2 and seasonal flu. 

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
