### PR TITLE
sources/community: Restore support for datasets/narratives stored with Git LFS

### DIFF
--- a/src/sources/community.js
+++ b/src/sources/community.js
@@ -42,7 +42,14 @@ class CommunitySource extends Source {
 
   get repo() { return `${this.owner}/${this.repoName}`; }
   async baseUrl() {
-    return `https://raw.githubusercontent.com/${this.repo}/${await this.branch}/`;
+    /* It's important to go thru github.com and let it redirect us to the final
+     * location, e.g. usually on raw.githubcontent.com.  We can't directly
+     * access the final location even though it seems constructable because
+     * some community repos use Git LFS to store their files and LFS blobs are
+     * hosted on a different final domain, media.githubusercontent.com.
+     *   -trs, 17 Feb 2023
+     */
+    return `https://github.com/${this.repo}/raw/${await this.branch}/`;
   }
 
   async repoNameWithBranch() {


### PR DESCRIPTION
This partially reverts «Remove an extra layer of CORS-unfriendly indirection from "raw" GitHub URLs» (d5ad654b) by switching this source's base URL back to github.com instead of
raw.githubusercontent.com.

It's important to go thru github.com and let it redirect us to the final location because GitHub serves LFS blobs on a different final domain, media.githubusercontent.com.

Related-to: <https://github.com/nextstrain/nextstrain.org/pull/658>
Related-to: <https://support.nextstrain.org/agent/nextstrain/nextstrain/tickets/details/668036000003625001>


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->
- [x] Broken community datasets now work
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
