### PR TITLE
endpoints/cli: Support downloading standalone installation archives from PR builds

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -372,6 +372,9 @@ app.route(["/users", "/users/:name"])
 app.routeAsync("/cli/download/:version/:assetSuffix")
   .getAsync(endpoints.cli.download);
 
+app.routeAsync("/cli/download/pr-build/:prId/:assetSuffix")
+  .getAsync(endpoints.cli.downloadPRBuild);
+
 app.routeAsync("/cli/download/ci-build/:runId/:assetSuffix")
   .getAsync(endpoints.cli.downloadCIBuild);
 


### PR DESCRIPTION
This new endpoint allows the standalone installer to install not just released versions but also the CI builds produced for arbitrary PRs. That's very helpful for development and testing of PRs.  With this new endpoint, for example, we can run:

    curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux \
        | DESTINATION=/tmp/cli bash -s pr-build/243

to install /tmp/cli/nextstrain from the last successful CI build for:

    https://github.com/nextstrain/cli/pulls/243

This uses existing support for downloading archives from CI builds.  The PR id is translated into the latest successful CI run id for that PR.

### Related issue(s)

#643 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Requests work locally as expected
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
