### PR TITLE
scripts: collect all S3 objects when truncated

### DIFF
--- a/scripts/collect-datasets.js
+++ b/scripts/collect-datasets.js
@@ -78,18 +78,9 @@ async function main({args}) {
 // -------------------------------------------------------------------------------- //
 
 async function collectFromBucket({BUCKET, fileToUrl, inclusionTest}) {
-  const S3 = new AWS.S3();
   console.log(`Collecting datasets from ${BUCKET} to retrieve metadata...`);
-  let s3Objects;
-  try {
-    s3Objects = await S3.listObjectsV2({Bucket: BUCKET}).promise();
-  } catch (err) {
-    console.log("Error listing objects via the S3 API -- were credentials correctly set?");
-    console.log(err.message);
-    process.exit(0); // exit zero so the build script doesn't fail causing the site to not be deployed.
-  }
-  if (s3Objects.isTruncated) console.log("WARNING: S3 listing is truncated. Results will be incomplete.");
-  s3Objects = s3Objects.Contents
+  const allS3Objects = await listAllObjects({BUCKET});
+  const s3Objects = allS3Objects
     .filter((s3obj) => filenameLooksLikeDataset(s3obj.Key))
     .filter((s3obj) => inclusionTest(s3obj.Key)) // eslint-disable-line semi
     // .filter((_, i) => i<2);
@@ -103,6 +94,33 @@ async function collectFromBucket({BUCKET, fileToUrl, inclusionTest}) {
     return s3obj;
   })));
   return dataObjects;
+}
+
+async function listAllObjects({BUCKET}) {
+  const S3 = new AWS.S3();
+  const s3ListObjectParams = {
+    Bucket: BUCKET,
+    ContinuationToken: null
+  };
+  const s3Objects = [];
+
+  try {
+    let isTruncated = true;
+    while (isTruncated) {
+      // eslint-disable-next-line no-await-in-loop
+      const s3Response = await S3.listObjectsV2(s3ListObjectParams).promise();
+      s3Objects.push(...s3Response.Contents);
+
+      s3ListObjectParams.ContinuationToken = s3Response.NextContinuationToken;
+      isTruncated = s3Response.IsTruncated;
+    }
+  } catch (err) {
+    console.log("Error listing objects via the S3 API -- were credentials correctly set?");
+    console.log(err.message);
+    process.exit(0); // exit zero so the build script doesn't fail causing the site to not be deployed.
+  }
+
+  return s3Objects;
 }
 
 function getDatasetMetadata(datasetObjects) {

--- a/scripts/collect-search-results.js
+++ b/scripts/collect-search-results.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import argparse from 'argparse';
-import AWS from 'aws-sdk';
 import fetch from 'node-fetch';
 import fs from 'fs';
 import pLimit from 'p-limit';
+import S3 from '@aws-sdk/client-s3';
 
 const bucket = "nextstrain-data";
 
@@ -98,22 +98,12 @@ async function collectFromBucket({BUCKET, fileToUrl, inclusionTest}) {
 }
 
 async function listAllObjects({BUCKET}) {
-  const S3 = new AWS.S3();
-  const s3ListObjectParams = {
-    Bucket: BUCKET,
-    ContinuationToken: null
-  };
+  const client = new S3.S3Client();
   const s3Objects = [];
 
   try {
-    let isTruncated = true;
-    while (isTruncated) {
-      // eslint-disable-next-line no-await-in-loop
-      const s3Response = await S3.listObjectsV2(s3ListObjectParams).promise();
-      s3Objects.push(...s3Response.Contents);
-
-      s3ListObjectParams.ContinuationToken = s3Response.NextContinuationToken;
-      isTruncated = s3Response.IsTruncated;
+    for await (const page of S3.paginateListObjectsV2({client}, {Bucket: BUCKET})) {
+      s3Objects.push(...page.Contents);
     }
   } catch (err) {
     console.log("Error listing objects via the S3 API -- were credentials correctly set?");


### PR DESCRIPTION
### Description of proposed changes
Collect all S3 objects by using the `ContinuationToken` param and fetching all content until `IsTruncated` is no longer true.

### Related issue(s)
Fixes #670.

### Testing
Scripts worked locally with:
```
./scripts/collect-datasets --keyword flu 
./scripts/collect-datasets --keyword staging

./scripts/collect-search-results --pathogen sars-cov-2
./scripts/collect-search-results --pathogen seasonal-flu
```

This now pulls >6000 datasets from staging and all of the dated datasets for ncov. 
Should we add additional filters to limit the number of datasets? Maybe limit objects by their `LastModified` date? 