### PR TITLE
Split groups data between production and testing environments

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -65,6 +65,9 @@ Deploys to the production app are performed by manually [promoting](https://devc
   - `CONFIG_FILE` is the path to a JSON file defining the defaults for the required variables below.
     If not provided, the checked-in files `env/production/config.json` and `env/testing/config.json` are used (depending on the value of `NODE_ENV`).
 
+  - `GROUPS_DATA_FILE` is the path to a JSON file defining the known Groups.
+    If not provided, the checked-in files `env/production/groups.json` and `env/testing/groups.json` are used (depending on the value of `NODE_ENV`).
+
 Several variables are required but obtain defaults from a config file (e.g. `env/production/config.json`):
 
   - `COGNITO_USER_POOL_ID` must be set to the id of the Cognito user pool to use for authentication.

--- a/env/production/groups.json
+++ b/env/production/groups.json
@@ -216,15 +216,5 @@
   {
     "name": "MPOX-CDC",
     "isPublic": false
-  },
-  {
-    "name": "test",
-    "isPublic": true,
-    "isDevOnly": true
-  },
-  {
-    "name": "test-private",
-    "isPublic": false,
-    "isDevOnly": true
   }
 ]

--- a/env/testing/groups.json
+++ b/env/testing/groups.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "blab",
+    "isPublic": true
+  },
+  {
+    "name": "test",
+    "isPublic": true
+  },
+  {
+    "name": "test-private",
+    "isPublic": false
+  }
+]

--- a/scripts/migrate-group.js
+++ b/scripts/migrate-group.js
@@ -8,6 +8,7 @@ import os from 'os';
 import { basename, dirname, relative as relativePath, parse as parsePath } from 'path';
 import process from 'process';
 import { fileURLToPath } from 'url';
+import { GROUPS_DATA_FILE } from '../src/config.js';
 import { Group } from '../src/groups.js';
 import { reportUnhandledRejectionsAtExit, run, setupConsole } from '../src/utils/scripts.js';
 
@@ -25,7 +26,7 @@ function parseArgs() {
     description: `
       Migrate a Nextstrain Group from an old single-tenant bucket to the new
       multi-tenant bucket.  The group must already be defined in
-      data/groups.json.
+      the groups.json data file.
     `,
   });
 
@@ -392,7 +393,7 @@ async function getIAMGroup(client, GroupName) {
 
 
 async function updateGroupsDataFile({dryRun = true, group}) {
-  const dataFile = `${REPO}/data/groups.json`;
+  const dataFile = relativePath(REPO, GROUPS_DATA_FILE);
 
   console.group(`\nRemoving group's "bucket" key from ${dataFile}`);
 

--- a/scripts/provision-group.js
+++ b/scripts/provision-group.js
@@ -37,7 +37,7 @@ function parseArgs() {
   const argparser = new ArgumentParser({
     description: `
       Provision AWS Cognito resources for a Nextstrain Group and its members.
-      The group must already be defined in data/groups.json.
+      The group must already be defined in the groups.json data file.
     `,
   });
 

--- a/src/config.js
+++ b/src/config.js
@@ -106,3 +106,16 @@ export const COGNITO_CLIENT_ID = fromEnvOrConfig("COGNITO_CLIENT_ID");
  * @type {string}
  */
 export const COGNITO_CLI_CLIENT_ID = fromEnvOrConfig("COGNITO_CLI_CLIENT_ID");
+
+
+/**
+ * Path to a JSON file containing Groups data.
+ *
+ * Defaults to env/production/groups.json if {@link PRODUCTION} or
+ * env/testing/groups.json otherwise.
+ *
+ * @type {string}
+ */
+export const GROUPS_DATA_FILE =
+     process.env.GROUPS_DATA_FILE
+  ?? path.join(__basedir, "env", (PRODUCTION ? "production" : "testing"), "groups.json");

--- a/src/endpoints/users.js
+++ b/src/endpoints/users.js
@@ -7,7 +7,7 @@ import { sendGatsbyPage } from './static.js';
 /**
  * Returns an array of Nextstrain groups that are visible to a
  * given *user* (or a non-logged in user). The order of groups returned
- * matches the order in `data/groups.json`.
+ * matches the order in the `groups.json` data file.
  *
  * @param {Object | undefined} user. `undefined` represents a non-logged-in user
  * @returns {Array} Each element is an object with keys `name` -> {str} (group name) and

--- a/src/groups.js
+++ b/src/groups.js
@@ -1,12 +1,12 @@
 import { strict as assert } from 'assert';
 import * as authz from "./authz/index.js";
-import { PRODUCTION } from './config.js';
+import { GROUPS_DATA_FILE } from './config.js';
 import { NotFound } from './httpErrors.js';
 import { GroupSource } from "./sources/index.js";
 
 /* eslint-disable-next-line import/first, import/newline-after-import */
 import { readFile } from 'fs/promises';
-const GROUPS_DATA = JSON.parse(await readFile(new URL('../data/groups.json', import.meta.url)));
+const GROUPS_DATA = JSON.parse(await readFile(GROUPS_DATA_FILE));
 
 /**
  * Map of Nextstrain Groups from their (normalized) name to their static config
@@ -17,11 +17,6 @@ const GROUPS_DATA = JSON.parse(await readFile(new URL('../data/groups.json', imp
  */
 const GROUP_RECORDS = new Map(
   GROUPS_DATA
-    /* Groups for dev/testing.  Might be nice to expose these in production too,
-     * but we'd need additional changes first to support "unlisted" Groups.
-     *   -trs, 24 Jan 2022
-     * */
-    .filter(groupRecord => PRODUCTION ? !groupRecord.isDevOnly : true)
     .map(groupRecord => [normalizeGroupName(groupRecord.name), groupRecord])
 );
 

--- a/test/auspice_client_requests.json
+++ b/test/auspice_client_requests.json
@@ -66,7 +66,7 @@
   },
   {
     "name": "Check getSourceInfo API for a (private) nextstrain groups splash page",
-    "url": "/charon/getSourceInfo?prefix=/groups/blab-private/",
+    "url": "/charon/getSourceInfo?prefix=/groups/test-private/",
     "expectStatusCode": 401
   },
   {
@@ -144,7 +144,7 @@
   },
   {
     "name": "Attempt to access a private Nextstrain Group when not logged in",
-    "url": "/charon/getAvailable?prefix=/groups/blab-private",
+    "url": "/charon/getAvailable?prefix=/groups/test-private",
     "expectStatusCode": 401
   },
   {


### PR DESCRIPTION
These environments do not share the resources behind group—they have separate Cognito user pools and a shared but access-partitioned S3 bucket—so it doesn't make that much sense to bundle both into the same data file anymore.  Pragmatically, this also avoids a bunch of noisy errors at local dev server start and periodically thereafter.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] `npm run test:ci` passes locally
- [x] `npm run lint` passes locally
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
