### PR TITLE
migrate-group: Exclude S3 object keys containing "/" from syncing

### DIFF
--- a/scripts/migrate-group.js
+++ b/scripts/migrate-group.js
@@ -103,6 +103,7 @@ async function syncData({dryRun = true, group}) {
     filters: [
       "--exclude=*",
       "--include=*.json",
+      "--exclude=*/*",
     ]
   });
 
@@ -114,6 +115,7 @@ async function syncData({dryRun = true, group}) {
     filters: [
       "--exclude=*",
       "--include=*.md",
+      "--exclude=*/*",
       "--exclude=group-overview.md",
     ]
   });
@@ -132,8 +134,8 @@ async function syncData({dryRun = true, group}) {
 
   // Discover files to consider for manual review
   const unsynced = (await s3ListObjects({group})).filter(
-    key => !key.endsWith(".json")
-        && !key.endsWith(".md")
+    key => !(key.endsWith(".json") && !key.includes("/"))
+        && !(key.endsWith(".md") && !key.includes("/"))
         && key !== "group-overview.md"
         && key !== "group-logo.png"
   );


### PR DESCRIPTION
…even if they match *.json or *.md.  Instead, report them as unsynced files.

This correctly handles an observed case of an object named "archive/zika.json" that was dutifully copied over, though it would be inaccessible.

Related-to: <https://github.com/nextstrain/private/issues/66>

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Manually ran (in dry run mode!) against original group where this was observed
- [x] Checks pass (but are mostly meaningless)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
