### PR TITLE
Add page to edit group customizations

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -323,6 +323,9 @@ app.routeAsync("/groups/:groupName")
 app.use("/groups/:groupName/settings",
   endpoints.groups.setGroup(req => req.params.groupName));
 
+app.routeAsync("/groups/:groupName/settings")
+  .getAsync(endpoints.static.sendGatsbyEntrypoint);
+
 app.routeAsync("/groups/:groupName/settings/logo")
   .getAsync(getGroupLogo)
   .putAsync(putGroupLogo)

--- a/src/app.js
+++ b/src/app.js
@@ -43,6 +43,7 @@ const {
 } = endpoints.sources;
 
 const {
+  optionsGroupSettings,
   getGroupLogo,
   putGroupLogo,
   deleteGroupLogo,
@@ -326,12 +327,14 @@ app.routeAsync("/groups/:groupName/settings/logo")
   .getAsync(getGroupLogo)
   .putAsync(putGroupLogo)
   .deleteAsync(deleteGroupLogo)
+  .optionsAsync(optionsGroupSettings)
 ;
 
 app.routeAsync("/groups/:groupName/settings/overview")
   .getAsync(getGroupOverview)
   .putAsync(putGroupOverview)
   .deleteAsync(deleteGroupOverview)
+  .optionsAsync(optionsGroupSettings)
 ;
 
 app.route("/groups/:groupName/settings/*")

--- a/src/async.js
+++ b/src/async.js
@@ -284,6 +284,14 @@ function addAsync(app) {
     return app.head.apply(app, args);
   };
 
+  app.optionsAsync = function() {
+    const fn = arguments[arguments.length - 1];
+    assert.ok(typeof fn === 'function',
+      'Last argument to `optionsAsync()` must be a function');
+    const args = wrapArgs(arguments);
+    return app.options.apply(app, args);
+  };
+
   return app;
 }
 

--- a/src/endpoints/groups.js
+++ b/src/endpoints/groups.js
@@ -17,6 +17,18 @@ const setGroup = (nameExtractor) => (req, res, next) => {
 /* Group customizations
  */
 
+const optionsGroupSettings = (req, res) => {
+  authz.assertAuthorized(req.user, authz.actions.Read, req.context.group);
+
+  const allowedMethods = ["OPTIONS", "GET", "HEAD"];
+
+  if (authz.authorized(req.user, authz.actions.Write, req.context.group)) {
+    allowedMethods.push("PUT", "DELETE");
+  }
+
+  res.set("Allow", allowedMethods);
+  return res.status(204).end();
+};
 
 /* Group logo
  */
@@ -151,6 +163,7 @@ async function receiveGroupLogo(req, res) {
 
 export {
   setGroup,
+  optionsGroupSettings,
   getGroupLogo,
   putGroupLogo,
   deleteGroupLogo,

--- a/static-site/gatsby-node.js
+++ b/static-site/gatsby-node.js
@@ -200,6 +200,12 @@ exports.createPages = ({graphql, actions}) => {
           component: path.resolve("src/sections/individual-group-page.jsx")
         });
 
+        createPage({
+          path: "/groups/:groupName/settings",
+          matchPath: "/groups/:groupName/settings/*",
+          component: path.resolve("src/sections/group-settings-page.jsx")
+        });
+
         // Community splash page
         createPage({
           path: "/community",

--- a/static-site/src/components/Datasets/situation-reports-by-language.jsx
+++ b/static-site/src/components/Datasets/situation-reports-by-language.jsx
@@ -5,6 +5,7 @@ import {FaFile} from "react-icons/fa";
 import { FlexCenter } from "../../layouts/generalComponents";
 import * as splashStyles from "../splash/styles";
 import CollapseTitle from "../Misc/collapse-title";
+import { DataFetchErrorParagraph } from "../splash/errorMessages";
 
 const charonGetAvailableAddress = "/charon/getAvailable";
 
@@ -71,10 +72,7 @@ export class SituationReportsByLanguage extends React.Component {
   render() {
     return (
       <>
-        { this.state.hasError && <splashStyles.CenteredFocusParagraph>
-                          Something went wrong getting situation reports.
-                          Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
-                          if this continues to happen.</splashStyles.CenteredFocusParagraph>}
+        { this.state.hasError && <DataFetchErrorParagraph />}
 
         {/* Sit Reps */
           !this.state.hasError &&

--- a/static-site/src/components/Groups/edit-logo-form.jsx
+++ b/static-site/src/components/Groups/edit-logo-form.jsx
@@ -24,7 +24,7 @@ const EditLogoForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
   const getGroupLogo = async () => {
     clearErrorMessage();
     try {
-      const response = await fetch(`/groups/${groupName}/settings/logo`);
+      const response = await fetch(`/groups/${encodeURIComponent(groupName)}/settings/logo`);
       if (response.status === 404) return null;
       if (response.ok) return URL.createObjectURL(await response.blob());
       createErrorMessage(response.statusText);
@@ -41,7 +41,7 @@ const EditLogoForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
     setDeletionInProgress(true);
 
     try {
-      const response = await fetch(`/groups/${groupName}/settings/logo`, {method: "DELETE"});
+      const response = await fetch(`/groups/${encodeURIComponent(groupName)}/settings/logo`, {method: "DELETE"});
       response.ok
         ? setLogo({ ...logo, current: null })
         : createErrorMessage(response.statusText);
@@ -59,7 +59,7 @@ const EditLogoForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
     setUploadInProgress(true);
 
     try {
-      const response = await fetch(`/groups/${groupName}/settings/logo`, {
+      const response = await fetch(`/groups/${encodeURIComponent(groupName)}/settings/logo`, {
         method: "PUT",
         headers: {
           "Content-Type": "image/png"

--- a/static-site/src/components/Groups/edit-logo-form.jsx
+++ b/static-site/src/components/Groups/edit-logo-form.jsx
@@ -1,15 +1,13 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { MediumSpacer } from "../../layouts/generalComponents";
 import * as splashStyles from "../splash/styles";
-import { AvatarWithoutMargins, CenteredForm, InputButton } from "./styles";
+import { AvatarWithoutMargins, CenteredForm, InputButton, InputLabel} from "./styles";
 
 
 const EditLogoForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
   const [ logo, setLogo ] = useState({ current: null, new: null });
   const [ deletionInProgress, setDeletionInProgress ] = useState(false);
   const [ uploadInProgress, setUploadInProgress ] = useState(false);
-  // Ref to allow us to create click event for hidden file input
-  const fileInput = useRef(null);
 
   useEffect(() => {
     const setCurrentLogo = async () => {
@@ -79,12 +77,6 @@ const EditLogoForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
     setUploadInProgress(false);
   }
 
-  const handleUploadButton = (e) => {
-    e.preventDefault();
-    clearErrorMessage();
-    fileInput.current.click();
-  }
-
   const previewImage = (e) => {
     e.preventDefault();
     clearErrorMessage();
@@ -109,11 +101,10 @@ const EditLogoForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
         : <splashStyles.H4>No current logo</splashStyles.H4>
       }
 
-      {/* Hide the file input to allow for custom text in button */}
-      <InputButton onClick={handleUploadButton}>
+      <InputLabel>
         Choose new logo
-      </InputButton>
-      <input type="file" ref={fileInput} style={{ display: "none" }} accept="image/png" onChange={previewImage}/>
+        <input type="file" style={{ display: "none" }} accept="image/png" onChange={previewImage}/>
+      </InputLabel>
 
       {logo.new
         ? <>

--- a/static-site/src/components/Groups/edit-logo-form.jsx
+++ b/static-site/src/components/Groups/edit-logo-form.jsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useRef, useState } from "react";
+import { MediumSpacer } from "../../layouts/generalComponents";
+import * as splashStyles from "../splash/styles";
+import { AvatarWithoutMargins, CenteredForm, InputButton } from "./styles";
+
+
+const EditLogoForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
+  const [ logo, setLogo ] = useState({ current: null, new: null });
+  const [ deletionInProgress, setDeletionInProgress ] = useState(false);
+  const [ uploadInProgress, setUploadInProgress ] = useState(false);
+  // Ref to allow us to create click event for hidden file input
+  const fileInput = useRef(null);
+
+  useEffect(() => {
+    const setCurrentLogo = async () => {
+      const currentLogo = await getGroupLogo();
+      if (!cleanUp) setLogo({ ...logo, current: currentLogo });
+    }
+
+    let cleanUp = false;
+    setCurrentLogo();
+    return () => cleanUp = true;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const getGroupLogo = async () => {
+    clearErrorMessage();
+    try {
+      const response = await fetch(`/groups/${groupName}/settings/logo`);
+      if (response.status === 404) return null;
+      if (response.ok) return URL.createObjectURL(await response.blob());
+      createErrorMessage(response.statusText);
+    } catch (err) {
+      console.error(err.message)
+      createErrorMessage();
+    }
+  }
+
+  const deleteGroupLogo = async (e) => {
+    e.preventDefault();
+    clearErrorMessage();
+    // TODO: Ask for confirmation before deleting?
+    setDeletionInProgress(true);
+
+    try {
+      const response = await fetch(`/groups/${groupName}/settings/logo`, {method: "DELETE"});
+      response.ok
+        ? setLogo({ ...logo, current: null })
+        : createErrorMessage(response.statusText);
+    } catch (err) {
+      console.error(err.message);
+      createErrorMessage()
+    }
+
+    setDeletionInProgress(false);
+  }
+
+  const uploadGroupLogo = async (e) => {
+    e.preventDefault();
+    clearErrorMessage();
+    setUploadInProgress(true);
+
+    try {
+      const response = await fetch(`/groups/${groupName}/settings/logo`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "image/png"
+        },
+        body: logo.new
+      });
+      response.ok
+        ? setLogo({ new: null, current: await getGroupLogo() })
+        : createErrorMessage(response.statusText);
+    } catch (err) {
+      console.error(err.message);
+      createErrorMessage();
+    }
+
+    setUploadInProgress(false);
+  }
+
+  const handleUploadButton = (e) => {
+    e.preventDefault();
+    clearErrorMessage();
+    fileInput.current.click();
+  }
+
+  const previewImage = (e) => {
+    e.preventDefault();
+    clearErrorMessage();
+    setLogo({ ...logo, new: e.target.files[0] });
+  }
+
+  return (
+    <CenteredForm>
+      {logo.current
+        ? <>
+            <splashStyles.H4>Current Logo:</splashStyles.H4>
+            <AvatarWithoutMargins alt="group-logo" src={logo.current}/>
+            <InputButton
+              disabled={deletionInProgress || uploadInProgress}
+              onClick={deleteGroupLogo}>
+              {deletionInProgress
+                ? "Deleting current logo..."
+                : "Delete current logo"
+              }
+            </InputButton>
+          </>
+        : <splashStyles.H4>No Current Logo</splashStyles.H4>
+      }
+
+      {/* Hide the file input to allow for custom text in button */}
+      <InputButton onClick={handleUploadButton}>
+        Choose new logo
+      </InputButton>
+      <input type="file" ref={fileInput} style={{ display: "none" }} accept="image/png" onChange={previewImage}/>
+
+      {logo.new
+        ? <>
+            <MediumSpacer/>
+            <splashStyles.H4>Logo Preview:</splashStyles.H4>
+            <AvatarWithoutMargins alt="group-logo-preview" src={URL.createObjectURL(logo.new)}/>
+            <InputButton
+              disabled={deletionInProgress || uploadInProgress}
+              onClick={uploadGroupLogo}>
+              {uploadInProgress
+                ? "Uploading new logo..."
+                : "Upload new logo"
+              }
+            </InputButton>
+          </>
+        : null
+      }
+    </CenteredForm>
+  );
+};
+
+export default EditLogoForm;

--- a/static-site/src/components/Groups/edit-logo-form.jsx
+++ b/static-site/src/components/Groups/edit-logo-form.jsx
@@ -95,7 +95,7 @@ const EditLogoForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
     <CenteredForm>
       {logo.current
         ? <>
-            <splashStyles.H4>Current Logo:</splashStyles.H4>
+            <splashStyles.H4>Current logo</splashStyles.H4>
             <AvatarWithoutMargins alt="group-logo" src={logo.current}/>
             <InputButton
               disabled={deletionInProgress || uploadInProgress}
@@ -106,7 +106,7 @@ const EditLogoForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
               }
             </InputButton>
           </>
-        : <splashStyles.H4>No Current Logo</splashStyles.H4>
+        : <splashStyles.H4>No current logo</splashStyles.H4>
       }
 
       {/* Hide the file input to allow for custom text in button */}
@@ -118,7 +118,7 @@ const EditLogoForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
       {logo.new
         ? <>
             <MediumSpacer/>
-            <splashStyles.H4>Logo Preview:</splashStyles.H4>
+            <splashStyles.H4>New logo preview</splashStyles.H4>
             <AvatarWithoutMargins alt="group-logo-preview" src={URL.createObjectURL(logo.new)}/>
             <InputButton
               disabled={deletionInProgress || uploadInProgress}

--- a/static-site/src/components/Groups/edit-overview-form.jsx
+++ b/static-site/src/components/Groups/edit-overview-form.jsx
@@ -86,6 +86,10 @@ const EditOverviewForm = ({ groupName, createErrorMessage, clearErrorMessage }) 
     <CenteredForm style={{ flexGrow: 3 }} onSubmit={uploadOverview}>
       <label htmlFor="edit-group-overview">
         <splashStyles.H4>Overview</splashStyles.H4>
+        <splashStyles.CenteredFocusParagraph style={{ margin: 5 }}>
+          See <a href="https://docs.nextstrain.org/en/latest/guides/share/groups/customize.html" target="_blank" rel="noopener noreferrer">Group customization docs </a>
+          for details on how to format your overview.
+        </splashStyles.CenteredFocusParagraph>
       </label>
       <TextArea
         id="edit-group-overview"

--- a/static-site/src/components/Groups/edit-overview-form.jsx
+++ b/static-site/src/components/Groups/edit-overview-form.jsx
@@ -62,9 +62,12 @@ const EditOverviewForm = ({ groupName, createErrorMessage, clearErrorMessage }) 
         body: overview
       });
 
-      response.ok
-        ? setUploadComplete(true)
-        : createErrorMessage(response);
+      if (response.ok) {
+        setUploadComplete(true)
+        setOverview(await getOverview());
+      } else {
+        createErrorMessage(response);
+      }
     } catch (err) {
       console.error(err.message);
       createErrorMessage();

--- a/static-site/src/components/Groups/edit-overview-form.jsx
+++ b/static-site/src/components/Groups/edit-overview-form.jsx
@@ -33,7 +33,7 @@ const EditOverviewForm = ({ groupName, createErrorMessage, clearErrorMessage }) 
   const getOverview = async () => {
     clearErrorMessage();
     try {
-      const response = await fetch(`/groups/${groupName}/settings/overview`);
+      const response = await fetch(`/groups/${encodeURIComponent(groupName)}/settings/overview`);
       if (response.status === 404) return OVERVIEW_TEMPLATE;
       if (response.ok) {
         const currentOverview = await response.text();
@@ -54,7 +54,7 @@ const EditOverviewForm = ({ groupName, createErrorMessage, clearErrorMessage }) 
     setUploadInProgress(true);
 
     try {
-      const response = await fetch(`/groups/${groupName}/settings/overview`, {
+      const response = await fetch(`/groups/${encodeURIComponent(groupName)}/settings/overview`, {
         method: "PUT",
         headers: {
           "Content-Type": "text/markdown"

--- a/static-site/src/components/Groups/edit-overview-form.jsx
+++ b/static-site/src/components/Groups/edit-overview-form.jsx
@@ -10,7 +10,7 @@ showDatasets:
 showNarratives:
 ---
 
-Add description of your group here.
+<!-- Replace this line with a description of your group. -->
 `;
 
 const EditOverviewForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
@@ -85,7 +85,7 @@ const EditOverviewForm = ({ groupName, createErrorMessage, clearErrorMessage }) 
   return (
     <CenteredForm style={{ flexGrow: 3 }} onSubmit={uploadOverview}>
       <label htmlFor="edit-group-overview">
-        <splashStyles.H4>Edit Overview:</splashStyles.H4>
+        <splashStyles.H4>Overview</splashStyles.H4>
       </label>
       <TextArea
         id="edit-group-overview"

--- a/static-site/src/components/Groups/edit-overview-form.jsx
+++ b/static-site/src/components/Groups/edit-overview-form.jsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from "react";
+import * as splashStyles from "../splash/styles";
+import { CenteredForm, InputButton, TextArea } from "./styles";
+
+const OVERVIEW_TEMPLATE = `---
+title:
+byline:
+website:
+showDatasets:
+showNarratives:
+---
+
+Add description of your group here.
+`;
+
+const EditOverviewForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
+  const [ overview, setOverview ] = useState();
+  const [ uploadInProgress, setUploadInProgress ] = useState(false);
+  const [ uploadComplete, setUploadComplete ] = useState(false);
+
+  useEffect(() => {
+    const setCurrentOverview = async () => {
+      const currentOverview = await getOverview();
+      if (!cleanUp) setOverview(currentOverview);
+    }
+
+    let cleanUp = false;
+    setCurrentOverview();
+    return () => cleanUp = true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const getOverview = async () => {
+    clearErrorMessage();
+    try {
+      const response = await fetch(`/groups/${groupName}/settings/overview`);
+      if (response.status === 404) return OVERVIEW_TEMPLATE;
+      if (response.ok) {
+        const currentOverview = await response.text();
+        return currentOverview.trim().length > 0
+          ? currentOverview
+          : OVERVIEW_TEMPLATE;
+      }
+      createErrorMessage(response);
+    } catch (err) {
+      console.error(err.message)
+      createErrorMessage();
+    }
+  }
+
+  const uploadOverview = async (e) => {
+    e.preventDefault();
+    clearErrorMessage();
+    setUploadInProgress(true);
+
+    try {
+      const response = await fetch(`/groups/${groupName}/settings/overview`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "text/markdown"
+        },
+        body: overview
+      });
+
+      response.ok
+        ? setUploadComplete(true)
+        : createErrorMessage(response);
+    } catch (err) {
+      console.error(err.message);
+      createErrorMessage();
+    }
+
+    setUploadInProgress(false);
+  }
+
+  const changeOverview = (e) => {
+    e.preventDefault();
+    clearErrorMessage();
+    if (uploadInProgress) return;
+    if (uploadComplete) setUploadComplete(false);
+
+    setOverview(e.target.value);
+  }
+
+  return (
+    <CenteredForm style={{ flexGrow: 3 }} onSubmit={uploadOverview}>
+      <label htmlFor="edit-group-overview">
+        <splashStyles.H4>Edit Overview:</splashStyles.H4>
+      </label>
+      <TextArea
+        id="edit-group-overview"
+        value={overview}
+        onChange={changeOverview}
+        disabled={uploadInProgress}
+      />
+      <InputButton
+        type="submit"
+        disabled={uploadInProgress || uploadComplete}>
+        {uploadInProgress
+          ? "Uploading overview..."
+          : uploadComplete
+            ? "Overview successfully uploaded"
+            : "Upload overview"}
+      </InputButton>
+    </CenteredForm>
+  );
+}
+
+export default EditOverviewForm;

--- a/static-site/src/components/Groups/edit-overview-form.jsx
+++ b/static-site/src/components/Groups/edit-overview-form.jsx
@@ -90,7 +90,7 @@ const EditOverviewForm = ({ groupName, createErrorMessage, clearErrorMessage }) 
       <label htmlFor="edit-group-overview">
         <splashStyles.H4>Overview</splashStyles.H4>
         <splashStyles.CenteredFocusParagraph style={{ margin: 5 }}>
-          See <a href="https://docs.nextstrain.org/en/latest/guides/share/groups/customize.html" target="_blank" rel="noopener noreferrer">Group customization docs </a>
+          See <a href="https://docs.nextstrain.org/page/guides/share/groups/customize.html" target="_blank">Group customization docs</a>{' '}
           for details on how to format your overview.
         </splashStyles.CenteredFocusParagraph>
       </label>

--- a/static-site/src/components/Groups/styles.jsx
+++ b/static-site/src/components/Groups/styles.jsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { AvatarImg } from "../splash/sourceInfoHeading";
 
 export const CenteredForm = styled.form`
@@ -10,7 +10,7 @@ export const CenteredForm = styled.form`
   margin: 10px;
 `;
 
-export const InputButton = styled.button`
+const sharedInputStyle = css`
   border: 1px solid #CCC;
   background-color: inherit;
   border-radius: 3px;
@@ -23,9 +23,24 @@ export const InputButton = styled.button`
   text-transform: uppercase;
   vertical-align: middle;
   margin: 5px;
+`;
+
+const sharedInputHoverStyle = css`
+  color: black;
+  border: 1px solid black;
+`;
+
+export const InputLabel = styled.label`
+  ${sharedInputStyle}
+  &:hover {
+    ${sharedInputHoverStyle}
+  }
+`;
+
+export const InputButton = styled.button`
+  ${sharedInputStyle}
   &:hover:enabled {
-    color: black;
-    border: 1px solid black;
+    ${sharedInputHoverStyle}
   }
   &:disabled {
     border: none;

--- a/static-site/src/components/Groups/styles.jsx
+++ b/static-site/src/components/Groups/styles.jsx
@@ -4,7 +4,7 @@ import { AvatarImg } from "../splash/sourceInfoHeading";
 export const CenteredForm = styled.form`
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   align-content: center;
   margin: 10px;
@@ -40,6 +40,6 @@ export const TextArea = styled.textarea`
 width: 100%;
 height: 100%;
 font-size: 14px;
-font-family: ${(props) => props.theme.generalFont};
+font-family: monospace;
 color: ${(props) => props.theme.darkGrey};
 `;

--- a/static-site/src/components/Groups/styles.jsx
+++ b/static-site/src/components/Groups/styles.jsx
@@ -35,3 +35,11 @@ export const InputButton = styled.button`
 export const AvatarWithoutMargins = styled(AvatarImg)`
   margin: 0;
 `;
+
+export const TextArea = styled.textarea`
+width: 100%;
+height: 100%;
+font-size: 14px;
+font-family: ${(props) => props.theme.generalFont};
+color: ${(props) => props.theme.darkGrey};
+`;

--- a/static-site/src/components/Groups/styles.jsx
+++ b/static-site/src/components/Groups/styles.jsx
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+import { AvatarImg } from "../splash/sourceInfoHeading";
+
+export const CenteredForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  align-content: center;
+  margin: 10px;
+`;
+
+export const InputButton = styled.button`
+  border: 1px solid #CCC;
+  background-color: inherit;
+  border-radius: 3px;
+  cursor: pointer;
+  padding: 5px 10px 5px 10px;
+  font-size: 12px;
+  font-family: ${(props) => props.theme.generalFont};
+  color: ${(props) => props.theme.darkGrey};
+  font-weight: 400;
+  text-transform: uppercase;
+  vertical-align: middle;
+  margin: 5px;
+  &:hover:enabled {
+    color: black;
+    border: 1px solid black;
+  }
+  &:disabled {
+    border: none;
+  }
+`;
+
+export const AvatarWithoutMargins = styled(AvatarImg)`
+  margin: 0;
+`;

--- a/static-site/src/components/splash/errorMessages.jsx
+++ b/static-site/src/components/splash/errorMessages.jsx
@@ -16,3 +16,10 @@ export const ErrorBanner = ({title, contents}) => (
     <p>{contents}</p>
   </splashStyles.FixedBanner>
 );
+
+export const DataFetchErrorParagraph = () => (
+  <splashStyles.CenteredFocusParagraph>
+    Something went wrong getting data.
+    Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a> if this continues to happen.
+  </splashStyles.CenteredFocusParagraph>
+);

--- a/static-site/src/components/splash/sourceInfoHeading.jsx
+++ b/static-site/src/components/splash/sourceInfoHeading.jsx
@@ -29,13 +29,15 @@ const OverviewContainer = styled.div`
   }
 `;
 
+export const AvatarImg = styled.img`
+  width: 140px;
+  margin-right: 20px;
+  object-fit: contain;
+`;
+
 function Title({avatarSrc, children}) {
   if (!children) return null;
-  const AvatarImg = styled.img`
-    width: 140px;
-    margin-right: 20px;
-    object-fit: contain;
-  `;
+
   const TitleDiv = styled.div`
     font-weight: 500;
     font-size: 26px;

--- a/static-site/src/layouts/generalComponents.jsx
+++ b/static-site/src/layouts/generalComponents.jsx
@@ -26,6 +26,13 @@ export const FlexGridLeft = styled.div`
   flex-wrap: wrap;
 `;
 
+export const FlexGridRight = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+`
+
 export const SmallSpacer = styled.div`
   height: 5px;
 `;

--- a/static-site/src/pages/groups.jsx
+++ b/static-site/src/pages/groups.jsx
@@ -8,6 +8,7 @@ import DatasetSelect from "../components/Datasets/dataset-select";
 import { GroupCards } from "../components/splash/userGroups";
 import GenericPage from "../layouts/generic-page";
 import { UserContext } from "../layouts/userDataWrapper";
+import { DataFetchErrorParagraph } from "../components/splash/errorMessages";
 
 const title = "Scalable Sharing with Nextstrain Groups";
 const abstract = (<>
@@ -140,10 +141,7 @@ class GroupsPage extends React.Component {
             columns={datasetColumns({isNarrative: true})}
           />
         )}
-        { this.state.errorFetchingData && <splashStyles.CenteredFocusParagraph>
-                          Something went wrong getting data.
-                          Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
-                          if this continues to happen.</splashStyles.CenteredFocusParagraph>}
+        { this.state.errorFetchingData && <DataFetchErrorParagraph />}
 
       </>
     );

--- a/static-site/src/sections/group-settings-page.jsx
+++ b/static-site/src/sections/group-settings-page.jsx
@@ -40,7 +40,7 @@ const EditGroupSettingsPage = ({ location, groupName }) => {
   return (
     <GenericPage location={location}>
       <FlexGridRight>
-        <splashStyles.Button to={`/groups/${groupName}`}>
+        <splashStyles.Button to={`/groups/${encodeURIComponent(groupName)}`}>
           Return to "{groupName}" Page
         </splashStyles.Button>
       </FlexGridRight>
@@ -73,7 +73,7 @@ const EditGroupSettingsPage = ({ location, groupName }) => {
 
 export const canUserEditGroupSettings = async (groupName) => {
   try {
-    const groupOverviewOptions = await fetch(`/groups/${groupName}/settings/overview`, { method: "OPTIONS" });
+    const groupOverviewOptions = await fetch(`/groups/${encodeURIComponent(groupName)}/settings/overview`, { method: "OPTIONS" });
     const allowedMethods = new Set(groupOverviewOptions.headers.get("Allow")?.split(/\s*,\s*/));
     const editMethods = ["PUT", "DELETE"];
     return editMethods.every((method) => allowedMethods.has(method));

--- a/static-site/src/sections/group-settings-page.jsx
+++ b/static-site/src/sections/group-settings-page.jsx
@@ -6,10 +6,10 @@ import { FlexGrid, FlexGridRight, HugeSpacer, MediumSpacer } from "../layouts/ge
 import EditLogoForm from "../components/Groups/edit-logo-form";
 import EditOverviewForm from "../components/Groups/edit-overview-form";
 
-const UNAUTHORIZED_MESSAGE = `
-  You must have the owners role within a group to edit group settings.
-  If your permissions have changed recently, try logging out and logging back in.
-`;
+const UNAUTHORIZED_MESSAGE = <>
+  You must have the owners role within a group to edit group settings.<br/>
+  If your permissions have changed recently, try <a href="/logout">logging out</a> and logging back in.<br/>
+</>;
 
 const EditGroupSettingsPage = ({ location, groupName }) => {
   const [ userAuthorized, setUserAuthorized ] = useState(null);

--- a/static-site/src/sections/group-settings-page.jsx
+++ b/static-site/src/sections/group-settings-page.jsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from "react";
 import * as splashStyles from "../components/splash/styles";
 import { ErrorBanner } from "../components/splash/errorMessages";
 import GenericPage from "../layouts/generic-page";
-import { FlexGridRight, HugeSpacer, MediumSpacer } from "../layouts/generalComponents";
+import { FlexGrid, FlexGridRight, HugeSpacer, MediumSpacer } from "../layouts/generalComponents";
+import EditLogoForm from "../components/Groups/edit-logo-form";
 
 const UNAUTHORIZED_MESSAGE = `
   You must have the owners role within a group to edit group settings.
@@ -11,6 +12,7 @@ const UNAUTHORIZED_MESSAGE = `
 
 const EditGroupSettingsPage = ({ location, groupName }) => {
   const [ userAuthorized, setUserAuthorized ] = useState(true);
+  const [ errorMessage, setErrorMessage ] = useState();
 
   useEffect(() => {
     const checkUserAuthz = async () => {
@@ -23,6 +25,17 @@ const EditGroupSettingsPage = ({ location, groupName }) => {
     return () => cleanUp = true;
   }, [groupName]);
 
+  const createErrorMessage = (details) => {
+    setErrorMessage({
+      title: "An error occurred when trying to fetch or update group settings. Please try again.",
+      contents: details ? `Error details: ${details}` : null
+    });
+  };
+
+  const clearErrorMessage = () => {
+    if (errorMessage) setErrorMessage(null);
+  };
+
   return (
     <GenericPage location={location}>
       <FlexGridRight>
@@ -32,13 +45,20 @@ const EditGroupSettingsPage = ({ location, groupName }) => {
       </FlexGridRight>
       <MediumSpacer/>
 
+      {errorMessage && <ErrorBanner title={errorMessage.title} contents={errorMessage.contents} />}
+
       <splashStyles.H2>
         Editing "{groupName}" Group Settings
       </splashStyles.H2>
       <HugeSpacer/>
 
       {userAuthorized
-        ? <p>Placeholder for editing forms.</p>
+        ? <FlexGrid>
+            <EditLogoForm
+              groupName={groupName}
+              createErrorMessage={createErrorMessage}
+              clearErrorMessage={clearErrorMessage}/>
+          </FlexGrid>
         : <ErrorBanner title={UNAUTHORIZED_MESSAGE}/>}
     </GenericPage>
   )

--- a/static-site/src/sections/group-settings-page.jsx
+++ b/static-site/src/sections/group-settings-page.jsx
@@ -12,13 +12,13 @@ const UNAUTHORIZED_MESSAGE = `
 `;
 
 const EditGroupSettingsPage = ({ location, groupName }) => {
-  const [ userAuthorized, setUserAuthorized ] = useState(true);
+  const [ userAuthorized, setUserAuthorized ] = useState(null);
   const [ errorMessage, setErrorMessage ] = useState();
 
   useEffect(() => {
     const checkUserAuthz = async () => {
-      if (! await canUserEditGroupSettings(groupName) && !cleanUp){
-        setUserAuthorized(false);
+      if (!cleanUp) {
+        setUserAuthorized(await canUserEditGroupSettings(groupName));
       }
     }
     let cleanUp = false;
@@ -53,18 +53,20 @@ const EditGroupSettingsPage = ({ location, groupName }) => {
       </splashStyles.H2>
       <HugeSpacer/>
 
-      {userAuthorized
-        ? <FlexGrid style={{ minHeight: "500px" }}>
-            <EditLogoForm
-              groupName={groupName}
-              createErrorMessage={createErrorMessage}
-              clearErrorMessage={clearErrorMessage}/>
-            <EditOverviewForm
-              groupName={groupName}
-              createErrorMessage={createErrorMessage}
-              clearErrorMessage={clearErrorMessage}/>
-          </FlexGrid>
-        : <ErrorBanner title={UNAUTHORIZED_MESSAGE}/>}
+      {userAuthorized === null
+        ? <splashStyles.H4>Checking user role in group</splashStyles.H4>
+        : userAuthorized
+          ? <FlexGrid style={{ minHeight: "500px" }}>
+              <EditLogoForm
+                groupName={groupName}
+                createErrorMessage={createErrorMessage}
+                clearErrorMessage={clearErrorMessage}/>
+              <EditOverviewForm
+                groupName={groupName}
+                createErrorMessage={createErrorMessage}
+                clearErrorMessage={clearErrorMessage}/>
+            </FlexGrid>
+          : <ErrorBanner title={UNAUTHORIZED_MESSAGE}/>}
     </GenericPage>
   )
 };

--- a/static-site/src/sections/group-settings-page.jsx
+++ b/static-site/src/sections/group-settings-page.jsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from "react";
+import * as splashStyles from "../components/splash/styles";
+import { ErrorBanner } from "../components/splash/errorMessages";
+import GenericPage from "../layouts/generic-page";
+import { FlexGridRight, HugeSpacer, MediumSpacer } from "../layouts/generalComponents";
+
+const UNAUTHORIZED_MESSAGE = `
+  You must have the owners role within a group to edit group settings.
+  If your permissions have changed recently, try logging out and logging back in.
+`;
+
+const EditGroupSettingsPage = ({ location, groupName }) => {
+  const [ userAuthorized, setUserAuthorized ] = useState(true);
+
+  useEffect(() => {
+    const checkUserAuthz = async () => {
+      if (! await canUserEditGroupSettings(groupName) && !cleanUp){
+        setUserAuthorized(false);
+      }
+    }
+    let cleanUp = false;
+    checkUserAuthz();
+    return () => cleanUp = true;
+  }, [groupName]);
+
+  return (
+    <GenericPage location={location}>
+      <FlexGridRight>
+        <splashStyles.Button to={`/groups/${groupName}`}>
+          Return to "{groupName}" Page
+        </splashStyles.Button>
+      </FlexGridRight>
+      <MediumSpacer/>
+
+      <splashStyles.H2>
+        Editing "{groupName}" Group Settings
+      </splashStyles.H2>
+      <HugeSpacer/>
+
+      {userAuthorized
+        ? <p>Placeholder for editing forms.</p>
+        : <ErrorBanner title={UNAUTHORIZED_MESSAGE}/>}
+    </GenericPage>
+  )
+};
+
+export const canUserEditGroupSettings = async (groupName) => {
+  try {
+    const groupOverviewOptions = await fetch(`/groups/${groupName}/settings/overview`, { method: "OPTIONS" });
+    const allowedMethods = new Set(groupOverviewOptions.headers.get("Allow")?.split(/\s*,\s*/));
+    const editMethods = ["PUT", "DELETE"];
+    return editMethods.every((method) => allowedMethods.has(method));
+  } catch (err) {
+    console.error("Cannot check user permissions to edit group settings", err.message);
+  }
+};
+
+export default EditGroupSettingsPage;

--- a/static-site/src/sections/group-settings-page.jsx
+++ b/static-site/src/sections/group-settings-page.jsx
@@ -4,6 +4,7 @@ import { ErrorBanner } from "../components/splash/errorMessages";
 import GenericPage from "../layouts/generic-page";
 import { FlexGrid, FlexGridRight, HugeSpacer, MediumSpacer } from "../layouts/generalComponents";
 import EditLogoForm from "../components/Groups/edit-logo-form";
+import EditOverviewForm from "../components/Groups/edit-overview-form";
 
 const UNAUTHORIZED_MESSAGE = `
   You must have the owners role within a group to edit group settings.
@@ -53,8 +54,12 @@ const EditGroupSettingsPage = ({ location, groupName }) => {
       <HugeSpacer/>
 
       {userAuthorized
-        ? <FlexGrid>
+        ? <FlexGrid style={{ minHeight: "500px" }}>
             <EditLogoForm
+              groupName={groupName}
+              createErrorMessage={createErrorMessage}
+              clearErrorMessage={clearErrorMessage}/>
+            <EditOverviewForm
               groupName={groupName}
               createErrorMessage={createErrorMessage}
               clearErrorMessage={clearErrorMessage}/>

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -36,8 +36,8 @@ class Index extends React.Component {
     const groupName = this.props["groupName"];
     try {
       const [sourceInfo, availableData] = await Promise.all([
-        fetchAndParseJSON(`/charon/getSourceInfo?prefix=/groups/${groupName}/`),
-        fetchAndParseJSON(`/charon/getAvailable?prefix=/groups/${groupName}/`)
+        fetchAndParseJSON(`/charon/getSourceInfo?prefix=/groups/${encodeURIComponent(groupName)}/`),
+        fetchAndParseJSON(`/charon/getAvailable?prefix=/groups/${encodeURIComponent(groupName)}/`)
       ]);
 
       this.setState({

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -1,12 +1,13 @@
 import React from "react";
 import ScrollableAnchor, { configureAnchors } from "react-scrollable-anchor";
-import { HugeSpacer } from "../layouts/generalComponents";
+import { HugeSpacer, FlexGridRight } from "../layouts/generalComponents";
 import * as splashStyles from "../components/splash/styles";
 import DatasetSelect from "../components/Datasets/dataset-select";
 import GenericPage from "../layouts/generic-page";
 import { fetchAndParseJSON } from "../util/datasetsHelpers";
 import SourceInfoHeading from "../components/splash/sourceInfoHeading";
 import { ErrorBanner } from "../components/splash/errorMessages";
+import { canUserEditGroupSettings } from "./group-settings-page";
 
 class Index extends React.Component {
   constructor(props) {
@@ -15,7 +16,8 @@ class Index extends React.Component {
     const nonExistentPath = this.props["*"];
     this.state = {
       groupNotFound: false,
-      nonExistentPath
+      nonExistentPath,
+      editGroupSettingsAllowed: false
     };
   }
 
@@ -37,9 +39,11 @@ class Index extends React.Component {
         fetchAndParseJSON(`/charon/getSourceInfo?prefix=/groups/${groupName}/`),
         fetchAndParseJSON(`/charon/getAvailable?prefix=/groups/${groupName}/`)
       ]);
+
       this.setState({
         sourceInfo,
         groupName,
+        editGroupSettingsAllowed: await canUserEditGroupSettings(groupName),
         datasets: this.createDatasetListing(availableData.datasets, groupName),
         narratives: this.createDatasetListing(availableData.narratives, groupName),
       });
@@ -94,6 +98,13 @@ class Index extends React.Component {
     }
     return (
       <GenericPage location={location} banner={banner}>
+        {this.state.editGroupSettingsAllowed && (
+          <FlexGridRight>
+            <splashStyles.Button to={`/groups/${this.state.groupName}/settings`}>
+              Edit Group Settings
+            </splashStyles.Button>
+          </FlexGridRight>
+        )}
         <SourceInfoHeading sourceInfo={this.state.sourceInfo}/>
         <HugeSpacer />
         {this.state.sourceInfo.showDatasets && (

--- a/static-site/src/sections/influenza-page.jsx
+++ b/static-site/src/sections/influenza-page.jsx
@@ -11,7 +11,7 @@ import { PathogenPageIntroduction } from "../components/Datasets/pathogen-page-i
 import DatasetSelect from "../components/Datasets/dataset-select";
 import GenericPage from "../layouts/generic-page";
 import { fetchAndParseJSON } from "../util/datasetsHelpers";
-import { ErrorBanner } from "../components/splash/errorMessages";
+import { DataFetchErrorParagraph, ErrorBanner } from "../components/splash/errorMessages";
 import Cards from "../components/Cards/index";
 import fluCards from "../components/Cards/fluCards";
 
@@ -133,10 +133,7 @@ class Index extends React.Component {
                 columns={tableColumns}
               />
             )}
-            { this.state.errorFetchingData && <splashStyles.CenteredFocusParagraph>
-                        Something went wrong getting data.
-                        Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
-                        if this continues to happen.</splashStyles.CenteredFocusParagraph>}
+            { this.state.errorFetchingData && <DataFetchErrorParagraph /> }
           </div>
         </ScrollableAnchor>
       </GenericPage>

--- a/static-site/src/sections/pathogens.jsx
+++ b/static-site/src/sections/pathogens.jsx
@@ -12,6 +12,7 @@ import GenericPage from "../layouts/generic-page";
 import Cards from "../components/Cards/index";
 import pathogenCards from "../components/Cards/pathogenCards";
 import { AnchorLink } from "../components/Datasets/pathogen-page-introduction";
+import { DataFetchErrorParagraph } from "../components/splash/errorMessages";
 
 const nextstrainLogoPNG = "/favicon.png";
 
@@ -93,13 +94,7 @@ class Index extends React.Component {
                 columns={tableColumns}
               />
             )}
-            {this.state.errorFetchingData && (
-              <splashStyles.CenteredFocusParagraph>
-                Something went wrong getting data.
-                Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
-                if this continues to happen.
-              </splashStyles.CenteredFocusParagraph>
-            )}
+            {this.state.errorFetchingData && <DataFetchErrorParagraph />}
           </div>
         </ScrollableAnchor>
       </GenericPage>

--- a/static-site/src/sections/sequence-search.jsx
+++ b/static-site/src/sections/sequence-search.jsx
@@ -5,6 +5,7 @@ import {FaFile, FaExclamation} from "react-icons/fa";
 import { SmallSpacer, MediumSpacer, HugeSpacer, FlexCenter } from "../layouts/generalComponents";
 import * as splashStyles from "../components/splash/styles";
 import GenericPage from "../layouts/generic-page";
+import { DataFetchErrorParagraph } from "../components/splash/errorMessages";
 
 /**
  * See https://github.com/JedWatson/react-select/issues/3128 for ways to speed up <Select>
@@ -101,9 +102,9 @@ class SequencesToDatasets extends React.Component {
           <div className="col-md-10">
             {this.state.errorFetchingData && (
               <LargeRedSection>
-                      Something went wrong fetching the data!
-                      Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
-                      if this continues to happen.
+                <FlexCenter>
+                  <DataFetchErrorParagraph />
+                </FlexCenter>
               </LargeRedSection>
             )}
             <HugeSpacer/>

--- a/static-site/src/sections/staging-page.jsx
+++ b/static-site/src/sections/staging-page.jsx
@@ -8,7 +8,7 @@ import * as splashStyles from "../components/splash/styles";
 import DatasetSelect from "../components/Datasets/dataset-select";
 import { fetchAndParseJSON } from "../util/datasetsHelpers";
 import GenericPage from "../layouts/generic-page";
-import { ErrorBanner } from "../components/splash/errorMessages";
+import { DataFetchErrorParagraph, ErrorBanner } from "../components/splash/errorMessages";
 
 const nextstrainLogoPNG = "/favicon.png";
 
@@ -101,13 +101,7 @@ class Index extends React.Component {
             columns={tableColumns}
           />
         )}
-        {this.state.errorFetchingData && (
-          <splashStyles.CenteredFocusParagraph>
-            Something went wrong getting data.
-            Please <a href="mailto:hello@nextstrain.org">contact us at hello@nextstrain.org </a>
-            if this continues to happen.
-          </splashStyles.CenteredFocusParagraph>
-        )}
+        {this.state.errorFetchingData && <DataFetchErrorParagraph />}
       </GenericPage>
     );
   }


### PR DESCRIPTION
### Description of proposed changes
Adds a new page for users to edit group customizations, which currently only include the logo and overview.
Includes a new OPTIONS route to check if users are authorized to edit group settings. 

Only users with the `owner` role should see the button "EDIT GROUP SETTINGS" to navigate to the new page:

![Screen Shot 2023-04-03 at 2 01 52 PM](https://user-images.githubusercontent.com/40774762/229626836-ad2b92ba-4ad4-4eba-89c2-4de47162d975.png)

Other users can still navigate to the new page using the URL `/groups/:groupName/settings`, but they would only see an error banner:

![Screen Shot 2023-04-03 at 2 04 46 PM](https://user-images.githubusercontent.com/40774762/229627334-246917fd-a244-4438-8d1e-e14614c8ff50.png)

The new page allows users to:
- delete current logo
- upload new logo
- edit/upload overview

![Screen Shot 2023-04-03 at 2 13 42 PM](https://user-images.githubusercontent.com/40774762/229628912-0eeee50e-de1c-4c39-b652-a41192745d02.png)


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
