### PR TITLE
sources: Bypass CloudFront for core and staging source manifests

### DIFF
--- a/src/endpoints/charon/setAvailableDatasets.js
+++ b/src/endpoints/charon/setAvailableDatasets.js
@@ -122,12 +122,12 @@ const setAvailableDatasetsFromManifest = async () => {
   utils.verbose("Fetching manifests for core & staging");
 
   const servers = {
-    core: "data",
-    staging: "staging"
+    core: "nextstrain-data",
+    staging: "nextstrain-staging"
   };
 
   const promises = Object.keys(servers).map((server) => {
-    return fetch(`http://${servers[server]}.nextstrain.org/manifest_guest.json`)
+    return fetch(`https://${servers[server]}.s3.amazonaws.com/manifest_guest.json`)
       .then((result) => {
         return result.json();
       })


### PR DESCRIPTION
This usage was missed by "sources: Bypass CloudFront for core and staging source S3 buckets" (4365b26).  The rationale for that commit applies here as well.

Related-to: <https://github.com/nextstrain/nextstrain.org/pull/552>

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Manifest loads locally
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
