### PR TITLE
tests: Ensure SESSION_ENCRYPTION_KEYS is unset rather than assume it isn't

### DIFF
--- a/test/authn.test.js
+++ b/test/authn.test.js
@@ -24,6 +24,7 @@ afterEach(() => {
 test("SESSION_ENCRYPTION_KEYS required in production", async () => {
   process.env.NODE_ENV = "production";
   process.env.SESSION_SECRET = "not a secret";
+  delete process.env.SESSION_ENCRYPTION_KEYS;
 
   await expect(async () => await import("../src/authn/session"))
     .rejects


### PR DESCRIPTION
Ensures the condition under which we're testing behaviour rather than assuming the condition.

I noticed failures of that assumption recently, because I've started running with keys configured in local development to allow for session continuity across local server restarts.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
