### PR TITLE
Redirect `/monkeypox` to `/mpox`

### DIFF
--- a/src/redirects.js
+++ b/src/redirects.js
@@ -44,6 +44,7 @@ const setup = (app) => {
    * recommendations. Note that monkeypox YYYY-MM-DD URLs remain,
    * e.g. /monkeypox/hmpxv1/2022-09-04
    */
+  app.route('/monkeypox').get((req, res) => res.redirect('/mpox');
   app.route('/monkeypox/mpxv').get((req, res) => res.redirect('/mpox/all-clades'));
   app.route('/monkeypox/hmpxv1').get((req, res) => res.redirect('/mpox/clade-IIb'));
   app.route('/monkeypox/hmpxv1/big').get((req, res) => res.redirect('/mpox/lineage-B.1'));

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -44,7 +44,7 @@ const setup = (app) => {
    * recommendations. Note that monkeypox YYYY-MM-DD URLs remain,
    * e.g. /monkeypox/hmpxv1/2022-09-04
    */
-  app.route('/monkeypox').get((req, res) => res.redirect('/mpox');
+  app.route('/monkeypox').get((req, res) => res.redirect('/mpox'));
   app.route('/monkeypox/mpxv').get((req, res) => res.redirect('/mpox/all-clades'));
   app.route('/monkeypox/hmpxv1').get((req, res) => res.redirect('/mpox/clade-IIb'));
   app.route('/monkeypox/hmpxv1/big').get((req, res) => res.redirect('/mpox/lineage-B.1'));


### PR DESCRIPTION
See https://bedfordlab.slack.com/archives/C03G8HQEV18/p1695669073962029?thread_ts=1695508115.055009&cid=C03G8HQEV18

- [x] Checks pass
- [x] Works as expected: https://nextstrain-s-monkeypox--0dd7jn.herokuapp.com/monkeypox