### PR TITLE
auspice-client: Append extension on ESM imports

### DIFF
--- a/auspice-client/customisations/languageSelector.js
+++ b/auspice-client/customisations/languageSelector.js
@@ -1,5 +1,5 @@
 import React from "react"; // eslint-disable-line
-import ISO6391 from "iso-639-1/build/index";
+import ISO6391 from "iso-639-1/build/index.js";
 
 /* This and some of the following functions are reused
 in the static site (specifically ../../static-site/src/pages/ncov-sit-reps.jsx)

--- a/auspice-client/customisations/navbar.js
+++ b/auspice-client/customisations/navbar.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-multi-spaces */
 import React from "react"; // eslint-disable-line
-import LanguageSelector from "./languageSelector";
+import LanguageSelector from "./languageSelector.js";
 
 const logoPNG = require("./nextstrain-logo-small.png");
 

--- a/auspice-client/customisations/splash.js
+++ b/auspice-client/customisations/splash.js
@@ -1,7 +1,7 @@
 import React, {useState, useEffect} from "react"; // eslint-disable-line
 import styled from 'styled-components'; // eslint-disable-line
-import MarkdownDisplay from "auspice/src/components/markdownDisplay";
-import NavBar from "./navbar";
+import MarkdownDisplay from "auspice/src/components/markdownDisplay/index.js";
+import NavBar from "./navbar.js";
 
 
 /**


### PR DESCRIPTION
### Description of proposed changes

This is necessary for Webpack 5, which resolves paths as fully specified.

Something similar was done in the CJS→ESM migration (56b50c572d043fe296562b08ec7027bcc067260d), independent of `auspice-client`.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

For https://github.com/nextstrain/auspice/pull/1520 to work with nextstrain.org.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Changes work when applied to a preview PR with Auspice using Webpack 5 (see passing checks on db440438e71388ab37451204cce0051731476a3b)
- [x] Current checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
