### PR TITLE
Restore delayed import of ./src/app.js by using a dynamic import()

### DIFF
--- a/server.js
+++ b/server.js
@@ -25,8 +25,7 @@ const port = process.env.PORT || 5000;
 /* Import app after setting global.verbose so that calls to utils.verbose()
  * respect our --verbose option as expected.
  */
-/* eslint-disable import/first */
-import app from './src/app.js';
+const {default: app} = await import('./src/app.js');
 
 app.set("port", port);
 


### PR DESCRIPTION
The inherently dynamic require() was changed to a static import in the conversion to ES modules¹ with "Use cjs-to-es6 to help conversion" (1963fcd).  That broke the intended delayed import, since Node.js starts locating and executing static imports before the actual import statements are reached in the importing module's execution.  Use a dynamic import() instead to restore the delayed import.

We delay the import until after setting global.verbose so that calls to utils.verbose() in the codebase respect the server's --verbose option as expected.

The missing utils.verbose() output this caused was first noticed by @jameshadfield.²

¹ <https://github.com/nextstrain/nextstrain.org/pull/583>

² In <https://github.com/nextstrain/nextstrain.org/pull/678> as
  191ffa28d04424de593fe02132f5f86bbb5cfcbb, a different proposed fix.

### Testing

- [x] Confirmed missing verbose output is restored locally
- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
