### PR TITLE
Update manifest with 21L ncov datasets

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -275,6 +275,72 @@
                   "default": "6m"
                 }
               },
+              "21L": {
+      				  "global": {
+        					"resolution": {
+        					  "1m": "",
+        					  "2m": "",
+        					  "6m": "",
+        					  "all-time": "",
+        					  "default": "6m"
+        					}
+      				  },
+      				  "africa": {
+        					"resolution": {
+        					  "1m": "",
+        					  "2m": "",
+        					  "6m": "",
+        					  "all-time": "",
+        					  "default": "6m"
+        					}
+      				  },
+      				  "asia": {
+        					"resolution": {
+        					  "1m": "",
+        					  "2m": "",
+        					  "6m": "",
+        					  "all-time": "",
+        					  "default": "6m"
+        					}
+      				  },
+      				  "europe": {
+        					"resolution": {
+        					  "1m": "",
+        					  "2m": "",
+        					  "6m": "",
+        					  "all-time": "",
+        					  "default": "6m"
+        					}
+      				  },
+      				  "north-america": {
+        					"resolution": {
+        					  "1m": "",
+        					  "2m": "",
+        					  "6m": "",
+        					  "all-time": "",
+        					  "default": "6m"
+        					}
+      				  },
+      				  "oceania": {
+        					"resolution": {
+        					  "1m": "",
+        					  "2m": "",
+        					  "6m": "",
+        					  "all-time": "",
+        					  "default": "6m"
+        					}
+      				  },
+      				  "south-america": {
+        					"resolution": {
+        					  "1m": "",
+        					  "2m": "",
+        					  "6m": "",
+        					  "all-time": "",
+        					  "default": "6m"
+        					}
+      				  },
+      				  "default": "global"
+              },
               "reference": "",
               "default": "global"
             }


### PR DESCRIPTION
### Description of proposed changes

This updates `manifest_core.json` with the newly implemented 21L datasets like [nextstrain.org/ncov/gisaid/21L/global/6m](https://nextstrain.org/ncov/gisaid/21L/global/6m).

### Testing

Tested via review app. Everything looks to be working.

- [x] Checks pass


