### PR TITLE
aws/iam: Manage IAM resources for the testing environment

### DIFF
--- a/aws/iam/variable-env.tf
+++ b/aws/iam/variable-env.tf
@@ -1,0 +1,1 @@
+../variable-env.tf

--- a/docs/terraform.rst
+++ b/docs/terraform.rst
@@ -185,7 +185,7 @@ Terraform thinks no changes need to be made.  It goes somewhat like this:
 
     .. code-block:: none
 
-        module.iam.aws_iam_policy.NextstrainDotOrgServerInstance
+        module.iam.aws_iam_policy.server
 
  4. Iteratively fill out the stub resource in the configuration with the help
     of inspecting the state::

--- a/env/production/terraform.tf
+++ b/env/production/terraform.tf
@@ -50,6 +50,8 @@ module "iam" {
   providers = {
     aws = aws
   }
+
+  env = "production"
 }
 
 moved {

--- a/env/testing/terraform.tf
+++ b/env/testing/terraform.tf
@@ -39,5 +39,11 @@ module "cognito" {
   ]
 }
 
-# Skip iam as it only applies to production (for now at least).
-#   -trs, 6 Feb 2023
+module "iam" {
+  source = "../../aws/iam"
+  providers = {
+    aws = aws
+  }
+
+  env = "testing"
+}


### PR DESCRIPTION
The "dev" policy becomes a general "non-production" policy, and we'll be able to use Terraform templating to tailor the policies to specific environments.  This will be necessary for Cognito access soon.

### Related issue(s)

#656 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Local server works
- [x] Terraform plan is as expected
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
