### PR TITLE
[bugfix] default params for signedUrl()

### DIFF
--- a/src/s3.js
+++ b/src/s3.js
@@ -42,15 +42,15 @@ export async function* listObjects({bucket, prefix}) {
  * Generate a signed URL for an S3 object.
  *
  * @param {object} params
- * @param {string} params.method - HEAD, GET, PUT, DELETE
  * @param {string} params.bucket - name of bucket
  * @param {string} params.key - object key
+ * @param {string} [params.method] - HEAD, GET, PUT, DELETE. Default: GET
  * @param {object} [params.headers] - Content-Type and/or Content-Encoding headers for PUT
  * @param {number} [params.expiresIn] - seconds until the URL expires
  * @param {number} [params.issuedAt] - absolute time in seconds since the Unix epoch at which the signed URL should be considered issued at, i.e. when the countdown for expiresIn starts
  * @returns {string} signed URL
  */
-export async function signedUrl({method, bucket, key, headers, expiresIn, issuedAt} = {method: "GET", headers: {}}) {
+export async function signedUrl({method="GET", bucket, key, headers={}, expiresIn, issuedAt}) {
   const normalizedHeaders = normalizeHeaders(headers);
 
   const commands = new Map([


### PR DESCRIPTION
The default parameter values for this function would only be used in the case where no argument was provided, which makes no sense as a bucket and key will always be needed. These changes preserve the intended defaults of headers={} and method='GET'. (Reading the previous code it seems the intention was to allow a default method of 'GET', despite the docstring indicating it was required.)


- [ ] Checks pass
