### PR TITLE
authn: Stop request processing on failed Bearer authn attempts

### DIFF
--- a/src/httpErrors.js
+++ b/src/httpErrors.js
@@ -12,3 +12,14 @@ export const {
   UnsupportedMediaType,
   isHttpError,
 } = httpErrors;
+
+
+/**
+ * HttpError classes by status code.
+ *
+ * @type {Object.<string, httpErrors.HttpError>}
+ */
+export const HttpErrors = Object.fromEntries(
+  Object.entries(httpErrors)
+    .filter(([status,]) => !!Number(status))
+);


### PR DESCRIPTION
Fixes regression where after a failed Bearer authn attempt the request processing continued on (still unauthenticated).  Failed attempts now once again produce an error response (typically 400 or 401) with the appropriate challenge (if any) in the WWW-Authenticate header.  In particular, this restores responses like:

    HTTP/1.1 401 Unauthorized
    WWW-Authenticate: error="invalid_token" …

when a stale token is sent in the request.  Nextstrain CLI relies on these responses to form a more helpful error message to the user.

The regression was introduced by "authn: Switch to custom authenticator callbacks" (aca4d07f) because the Passport "strategy" we use here stops performing the default behaviour we were relying on once a callback is provided.  Instead, it expects the callback to provide all the behaviour.

Note that this regression was merely a usability issue, not a security issue, as the rest of the request processing remained unauthenticated.

Good tests of the interaction of Bearer authn with our "stale before" functionality would have caught this regression, but we continue to not have suitable testing scaffolding for tests involving authentication and so adding them (at the time or now) is not trivial.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
