### PR TITLE
Support downloading standalone installation archives from CI builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "iso-639-1": "^2.1.0",
         "jose": "npm:jose-node-cjs-runtime@^3.11.3",
         "js-yaml": "^4.0.0",
+        "jszip": "^3.10.1",
         "lodash.partition": "^4.6.0",
         "make-fetch-happen": "^10.0.0",
         "marked": "^0.7.0",
@@ -17836,6 +17837,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -21305,6 +21311,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
@@ -21388,6 +21405,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -22936,6 +22961,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/papaparse": {
       "version": "5.3.2",
@@ -24622,8 +24652,7 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "peer": true
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/setprototypeof": {
       "version": "1.1.1",
@@ -41141,6 +41170,11 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -43733,6 +43767,17 @@
         }
       }
     },
+    "jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "keyv": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
@@ -43801,6 +43846,14 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "lines-and-columns": {
@@ -44992,6 +45045,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "papaparse": {
       "version": "5.3.2",
@@ -46308,8 +46366,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "peer": true
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "setprototypeof": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "iso-639-1": "^2.1.0",
     "jose": "npm:jose-node-cjs-runtime@^3.11.3",
     "js-yaml": "^4.0.0",
+    "jszip": "^3.10.1",
     "lodash.partition": "^4.6.0",
     "make-fetch-happen": "^10.0.0",
     "marked": "^0.7.0",

--- a/src/app.js
+++ b/src/app.js
@@ -372,6 +372,9 @@ app.route(["/users", "/users/:name"])
 app.routeAsync("/cli/download/:version/:assetSuffix")
   .getAsync(endpoints.cli.download);
 
+app.routeAsync("/cli/download/ci-build/:runId/:assetSuffix")
+  .getAsync(endpoints.cli.downloadCIBuild);
+
 app.routeAsync("/cli/installer/:os")
   .getAsync(endpoints.cli.installer);
 

--- a/src/endpoints/cli.js
+++ b/src/endpoints/cli.js
@@ -1,4 +1,8 @@
-import { BadRequest, InternalServerError, NotFound } from '../httpErrors.js';
+/* eslint-disable no-use-before-define */
+import jszip from 'jszip';
+import mime from 'mime';
+import { pipeline } from 'stream/promises';
+import { BadRequest, InternalServerError, NotFound, ServiceUnavailable } from '../httpErrors.js';
 import { fetch } from '../fetch.js';
 
 
@@ -28,6 +32,55 @@ const download = async (req, res) => {
   }
 
   return res.redirect(asset.browser_download_url);
+};
+
+
+const downloadCIBuild = async (req, res) => {
+  if (!authorization) {
+    throw new ServiceUnavailable("Server does not have authorization to download CI builds.");
+  }
+
+  const runId = req.params.runId;
+  const assetSuffix = req.params.assetSuffix;
+  if (!runId || !assetSuffix) throw new BadRequest();
+
+  const endpoint = `https://api.github.com/repos/nextstrain/cli/actions/runs/${encodeURIComponent(runId)}/artifacts`;
+
+  const apiResponse = await fetch(endpoint, {headers: {authorization}});
+  assertStatusOk(apiResponse);
+
+  const artifacts = (await apiResponse.json()).artifacts;
+  const artifactName = assetSuffix.replace(/[.](tar[.]gz|zip)$/, "");
+  const artifact = artifacts.find(a => a.name === artifactName);
+
+  if (!artifact) {
+    throw new NotFound(`${endpoint} contains no artifact matching ${artifactName}`);
+  }
+
+  // Fetch the artifact's ZIP archive and unwrap the build archive inside.
+  const zipUrl = artifact.archive_download_url;
+  const zipResponse = await fetch(zipUrl, {headers: {authorization}});
+  assertStatusOk(zipResponse);
+
+  /* Unfortunately, this loads the entire ZIP into memory.  I couldn't find a
+   * library which supported streaming loads.  The closest was an outstanding
+   * PR of unknown status for node-stream-zip.¹  Ah well, this endpoint should
+   * only get light use by us developers anyway.
+   *   -trs, 6 Jan 2023
+   *
+   * ¹ https://github.com/antelle/node-stream-zip/pull/91/files
+   */
+  const zip = await jszip.loadAsync(zipResponse.arrayBuffer());
+  const asset = zip.filter((basename, file) => file.name.endsWith(`-${assetSuffix}`))[0];
+
+  if (!asset) {
+    throw new NotFound(`Artifact ZIP ${zipUrl} contains no file matching ${assetSuffix}`);
+  }
+
+  res.set("Content-Type", mime.getType(assetSuffix) || "application/octet-stream");
+
+  await pipeline(asset.nodeStream(), res);
+  return res.end();
 };
 
 
@@ -63,5 +116,6 @@ const installer = (req, res) => {
 
 export {
   download,
+  downloadCIBuild,
   installer,
 };

--- a/src/endpoints/cli.js
+++ b/src/endpoints/cli.js
@@ -17,17 +17,7 @@ const download = async (req, res) => {
     : `https://api.github.com/repos/nextstrain/cli/releases/tags/${encodeURIComponent(version)}`;
 
   const response = await fetch(endpoint, {headers: {authorization}});
-
-  switch (response.status) {
-    case 200:
-      break;
-
-    case 404:
-      throw new NotFound();
-
-    default:
-      throw new InternalServerError(`upstream said: ${response.status} ${response.statusText}`);
-  }
+  assertStatusOk(response);
 
   const release = await response.json();
   const assetName = `nextstrain-cli-${release.tag_name}-${assetSuffix}`;
@@ -38,6 +28,20 @@ const download = async (req, res) => {
   }
 
   return res.redirect(asset.browser_download_url);
+};
+
+
+const assertStatusOk = (response) => {
+  switch (response.status) {
+    case 200:
+      break;
+
+    case 404:
+      throw new NotFound();
+
+    default:
+      throw new InternalServerError(`upstream said: ${response.status} ${response.statusText}`);
+  }
 };
 
 

--- a/src/httpErrors.js
+++ b/src/httpErrors.js
@@ -7,6 +7,7 @@ export const {
   InternalServerError,
   NotAcceptable,
   NotFound,
+  ServiceUnavailable,
   Unauthorized,
   UnsupportedMediaType,
   isHttpError,


### PR DESCRIPTION
This new endpoint allows the standalone installer to install not just
released versions but also the builds produced by arbitrary CI runs.
That's very helpful for development and testing of PRs.  With this new
endpoint, for example, we can run:

    curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux \
        | DESTINATION=/tmp/cli bash -s ci-build/3859193828

to install /tmp/cli/nextstrain from:

    https://github.com/nextstrain/cli/actions/runs/3859193828#artifacts

Artifacts from GitHub Actions workflow runs require a bit more ceremony
than release assets, as all artifacts come wrapped in a ZIP file, which
we need to unwrap server-side for our installer.  Doing this server-side
also resolves the issue of artifacts requiring authentication to
download (despite that our artifacts are publicly visible).  Keeping the
additional complexity of API requests, authentication, and additional
compression out of the installer itself keeps the installer simpler and
thus more robust for end users.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Manual testing with both `curl` and the standalone installer pointed at my local server
- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
