### PR TITLE
Add mpox as the default monkeypox URL prefix

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -201,6 +201,14 @@
           "default": "hmpxv1"
         }
       },
+      "mpox": {
+        "resolution": {
+          "all-clades": "",
+          "clade-IIb": "",
+          "lineage-B.1": "",
+          "default": "clade-IIb"
+        }
+      },
       "mumps": {
         "resolution": {
           "na": "",

--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -194,13 +194,6 @@
         }
       },
       "measles": "",
-      "monkeypox": {
-        "resolution": {
-          "hmpxv1": "",
-          "mpxv": "",
-          "default": "hmpxv1"
-        }
-      },
       "mpox": {
         "resolution": {
           "all-clades": "",

--- a/src/app.js
+++ b/src/app.js
@@ -192,6 +192,7 @@ const coreBuildPaths = [
   "/mers",
   "/mumps",
   "/monkeypox",
+  "/mpox", // Prior to Sept 2023 we used /monkeypox/
   "/ncov",
   "/nextclade",
   "/rsv",

--- a/src/app.js
+++ b/src/app.js
@@ -191,8 +191,8 @@ const coreBuildPaths = [
   "/measles",
   "/mers",
   "/mumps",
-  "/monkeypox",
-  "/mpox", // Prior to Sept 2023 we used /monkeypox/
+  "/monkeypox", // Not actively updated, but YYYY-MM-DD URLs remain & don't redirect
+  "/mpox",      // monkeypox URLs will redirect to /mpox (except for datestamped URLs)
   "/ncov",
   "/nextclade",
   "/rsv",

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -39,6 +39,15 @@ const setup = (app) => {
       })
     ));
 
+  /**
+   * We shifted from using 'monkeypox' to 'mpox', as per WHO naming
+   * recommendations. Note that monkeypox YYYY-MM-DD URLs remain,
+   * e.g. /monkeypox/hmpxv1/2022-09-04
+   */
+  app.route('/monkeypox/mpxv').get((req, res) => res.redirect('/mpox/all-clades'));
+  app.route('/monkeypox/hmpxv1').get((req, res) => res.redirect('/mpox/clade-IIb'));
+  app.route('/monkeypox/hmpxv1/big').get((req, res) => res.redirect('/mpox/lineage-B.1'));
+
   /*
    * Redirect to translations of narratives if the client has
    * set language preference and the translation is available

--- a/static-site/src/components/Cards/coreCards.js
+++ b/static-site/src/components/Cards/coreCards.js
@@ -1,8 +1,8 @@
 const coreCards = [
   {
     img: "monkeypox.png",
-    url: "/monkeypox",
-    title: "Monkeypox"
+    url: "/mpox",
+    title: "Mpox"
   },
   {
     img: "seasonalinfluenza.png",

--- a/static-site/src/components/Cards/pathogenCards.js
+++ b/static-site/src/components/Cards/pathogenCards.js
@@ -26,8 +26,8 @@ const pathogenCards = [
   },
   {
     img: "monkeypox.png",
-    url: "/monkeypox",
-    title: "Monkeypox"
+    url: "/mpox",
+    title: "Mpox"
   },
   {
     img: "mumps.jpg",


### PR DESCRIPTION
All 3 current /mpox datasets (/mpox/lineage-B.1, /mpox/clade-IIb, /mpox/all-clades) are added to the manifest (and thus Auspice's dropdowns), with the last one set as the default. The card on the main splash page is switched to /mpox.

Context (slack): <https://bedfordlab.slack.com/archives/C03G8HQEV18/p1695508115055009>

The original /monkeypox/* URLs are left unchanged however we can remove these and add redirects instead if we wish to. Steps to do so:
* Removing `monkeypox` from the (committed) manifest JSON will remove it from the auspice sidebar dropdowns and stop the ability for default URL redirects such as 'monkeypox' → 'monkeypox/hmpxv1'
* Removing `/monkeypox` from `app.js` will stop nextstrain.org/monkeypox URLs working at all (they'll 404)
* Redirects to go from /monkeypox URLs to /mpox ones should be added in `./src/redirects.js`. All the dataset names have changed (i.e. it's not just `/monkeypox/mpox/`) so we should add explicit redirects for all the old URLs.