### PR TITLE
Fix Gatsby proxy for dev

### DIFF
--- a/src/endpoints/static.js
+++ b/src/endpoints/static.js
@@ -97,7 +97,7 @@ const sendGatsbyPage = (page) => async (req, res) => {
     const pageUrl = (new URL(page, req.app.locals.gatsbyDevUrl)).toString();
 
     /* eslint-disable-next-line import/no-extraneous-dependencies */
-    const proxy = (await import("http-proxy")).createProxyServer({
+    const proxy = (await import("http-proxy")).default.createProxyServer({
       target: pageUrl,
       ignorePath: true, // ignore req.path since pageUrl is fully specified
     });


### PR DESCRIPTION
### Description of proposed changes

Prior to this commit, I was unable to load any individual Group page
after starting the dev server with `npm run dev`. I would get the error:
```
TypeError: (intermediate value).createProxyServer is not a function
```

Since `http-proxy` only has a default export¹, so we must access
the `default` property of the module in order to access
the `createProxyServer` method.

¹ https://github.com/http-party/node-http-proxy/blob/master/index.js#L13
### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->
Follow up of #583

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Locally tested with `npm run dev` then successfully loaded an individual Groups page (`/groups/blab`) 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
