### PR TITLE
Add context to console error on groups page

### DIFF
--- a/static-site/src/sections/group-settings-page.jsx
+++ b/static-site/src/sections/group-settings-page.jsx
@@ -75,6 +75,9 @@ const EditGroupSettingsPage = ({ location, groupName }) => {
 export const canUserEditGroupSettings = async (groupName) => {
   try {
     const groupOverviewOptions = await fetch(uri`/groups/${groupName}/settings/overview`, { method: "OPTIONS" });
+    if ([401, 403].includes(groupOverviewOptions.status)) {
+      console.log("You can ignore the console error above; it is used to determine whether the edit button is shown.");
+    }
     const allowedMethods = new Set(groupOverviewOptions.headers.get("Allow")?.split(/\s*,\s*/));
     const editMethods = ["PUT", "DELETE"];
     return editMethods.every((method) => allowedMethods.has(method));


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Current implementation means an error for the settings page is shown in the console for every visit to a group page where you aren't logged in as an owner of the group.

It confused me until I realized that `canUserEditGroupSettings` is being called on the group page to determine whether to display the edit button. It seems like this is by design, and I'm not sure there is an easy way to achieve the same behavior without sending this call to /groups/{group}/settings. I think ok to leave as-is, but some extra context might be helpful for anyone who has a tendency to think that something is wrong when seeing red error messages in the browser console.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

N/A

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] ([preview page](https://nextstrain-s-victorlin--dz5hja.herokuapp.com/groups/blab)) Accessing blab group page when not logged in shows 401 followed by new console info message.
- [x] (tested locally) Accessing group page when logged in but not an owner shows 403 followed by new console info message.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
