### PR TITLE
Remove p-limit from our direct dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "mime": "^2.5.2",
         "negotiator": "^0.6.2",
         "node-fetch": "^2.6.0",
-        "p-limit": "^3.0.1",
         "passport": "^0.4.0",
         "passport-oauth2": "^1.5.0",
         "passport-strategy": "^1.0.0",
@@ -16834,20 +16833,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/p-limit": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.1.tgz",
-      "integrity": "sha512-mw/p92EyOzl2MhauKodw54Rx5ZK4624rNfgNaBguFZkHzyUG9WsDzFF5/yQVEJinbJDdP4jEfMN+uBquiGnaLg==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-locate": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
@@ -16893,6 +16878,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -32746,14 +32732,6 @@
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
-    "p-limit": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.1.tgz",
-      "integrity": "sha512-mw/p92EyOzl2MhauKodw54Rx5ZK4624rNfgNaBguFZkHzyUG9WsDzFF5/yQVEJinbJDdP4jEfMN+uBquiGnaLg==",
-      "requires": {
-        "p-try": "^2.0.0"
-      }
-    },
     "p-locate": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
@@ -32785,7 +32763,8 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
     },
     "pako": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "mime": "^2.5.2",
     "negotiator": "^0.6.2",
     "node-fetch": "^2.6.0",
-    "p-limit": "^3.0.1",
     "passport": "^0.4.0",
     "passport-oauth2": "^1.5.0",
     "passport-strategy": "^1.0.0",


### PR DESCRIPTION
Its last direct use was removed by "Remove dataset listing /influenza, /staging" (a75539a) and "Remove updates to strain-search JSON" (86956ef).¹

Related-to: <https://github.com/nextstrain/nextstrain.org/pull/694>


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
