### PR TITLE
Allow read-only CORS requests for public resources

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -404,14 +404,14 @@ app.route("/cli")
  */
 /* eslint-disable no-multi-spaces */
 const schemaRoutes = [
-  ["/schemas/augur/frequencies",       "https://github.com/nextstrain/augur/raw/master/augur/data/schema-frequencies.json"],
-  ["/schemas/auspice/config/v2",       "https://github.com/nextstrain/augur/raw/master/augur/data/schema-auspice-config-v2.json"],
-  ["/schemas/dataset/v1/meta",         "https://github.com/nextstrain/augur/raw/master/augur/data/schema-export-v1-meta.json"],
-  ["/schemas/dataset/v1/tree",         "https://github.com/nextstrain/augur/raw/master/augur/data/schema-export-v1-tree.json"],
-  ["/schemas/dataset/v2",              "https://github.com/nextstrain/augur/raw/master/augur/data/schema-export-v2.json"],
-  ["/schemas/dataset/root-sequence",   "https://github.com/nextstrain/augur/raw/master/augur/data/schema-export-root-sequence.json"],
-  ["/schemas/dataset/tip-frequencies", "https://github.com/nextstrain/augur/raw/master/augur/data/schema-tip-frequencies.json"],
-  ["/schemas/dataset/measurements",    "https://github.com/nextstrain/augur/raw/master/augur/data/schema-measurements.json"],
+  ["/schemas/augur/frequencies",       "https://raw.githubusercontent.com/nextstrain/augur/master/augur/data/schema-frequencies.json"],
+  ["/schemas/auspice/config/v2",       "https://raw.githubusercontent.com/nextstrain/augur/master/augur/data/schema-auspice-config-v2.json"],
+  ["/schemas/dataset/v1/meta",         "https://raw.githubusercontent.com/nextstrain/augur/master/augur/data/schema-export-v1-meta.json"],
+  ["/schemas/dataset/v1/tree",         "https://raw.githubusercontent.com/nextstrain/augur/master/augur/data/schema-export-v1-tree.json"],
+  ["/schemas/dataset/v2",              "https://raw.githubusercontent.com/nextstrain/augur/master/augur/data/schema-export-v2.json"],
+  ["/schemas/dataset/root-sequence",   "https://raw.githubusercontent.com/nextstrain/augur/master/augur/data/schema-export-root-sequence.json"],
+  ["/schemas/dataset/tip-frequencies", "https://raw.githubusercontent.com/nextstrain/augur/master/augur/data/schema-tip-frequencies.json"],
+  ["/schemas/dataset/measurements",    "https://raw.githubusercontent.com/nextstrain/augur/master/augur/data/schema-measurements.json"],
 ];
 /* eslint-enable no-multi-spaces */
 

--- a/src/app.js
+++ b/src/app.js
@@ -113,6 +113,13 @@ app.use((req, res, next) => {
 authn.setup(app);
 
 
+/* CORS.
+ *
+ * After authn so it doesn't apply to those routes.
+ */
+app.use(middleware.allowPublicReadOnlyCors);
+
+
 /* Canary.
  */
 app.use((req, res, next) => {

--- a/src/endpoints/cli.js
+++ b/src/endpoints/cli.js
@@ -146,10 +146,10 @@ const installer = (req, res) => {
   switch (os) {
     case "linux":
     case "mac":
-      return res.redirect("https://github.com/nextstrain/cli/raw/HEAD/bin/standalone-installer-unix");
+      return res.redirect("https://raw.githubusercontent.com/nextstrain/cli/HEAD/bin/standalone-installer-unix");
 
     case "windows":
-      return res.redirect("https://github.com/nextstrain/cli/raw/HEAD/bin/standalone-installer-windows");
+      return res.redirect("https://raw.githubusercontent.com/nextstrain/cli/HEAD/bin/standalone-installer-windows");
 
     default:
       throw new NotFound(`No installer for OS: ${os}`);

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -3,6 +3,51 @@ import { BadRequest } from './httpErrors.js';
 import * as utils from './utils/index.js';
 
 
+/* CORS policy to allow read-only requests for public resources.
+ *
+ * Only set CORS response headers for GET and HEAD requests.  Do not support
+ * CORS preflight requests.  This prevents CORS requests for other methods and
+ * GET/HEAD requests which trigger the preflight requirement.
+ *
+ * Resources for further understanding:
+ *
+ *   • CORS protocol reference <https://fetch.spec.whatwg.org/#cors-protocol>
+ *   • MDN's guide to CORS <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>
+ */
+const allowedCorsMethods = new Set(["GET", "HEAD"]);
+
+const allowPublicReadOnlyCors = (req, res, next) => {
+  if (allowedCorsMethods.has(req.method)) {
+    /* All origins are ok for GET and HEAD requests.
+     *
+     * We primarily use the wildcard here—instead of reflecting the Origin
+     * request header—to avoid Vary-ing the response on Origin.  However, it also
+     * further prevents credentialed requests since they do not allow wildcard
+     * usage.¹
+     *
+     * ¹ https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#credentialed_requests_and_wildcards
+     */
+    res.set("Access-Control-Allow-Origin", "*");
+
+    /* All our response headers are ok to expose.
+     *
+     * This means requestors can use headers like Etag and Link.
+     */
+    res.set("Access-Control-Expose-Headers", "*");
+
+    /* Explicit forbid credentialed requests by making sure the header allowing
+     * them is omitted.
+     *
+     * This doesn't prevent simple credentialed requests from being made and us
+     * responding, but it does cause the browser to throw away the response and
+     * deny the requesting code access to it.
+     */
+    res.removeHeader("Access-Control-Allow-Credentials");
+  }
+  return next();
+};
+
+
 /**
  * Rejects any attempted path traversals (..) which may be present if the
  * client sending the request didn't normalize the URL path when making the
@@ -63,6 +108,7 @@ const copyCookie = (oldName, newName) => (req, res, next) => {
 
 
 export {
+  allowPublicReadOnlyCors,
   rejectParentTraversals,
   copyCookie,
 };

--- a/src/sources/community.js
+++ b/src/sources/community.js
@@ -42,7 +42,7 @@ class CommunitySource extends Source {
 
   get repo() { return `${this.owner}/${this.repoName}`; }
   async baseUrl() {
-    return `https://github.com/${this.repo}/raw/${await this.branch}/`;
+    return `https://raw.githubusercontent.com/${this.repo}/${await this.branch}/`;
   }
 
   async repoNameWithBranch() {


### PR DESCRIPTION
This makes it possible, for example, to do client-side analyses on the dataset JSONs using standard nextstrain.org URLs.  Requested by @corneliusroemer¹, as it makes it much easier to load arbitrary trees into Nextclade web.

It's also nice in principle to allow cross-origin requests for public resources since it enables unforeseen integrations without having to ask permission.

I didn't use the "cors" library here since it does a lot more than what we need, is more permissive by default, and setting our own headers is less of a blackbox and thus clearer as to what we're sending and when.

¹ <https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1666027479770509>
  <https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1676473418174269>

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Headers are as expected
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
