### PR TITLE
Use "href" template literals for safe-by-construction URL strings

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -28,6 +28,7 @@ import { replacer as jsonReplacer } from './json.js';
 import * as middleware from './middleware.js';
 import * as redirects from './redirects.js';
 import * as sources from './sources/index.js';
+import { uri } from './templateLiterals.js';
 
 const {
   setSource,
@@ -59,8 +60,6 @@ const {
   UrlDefinedSource,
   GroupSource,
 } = sources;
-
-const esc = encodeURIComponent;
 
 const jsonMediaType = type => type.match(/^application\/(.+\+)?json$/);
 
@@ -306,7 +305,7 @@ app.use("/groups/:groupName",
     const restOfUrl = req.url !== "/" ? req.url : "";
 
     const canonicalName = req.context.source.group.name;
-    const canonicalUrl = `/groups/${esc(canonicalName)}${restOfUrl}`;
+    const canonicalUrl = uri`/groups/${canonicalName}` + restOfUrl;
 
     return req.params.groupName !== canonicalName
       ? res.redirect(canonicalUrl)
@@ -345,7 +344,7 @@ app.route("/groups/:groupName/settings/*")
 
 // Avoid matching "narratives" as a dataset name.
 app.routeAsync("/groups/:groupName/narratives")
-  .getAsync((req, res) => res.redirect(`/groups/${esc(req.params.groupName)}`));
+  .getAsync((req, res) => res.redirect(uri`/groups/${req.params.groupName}`));
 
 app.routeAsync("/groups/:groupName/narratives/*")
   .all(setNarrative(req => req.params[0]))

--- a/src/endpoints/cli.js
+++ b/src/endpoints/cli.js
@@ -4,6 +4,7 @@ import mime from 'mime';
 import { pipeline } from 'stream/promises';
 import { BadRequest, InternalServerError, NotFound, ServiceUnavailable } from '../httpErrors.js';
 import { fetch } from '../fetch.js';
+import { uri } from '../templateLiterals.js';
 
 
 const authorization = process.env.GITHUB_TOKEN
@@ -18,7 +19,7 @@ const download = async (req, res) => {
 
   const endpoint = version === "latest"
     ? "https://api.github.com/repos/nextstrain/cli/releases/latest"
-    : `https://api.github.com/repos/nextstrain/cli/releases/tags/${encodeURIComponent(version)}`;
+    : uri`https://api.github.com/repos/nextstrain/cli/releases/tags/${version}`;
 
   const response = await fetch(endpoint, {headers: {authorization}});
   assertStatusOk(response);
@@ -44,7 +45,7 @@ const downloadPRBuild = async (req, res) => {
    * associated with it.  Not all PR-associated workflow runs contain entries
    * in the run's "pull_request" array.
    */
-  const prResponse = await fetch(`https://api.github.com/repos/nextstrain/cli/pulls/${encodeURIComponent(prId)}`, {headers: {authorization}});
+  const prResponse = await fetch(uri`https://api.github.com/repos/nextstrain/cli/pulls/${prId}`, {headers: {authorization}});
   assertStatusOk(prResponse);
 
   const pr = await prResponse.json();
@@ -87,7 +88,7 @@ const downloadCIBuild = async (req, res) => {
   const assetSuffix = req.params.assetSuffix;
   if (!runId || !assetSuffix) throw new BadRequest();
 
-  const endpoint = `https://api.github.com/repos/nextstrain/cli/actions/runs/${encodeURIComponent(runId)}/artifacts`;
+  const endpoint = uri`https://api.github.com/repos/nextstrain/cli/actions/runs/${runId}/artifacts`;
 
   const apiResponse = await fetch(endpoint, {headers: {authorization}});
   assertStatusOk(apiResponse);

--- a/src/templateLiterals.js
+++ b/src/templateLiterals.js
@@ -1,0 +1,23 @@
+/**
+ * Safe-by-construction URI strings via [template literals]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates}.
+ *
+ * Interpolations in the template literal are automatically URI-encoded.
+ *
+ * @returns string
+ */
+export function uri(literalParts, ...exprParts) {
+  /* The tagged template literal is given to us as two lists: the literal parts
+   * and the interpolated expression values (i.e. the evaluation of … inside
+   * ${…}).  We zip and concatenate the two lists together while URI-encoding
+   * the interpolated values.
+   *
+   * There is always one more literal part than expression part—though it may
+   * be the empty string—and the whole template literal starts with the first
+   * literal part.
+   *   -trs, 4 May 2023
+   */
+  return literalParts.slice(1).reduce(
+    (url, literalPart, idx) => `${url}${encodeURIComponent(exprParts[idx])}${literalPart}`,
+    literalParts[0]
+  );
+}

--- a/static-site/src/components/Groups/edit-logo-form.jsx
+++ b/static-site/src/components/Groups/edit-logo-form.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { uri } from "../../../../src/templateLiterals.js";
 import { MediumSpacer } from "../../layouts/generalComponents";
 import * as splashStyles from "../splash/styles";
 import { AvatarWithoutMargins, CenteredForm, InputButton, InputLabel} from "./styles";
@@ -24,7 +25,7 @@ const EditLogoForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
   const getGroupLogo = async () => {
     clearErrorMessage();
     try {
-      const response = await fetch(`/groups/${encodeURIComponent(groupName)}/settings/logo`);
+      const response = await fetch(uri`/groups/${groupName}/settings/logo`);
       if (response.status === 404) return null;
       if (response.ok) return URL.createObjectURL(await response.blob());
       createErrorMessage(response.statusText);
@@ -41,7 +42,7 @@ const EditLogoForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
     setDeletionInProgress(true);
 
     try {
-      const response = await fetch(`/groups/${encodeURIComponent(groupName)}/settings/logo`, {method: "DELETE"});
+      const response = await fetch(uri`/groups/${groupName}/settings/logo`, {method: "DELETE"});
       response.ok
         ? setLogo({ ...logo, current: null })
         : createErrorMessage(response.statusText);
@@ -59,7 +60,7 @@ const EditLogoForm = ({ groupName, createErrorMessage, clearErrorMessage }) => {
     setUploadInProgress(true);
 
     try {
-      const response = await fetch(`/groups/${encodeURIComponent(groupName)}/settings/logo`, {
+      const response = await fetch(uri`/groups/${groupName}/settings/logo`, {
         method: "PUT",
         headers: {
           "Content-Type": "image/png"

--- a/static-site/src/components/Groups/edit-overview-form.jsx
+++ b/static-site/src/components/Groups/edit-overview-form.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { uri } from "../../../../src/templateLiterals.js";
 import * as splashStyles from "../splash/styles";
 import { CenteredForm, InputButton, TextArea } from "./styles";
 
@@ -33,7 +34,7 @@ const EditOverviewForm = ({ groupName, createErrorMessage, clearErrorMessage }) 
   const getOverview = async () => {
     clearErrorMessage();
     try {
-      const response = await fetch(`/groups/${encodeURIComponent(groupName)}/settings/overview`);
+      const response = await fetch(uri`/groups/${groupName}/settings/overview`);
       if (response.status === 404) return OVERVIEW_TEMPLATE;
       if (response.ok) {
         const currentOverview = await response.text();
@@ -54,7 +55,7 @@ const EditOverviewForm = ({ groupName, createErrorMessage, clearErrorMessage }) 
     setUploadInProgress(true);
 
     try {
-      const response = await fetch(`/groups/${encodeURIComponent(groupName)}/settings/overview`, {
+      const response = await fetch(uri`/groups/${groupName}/settings/overview`, {
         method: "PUT",
         headers: {
           "Content-Type": "text/markdown"

--- a/static-site/src/sections/group-settings-page.jsx
+++ b/static-site/src/sections/group-settings-page.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { uri } from "../../../src/templateLiterals.js";
 import * as splashStyles from "../components/splash/styles";
 import { ErrorBanner } from "../components/splash/errorMessages";
 import GenericPage from "../layouts/generic-page";
@@ -40,7 +41,7 @@ const EditGroupSettingsPage = ({ location, groupName }) => {
   return (
     <GenericPage location={location}>
       <FlexGridRight>
-        <splashStyles.Button to={`/groups/${encodeURIComponent(groupName)}`}>
+        <splashStyles.Button to={uri`/groups/${groupName}`}>
           Return to "{groupName}" Page
         </splashStyles.Button>
       </FlexGridRight>
@@ -73,7 +74,7 @@ const EditGroupSettingsPage = ({ location, groupName }) => {
 
 export const canUserEditGroupSettings = async (groupName) => {
   try {
-    const groupOverviewOptions = await fetch(`/groups/${encodeURIComponent(groupName)}/settings/overview`, { method: "OPTIONS" });
+    const groupOverviewOptions = await fetch(uri`/groups/${groupName}/settings/overview`, { method: "OPTIONS" });
     const allowedMethods = new Set(groupOverviewOptions.headers.get("Allow")?.split(/\s*,\s*/));
     const editMethods = ["PUT", "DELETE"];
     return editMethods.every((method) => allowedMethods.has(method));

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ScrollableAnchor, { configureAnchors } from "react-scrollable-anchor";
+import { uri } from "../../../src/templateLiterals.js";
 import { HugeSpacer, FlexGridRight } from "../layouts/generalComponents";
 import * as splashStyles from "../components/splash/styles";
 import DatasetSelect from "../components/Datasets/dataset-select";
@@ -36,8 +37,8 @@ class Index extends React.Component {
     const groupName = this.props["groupName"];
     try {
       const [sourceInfo, availableData] = await Promise.all([
-        fetchAndParseJSON(`/charon/getSourceInfo?prefix=/groups/${encodeURIComponent(groupName)}/`),
-        fetchAndParseJSON(`/charon/getAvailable?prefix=/groups/${encodeURIComponent(groupName)}/`)
+        fetchAndParseJSON(uri`/charon/getSourceInfo?prefix=/groups/${groupName}/`),
+        fetchAndParseJSON(uri`/charon/getAvailable?prefix=/groups/${groupName}/`)
       ]);
 
       this.setState({


### PR DESCRIPTION
Avoids having to write out encodeURIComponent(), which is quite a mouthful!

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
