### PR TITLE
Add workflow to auto-merge Auspice bump PRs

### DIFF
--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -1,0 +1,27 @@
+name: Dependabot automation
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  merge-auspice-bump:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Run if Auspice is an updated dependency and there are no major version bumps
+      # to allow for manual testing before merging.
+      - if: |
+          contains(fromJSON(steps.metadata.outputs.updated-dependencies-json).*.dependencyName, 'auspice')
+          && steps.metadata.outputs.update-type != 'version-update:semver-major'
+        # Dependabot should ensure CI passes before merging.
+        run: gh pr comment "${{ github.event.pull_request.html_url }}" --body "@dependabot merge"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_REPO }}


### PR DESCRIPTION
### Description of proposed changes

The auto-merge is reasonable because the target branch is deployed to the canary site (next.nextstrain.org), not the production site. Auto-merge allows us to test the latest Auspice release on the canary site without manually merging the automatically created version bump PRs.

### Changes outside of this PR

- [x] Regenerated `[org secret] GH_TOKEN_NEXTSTRAIN_BOT_REPO` and renamed as `[org Actions+Dependabot secret] GH_TOKEN_NEXTSTRAIN_BOT_REPO`
- [x] Created a new organization Dependabot secret on named `GH_TOKEN_NEXTSTRAIN_BOT_REPO` with the regenerated value
- [x] Updated the value of the existing organization Actions secret with the same name

### Related issue(s)

Prompted by [Slack discussion](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1679447507855999).

### Testing

- [x] Auto-merge was successful through manual testing on my personal fork repo ([PR](https://github.com/victorlin/nextstrain.org/pull/4), [run](https://github.com/victorlin/nextstrain.org/actions/runs/4513731600/jobs/7948936949)). Dependabot will wait for CI to pass then merge.
- [ ] Post-merge: new job is skipped on non-dependabot PRs (can't test this until the workflow exists in `master`)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
