### PR TITLE
dev: Check the Heroku build status during our GitHub Actions deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,22 @@ jobs:
           curl "$(jq -r .output_stream_url build.json)" \
             --fail --silent --show-error --location
 
+      - name: Check Heroku build
+        run: |
+          id="$(jq -r .id build.json)"
+
+          curl https://api.heroku.com/apps/"$HEROKU_APP"/builds/"$id" \
+            --fail --silent --show-error --location --netrc \
+            --header 'Accept: application/vnd.heroku+json; version=3' \
+              | tee build.json
+
+          status="$(jq -r .status build.json)"
+
+          if [[ "$status" != succeeded ]]; then
+            echo "build status is $status (not succeeded)" >&2
+            exit 1
+          fi
+
       - if: always()
         name: Logout of Heroku
         run: sed -i -e '/^machine api\.heroku\.com/d' ~/.netrc


### PR DESCRIPTION
We'd been assuming builds on Heroku were always successful, which meant the GitHub Actions status could (and did) mask build issues on Heroku.

Resolves <https://github.com/nextstrain/nextstrain.org/issues/726>.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Tested the snippets manually; testing the workflow is not possible without merge first
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
