### PR TITLE
Swap to iFrame for SARS-CoV-2 forecasts page

### DIFF
--- a/static-site/src/sections/sars-cov-2-forecasts-page.jsx
+++ b/static-site/src/sections/sars-cov-2-forecasts-page.jsx
@@ -7,13 +7,12 @@ import {
   HugeSpacer
 } from "../layouts/generalComponents";
 import GenericPage from "../layouts/generic-page";
-import CollapseTitle from "../components/Misc/collapse-title";
 import * as splashStyles from "../components/splash/styles";
 
 const gisaidLogo = require("../../static/logos/gisaid.png");
 
 // Hard-coded content
-const disclaimer = "DISCLAIMER: This page is an alpha release of model results";
+// const disclaimer = "DISCLAIMER: This page is an alpha release of model results";
 const title = "Nextstrain SARS-CoV-2 Forecasts";
 const abstract = (
   <>
@@ -23,22 +22,24 @@ const abstract = (
     growth advantages using daily sequence counts. We apply this model independently across
     different countries and partition SARS-CoV-2 variants by <a
     href="https://nextstrain.org/blog/2022-04-29-SARS-CoV-2-clade-naming-2022">Nextstrain
-    clades</a>. Each clade is assumed to have a fixed growth advantage relative to clade 22B (lineage BA.5).</>
+    clades</a> and separately by <a href="https://cov-lineages.org/">Pango lineages</a>. Each clade
+    is assumed to have a fixed growth advantage relative to clade 22B, while each lineage is relative
+    to lineage BA.5.</>
     <p/>
     <>Further details on data preparation and analysis can be found in the <a
     href="https://github.com/nextstrain/forecasts-ncov/">forecasts-ncov GitHub repo</a>, while
     further details on the MLR model implementation can be found in the <a
     href="https://www.github.com/blab/evofr">evofr GitHub repo</a>. Enabled by data from <a
     href="https://gisaid.org/"><img alt="GISAID" src={gisaidLogo} width={70}/></a>.</>
-    <br/>
     <p/>
-    <>
-    These analyses are the work of <a
+    <>These analyses are the work of <a
     href="https://bedford.io/team/marlin-figgins/">Marlin Figgins</a>, <a
     href="https://bedford.io/team/jover-lee/">Jover Lee</a>, <a
     href="https://bedford.io/team/james-hadfield/">James Hadfield</a> and <a
-    href="https://bedford.io/team/trevor-bedford/">Trevor Bedford</a>.
-    </>
+    href="https://bedford.io/team/trevor-bedford/">Trevor Bedford</a>.</>
+    <p/>
+    <><i>Multinomial Logistic Regression is commonly used to model SARS-CoV-2 variant frequencies.
+    However, please apply caution in interpretation of these results.</i></>
   </>
 )
 const acknowledgement = (
@@ -48,68 +49,11 @@ const acknowledgement = (
   </>
 )
 
-const nextstrainCladesSrcBase = "https://nextstrain-data.s3.amazonaws.com/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/global";
-const generatePictureSrcs = (srcBase, figureName) => {
-  // media min-widths taken from the cut-offs for the .container class in static-site/src/styles/bootstrap.css
-  return {
-    srcSets: [
-      {
-        media: "(min-width: 1550px)",
-        srcSet: `${srcBase}/${figureName}_xlarge.png`
-      },
-      {
-        media: "(min-width: 1200px)",
-        srcSet: `${srcBase}/${figureName}_large.png`
-      },
-      {
-        media: "(min-width: 992px)",
-        srcSet: `${srcBase}/${figureName}_medium.png`
-      }
-    ],
-    imgSrc: `${srcBase}/${figureName}_small.png`
-  }
-};
-
-const collapsibleContents = [
-  {
-    title: "Estimated variant frequencies over time",
-    text: (
-      <span>
-        Each line represents the estimated frequency of a particular clade through time.
-        Equivalent Pango lineage is given in parenthesis, eg clade 22B (lineage BA.5).
-      </span>
-    ),
-    images: {
-      nextstrainClades: {
-        alt: "Global estimated variant frequency plots from GISAID data",
-        ...generatePictureSrcs(nextstrainCladesSrcBase, "frequenciesPanel")
-      }
-    }
-  },
-  {
-    title: "Growth Advantage",
-    text: (
-      <span>
-        These plots show the estimated growth advantage for given variants relative to clade 22B (lineage BA.5). This
-        describes how many more secondary infections a variant causes on average relative to clade 22B.
-        Vertical bars show the 95% HPD.
-      </span>
-    ),
-    images: {
-      nextstrainClades: {
-        alt: "Global relative growth advantage plots from GISAID data",
-        ...generatePictureSrcs(nextstrainCladesSrcBase, "growthAdvantagePanel")
-      }
-    }
-  }
-];
-
-
 function Index(props) {
   const [ cladeType, setCladeType ] = useState("nextstrainClades");
 
   return (
-    <GenericPage location={props.location} banner={DisclaimerBanner()}>
+    <GenericPage location={props.location}>
       <splashStyles.H1>{title}</splashStyles.H1>
       <SmallSpacer />
 
@@ -120,7 +64,10 @@ function Index(props) {
       </CenteredContainer>
       <HugeSpacer />
 
-      {collapsibleContents.map((c) => <CollapsibleContent key={c.title} content={c} cladeType={cladeType} />)}
+      <IFrameContainer>
+        <ResponsiveIFrame src="https://nextstrain.github.io/forecasts-ncov/">
+        </ResponsiveIFrame>
+      </IFrameContainer>
 
       <CenteredContainer>
         <splashStyles.FocusParagraph>
@@ -131,55 +78,35 @@ function Index(props) {
   );
 }
 
-const DisclaimerBanner = () => {
-  return (
-    <splashStyles.FixedBanner backgroundColor="#ffedcc">
-      <splashStyles.StrongerText>
-        {disclaimer}
-      </splashStyles.StrongerText>
-    </splashStyles.FixedBanner>
-  )
-}
+// not currently used, but may restore
+// const DisclaimerBanner = () => {
+//   return (
+//     <splashStyles.FixedBanner backgroundColor="#ffedcc">
+//       <splashStyles.StrongerText>
+//         {disclaimer}
+//       </splashStyles.StrongerText>
+//     </splashStyles.FixedBanner>
+//   )
+// }
 
-const FullWidthPicture = styled.picture`
+// padding-top: 72% chosen so that at widescreen the iframe takes up basically the entire height of the window
+// padding-top: 580px chosen so that at vertical mobile display the iframe takes up basically the entire height of the window
+const IFrameContainer = styled.div`
+  position: relative;
+  overflow: hidden;
   width: 100%;
-  height: auto;
-  display: block;
-  text-align: center;
-  > img {
-    max-width: 100%;
-  }
+  padding-top: max(580px, 72%);
 `;
 
-function CollapsibleContent(props) {
-  const {title, text, images} = props.content;
-
-  return (
-    <Collapsible
-      triggerWhenOpen={<CollapseTitle name={title} isExpanded />}
-      trigger={<CollapseTitle name={title} />}
-      triggerStyle={{cursor: "pointer", textDecoration: "none"}}
-      open={true}
-    >
-      <div style={{ padding: "10px" }} >
-        <splashStyles.WideParagraph style={{ marginTop: "0px" }} >
-          {text}
-        </splashStyles.WideParagraph>
-        <HugeSpacer />
-        <FullWidthPicture>
-          {images[props.cladeType]?.srcSets
-            ? images[props.cladeType].srcSets
-                .map((source) => <source key={source.srcset} media={source.media} srcSet={source.srcSet}/>)
-            : null
-          }
-          <img
-            src={images[props.cladeType]?.imgSrc}
-            alt={images[props.cladeType]?.alt} />
-        </FullWidthPicture>
-
-      </div>
-    </Collapsible>
-  );
-}
+const ResponsiveIFrame = styled.iframe`
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  border: 0px;
+`;
 
 export default Index;


### PR DESCRIPTION
### Description of proposed changes

This commit switches from the currently PNG screenshots to a live iFrame embedding from https://nextstrain.github.io/forecasts-ncov/. This allows higher resolution and permits interactivity. I believe this is especially welcome for the lineage barchart where mousing over individual values is very helpful.

The iFrame width is responsive, but there is not perfect control over its height. That said, I believe my max(580px, 72%) solution works well at a variety of window sizes from vertical mobile to landscape desktop.

I also got rid of the disclaimer at the top of the page. This sort of MLR model is very standard at this point. It's used in the CDC Variant Tracker and we've spent a lot of time validating retrospective MLR frequency hindcasts, nowcasts and forecasts and I'm very happy with how well the model performs. I swapped this to a less aggressive warning directly above the iFrame plots.

### Testing

Tested locally.

- [x] Checks pass


