### PR TITLE
config: Support falsy numeric and boolean values…

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -82,7 +82,7 @@ const configFile = CONFIG_FILE
  * @param {function} [options.fromConfig] - conversion function to apply to values obtained from the config file; defaults to the identity function
  * @throws {Error} if no value is found and default is undefined
  */
-const fromEnvOrConfig = (name, default_, {fromEnv = maybeJSON, fromConfig = x => x} = {}) => {
+export const fromEnvOrConfig = (name, default_, {fromEnv = maybeJSON, fromConfig = x => x} = {}) => {
   const value =
        fromEnv(process.env[name])
     || fromConfig(configFile?.[name]);

--- a/src/config.js
+++ b/src/config.js
@@ -76,10 +76,10 @@ const configFile = CONFIG_FILE
  * is no value present in the environment or config file.
  *
  * @param {string} name - Variable name, e.g. "COGNITO_USER_POOL_ID"
- * @param {any} default - Final fallback value
- * @param {object} options
- * @param {function} options.fromEnv - conversion function to apply to values obtained from the environment; defaults to {@link maybeJSON}
- * @param {function} options.fromConfig - conversion function to apply to values obtained from the config file; defaults to the identity function
+ * @param {any} [default] - Final fallback value; if undefined then the variable is considered required.
+ * @param {object} [options]
+ * @param {function} [options.fromEnv] - conversion function to apply to values obtained from the environment; defaults to {@link maybeJSON}
+ * @param {function} [options.fromConfig] - conversion function to apply to values obtained from the config file; defaults to the identity function
  * @throws {Error} if no value is found and default is undefined
  */
 const fromEnvOrConfig = (name, default_, {fromEnv = maybeJSON, fromConfig = x => x} = {}) => {

--- a/src/config.js
+++ b/src/config.js
@@ -138,7 +138,7 @@ function configPath(value) {
  * In practice, that means the standard AWS config file (since the SDK also
  * looks at the AWS_REGION environment variable).
  *
- * @type string
+ * @type {string}
  */
 export const AWS_REGION = fromEnvOrConfig("AWS_REGION", null);
 

--- a/src/config.js
+++ b/src/config.js
@@ -2,8 +2,9 @@
  * Configuration variables for the nextstrain.org server.
  *
  * Values which aren't hardcoded are typically provided by environment
- * variables of the same name.  Some variables have hardcoded fallback values
- * when the environment variable is missing or empty.
+ * variables or config file fields of the same name.  Some variables have
+ * hardcoded fallback values when neither the environment variable nor config
+ * file field is present.
  *
  * See also {@link https://docs.nextstrain.org/projects/nextstrain-dot-org/page/infrastructure.html#environment-variables}.
  *

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,37 @@
+import {fromEnvOrConfig} from "../src/config.js";
+
+const env = process.env;
+
+/* Isolate process.env for each test so changes don't leak across tests.
+ */
+beforeEach(() => {
+  process.env = { ...env };
+});
+
+/* Reset process.env overrides.
+ */
+afterEach(() => {
+  process.env = env;
+});
+
+describe("configurable vs. missing values", () => {
+  test("boolean false is a configurable value", () => {
+    process.env.TEST_VAR = "false";
+    expect(fromEnvOrConfig("TEST_VAR", true)).toBe(false);
+  });
+
+  test("numeric 0 is a configurable value", () => {
+    process.env.TEST_VAR = "0";
+    expect(fromEnvOrConfig("TEST_VAR", 42)).toBe(0);
+  });
+
+  test("null is a missing value", async () => {
+    process.env.TEST_VAR = "null";
+    expect(fromEnvOrConfig("TEST_VAR", "default")).toBe("default");
+  });
+
+  test("empty string is a missing value", async () => {
+    process.env.TEST_VAR = "";
+    expect(fromEnvOrConfig("TEST_VAR", "default")).toBe("default");
+  });
+});


### PR DESCRIPTION
…instead of considering them missing.

The values considered missing are now more clear:

  1. undefined (i.e. not present)
  2. null (i.e. present but explicitly null)
  3. "" (i.e. present but empty, particularly for env vars)

This allows falsy values¹ like the number 0 and boolean false to be
configurable values², as expected to be for OIDC_IAT_BACKDATED_BY and
REDIS_REQUIRED.

For example, setting REDIS_REQUIRED=false is now functional as intended
by "Allow and document how to run safely in production mode without
Redis" (64f7d92b).  And setting OIDC_IAT_BACKDATED_BY=0 in the
environment now overrides any value from the config file instead of
being ignored.

Related-to: <https://github.com/nextstrain/nextstrain.org/pull/739>

¹ <https://developer.mozilla.org/en-US/docs/Glossary/Falsy>

² Other falsy values like NaN and 0n are also now considered
  non-missing, but there's no way to express those in our current config
  sources, which permit only strings or JSON values.  We may find
  ourselves wanting to treat NaN as missing too if config sources
  change.



## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
