### PR TITLE
Use inline exports

### DIFF
--- a/src/authn/index.js
+++ b/src/authn/index.js
@@ -69,7 +69,7 @@ const STRATEGY_SESSION = "session";
  */
 const RESAVE_TO_SESSION = Symbol("RESAVE_TO_SESSION");
 
-function setup(app) {
+export function setup(app) {
   passport.use(
     STRATEGY_OAUTH2,
     new OAuth2Strategy(
@@ -797,8 +797,3 @@ async function renewTokens(refreshToken) {
     refreshToken: refreshTokenUpdate ?? refreshToken,
   };
 }
-
-
-export {
-  setup
-};

--- a/src/authn/session.js
+++ b/src/authn/session.js
@@ -20,7 +20,7 @@ const KEYRING = keyringFromParamString(SESSION_ENCRYPTION_KEYS || `RANDOM=${rand
  * @param {Object} session - typically req.session
  * @returns {{idToken, accessToken, refreshTokens}|null}
  */
-async function getTokens(session) {
+export async function getTokens(session) {
   if (session?.encryptedTokens) {
     const context = {sid: session.id};
     const decryptedTokens = JSON.parse(await decrypt(KEYRING, session.encryptedTokens, context));
@@ -42,7 +42,7 @@ async function getTokens(session) {
  * @param {Object} session - typically req.session
  * @param {{idToken, accessToken, refreshTokens}|null} tokens - if null, removes any existing tokens from the session
  */
-async function setTokens(session, tokens) {
+export async function setTokens(session, tokens) {
   if (tokens) {
     /* Encryption context to bind this message to this session.  For example,
      * this prevents coyping of the encrypted tokens from one session to
@@ -71,13 +71,6 @@ async function setTokens(session, tokens) {
  *
  * @param {Object} session - typically req.session
  */
-async function deleteTokens(session) {
+export async function deleteTokens(session) {
   return await setTokens(session, null);
 }
-
-
-export {
-  getTokens,
-  setTokens,
-  deleteTokens,
-};

--- a/src/authz/index.js
+++ b/src/authz/index.js
@@ -5,6 +5,12 @@ import { Source, Resource } from '../sources/models.js';
 import actions from './actions.js';
 import tags from './tags.js';
 
+export {
+  actions,
+  tags,
+};
+
+
 /**
  * Checks if a user is allowed to take an action on an object.
  *
@@ -16,7 +22,7 @@ import tags from './tags.js';
  * @param {object} object - Object being acted upon.
  * @returns {boolean}
  */
-function authorized(user, action, object) {
+export function authorized(user, action, object) {
   // user may be null
   assert(!user || user.authzRoles != null, "user.authzRoles is not null if user is not null");
   assert(actions.has(action), "action is known");
@@ -72,7 +78,7 @@ function authorized(user, action, object) {
  * @param {Set} objectTags - Tags of object being acted upon.
  * @returns {boolean}
  */
-function evaluatePolicy(policy, userRoles, action, objectTags) {
+export function evaluatePolicy(policy, userRoles, action, objectTags) {
   assert(Array.isArray(policy));
   assert(policy.every(({tag, role, allow}) => tag && role && allow));
   assert(objectTags instanceof Set);
@@ -111,18 +117,8 @@ function evaluatePolicy(policy, userRoles, action, objectTags) {
  * @param {object} object - Object being acted upon.
  * @throws {AuthzDenied}
  */
-function assertAuthorized(user, action, object) {
+export function assertAuthorized(user, action, object) {
   if (!authorized(user, action, object)) {
     throw new AuthzDenied();
   }
 }
-
-
-export {
-  authorized,
-  assertAuthorized,
-  evaluatePolicy,
-
-  actions,
-  tags,
-};

--- a/src/cryptography.js
+++ b/src/cryptography.js
@@ -65,7 +65,7 @@ import { randomBytes } from 'crypto';
 /* These must be changed with care.  Blithely changing them could make existing
  * ciphertexts undecryptable.
  */
-const KEY_LENGTH_BITS = 256;
+export const KEY_LENGTH_BITS = 256;
 const KEY_COMMITMENT_POLICY = awsCrypto.CommitmentPolicy.FORBID_ENCRYPT_ALLOW_DECRYPT;
 const WRAPPING_SUITE = awsCrypto.RawAesWrappingSuiteIdentifier.AES256_GCM_IV12_TAG16_NO_PADDING;
 const DATA_SUITE = awsCrypto.AlgorithmSuiteIdentifier.ALG_AES256_GCM_IV12_TAG16_HKDF_SHA256;
@@ -88,7 +88,7 @@ const {
  *    key names and base64-encoded key material
  * @returns {Object}
  */
-function keyringFromParamString(keyParamString) {
+export function keyringFromParamString(keyParamString) {
   const keyParams = Array.from((new URLSearchParams(keyParamString)).entries());
 
   // Decryption with any key passed in.
@@ -128,7 +128,7 @@ function keyringFromParamString(keyParamString) {
  *   contextualizes this plaintext to prevent context shifts; not encrypted!
  * @returns {String} base64-encoded encrypted message (ciphertext)
  */
-async function encrypt(keyring, plaintext, context) {
+export async function encrypt(keyring, plaintext, context) {
   const {result: encryptedMessage} = await _encrypt(
     keyring,
     plaintext,
@@ -155,7 +155,7 @@ async function encrypt(keyring, plaintext, context) {
  *   contextualizes the plaintext to prevent context shifts; not encrypted!
  * @returns {String} plaintext
  */
-async function decrypt(keyring, ciphertext, context) {
+export async function decrypt(keyring, ciphertext, context) {
   const {plaintext, messageHeader: {encryptionContext}} =
     await _decrypt(keyring, Buffer.from(ciphertext, "base64"));
 
@@ -176,15 +176,6 @@ async function decrypt(keyring, ciphertext, context) {
  *
  * @param {Number} [byteLength] - length of key in bytes
  */
-function randomKey(byteLength = KEY_LENGTH_BITS / 8) {
+export function randomKey(byteLength = KEY_LENGTH_BITS / 8) {
   return Buffer.from(randomBytes(byteLength)).toString("base64url");
 }
-
-
-export {
-  KEY_LENGTH_BITS,
-  keyringFromParamString,
-  encrypt,
-  decrypt,
-  randomKey,
-};

--- a/src/endpoints/charon/getAvailable.js
+++ b/src/endpoints/charon/getAvailable.js
@@ -5,7 +5,7 @@ import { splitPrefixIntoParts, joinPartsIntoPrefix } from '../../utils/prefix.js
 import * as metaSources from '../../metaSources.js';
 
 /* handler for /charon/getAvailable requests */
-const getAvailable = async (req, res) => {
+export const getAvailable = async (req, res) => {
   const prefix = req.query.prefix ?? "/";
   utils.verbose(`getAvailable prefix: "${prefix}"`);
 
@@ -52,7 +52,3 @@ async function collectAllAvailableGroups(user) {
     narratives: narratives.map((request) => ({request}))
   };
 }
-
-export {
-  getAvailable,
-};

--- a/src/endpoints/charon/getDataset.js
+++ b/src/endpoints/charon/getDataset.js
@@ -32,7 +32,7 @@ const sendV1Dataset = async (res, metaJsonUrl, treeJsonUrl) => {
   return res.send(datasetJson);
 };
 
-const getDataset = async (req, res) => {
+export const getDataset = async (req, res) => {
   const type = req.query.type ?? "main";
 
   utils.log(`Getting (nextstrain) datasets for: ${req.url.split('?')[1]}`);
@@ -52,8 +52,4 @@ const getDataset = async (req, res) => {
     }
     throw errV2;
   }
-};
-
-export {
-  getDataset,
 };

--- a/src/endpoints/charon/getNarrative.js
+++ b/src/endpoints/charon/getNarrative.js
@@ -1,7 +1,7 @@
 import { BadRequest } from '../../httpErrors.js';
 import { sendNarrativeSubresource } from '../sources.js';
 
-const getNarrative = async (req, res) => {
+export const getNarrative = async (req, res) => {
   const query = req.query;
   const validTypes = new Set(["markdown", "md"]);
 
@@ -10,8 +10,4 @@ const getNarrative = async (req, res) => {
   }
 
   return await sendNarrativeSubresource("md")(req, res);
-};
-
-export {
-  getNarrative,
 };

--- a/src/endpoints/charon/getSourceInfo.js
+++ b/src/endpoints/charon/getSourceInfo.js
@@ -1,11 +1,6 @@
 /**
  * Prototype implementation.
  */
-const getSourceInfo = async (req, res) => {
+export const getSourceInfo = async (req, res) => {
   return res.json(await req.context.source.getInfo());
-};
-
-
-export {
-  getSourceInfo,
 };

--- a/src/endpoints/charon/index.js
+++ b/src/endpoints/charon/index.js
@@ -2,12 +2,12 @@ import { BadRequest, isHttpError } from '../../httpErrors.js';
 import { splitPrefixIntoParts } from '../../utils/prefix.js';
 import { setSource, setDataset, canonicalizeDataset, setNarrative } from '../sources.js';
 import './setAvailableDatasets.js'; // sets globals
-import { getAvailable } from './getAvailable.js';
-import { getDataset } from './getDataset.js';
-import { getNarrative } from './getNarrative.js';
-import { getSourceInfo } from './getSourceInfo.js';
+export { getAvailable } from './getAvailable.js';
+export { getDataset } from './getDataset.js';
+export { getNarrative } from './getNarrative.js';
+export { getSourceInfo } from './getSourceInfo.js';
 
-const setSourceFromPrefix = setSource(req => {
+export const setSourceFromPrefix = setSource(req => {
   const prefix = req.query.prefix;
   if (!prefix) throw new BadRequest("Required query parameter 'prefix' is missing");
 
@@ -23,9 +23,9 @@ const setSourceFromPrefix = setSource(req => {
   return req.context.splitPrefixIntoParts.source;
 });
 
-const setDatasetFromPrefix = setDataset(req => req.context.splitPrefixIntoParts.prefixParts.join("/"));
+export const setDatasetFromPrefix = setDataset(req => req.context.splitPrefixIntoParts.prefixParts.join("/"));
 
-const canonicalizeDatasetPrefix = canonicalizeDataset((req, resolvedPrefix) => {
+export const canonicalizeDatasetPrefix = canonicalizeDataset((req, resolvedPrefix) => {
   // A absolute base is required but we won't use it, so use something bogus.
   const resolvedUrl = new URL(req.originalUrl, "http://x");
   resolvedUrl.searchParams.set("prefix", resolvedPrefix);
@@ -33,7 +33,7 @@ const canonicalizeDatasetPrefix = canonicalizeDataset((req, resolvedPrefix) => {
   return resolvedUrl.pathname + resolvedUrl.search;
 });
 
-const setNarrativeFromPrefix = setNarrative(req => {
+export const setNarrativeFromPrefix = setNarrative(req => {
   const {prefixParts} = req.context.splitPrefixIntoParts;
 
   // Remove 'en' from nCoV narrative prefixParts
@@ -46,15 +46,3 @@ const setNarrativeFromPrefix = setNarrative(req => {
 
   return prefixParts.join("/");
 });
-
-export {
-  setSourceFromPrefix,
-  setDatasetFromPrefix,
-  canonicalizeDatasetPrefix,
-  setNarrativeFromPrefix,
-
-  getAvailable,
-  getDataset,
-  getNarrative,
-  getSourceInfo
-};

--- a/src/endpoints/cli.js
+++ b/src/endpoints/cli.js
@@ -11,7 +11,7 @@ const authorization = process.env.GITHUB_TOKEN
   : "";
 
 
-async function download(req, res) {
+export async function download(req, res) {
   const version = req.params.version;
   const assetSuffix = req.params.assetSuffix;
   if (!version || !assetSuffix) throw new BadRequest();
@@ -35,7 +35,7 @@ async function download(req, res) {
 }
 
 
-async function downloadPRBuild(req, res) {
+export async function downloadPRBuild(req, res) {
   const prId = Number(req.params.prId);
   if (!prId || !Number.isFinite(prId)) throw new BadRequest("PR id is not a number");
 
@@ -78,7 +78,7 @@ async function downloadPRBuild(req, res) {
 }
 
 
-async function downloadCIBuild(req, res) {
+export async function downloadCIBuild(req, res) {
   if (!authorization) {
     throw new ServiceUnavailable("Server does not have authorization to download CI builds.");
   }
@@ -141,7 +141,7 @@ function assertStatusOk(response) {
 }
 
 
-function installer (req, res) {
+export function installer (req, res) {
   const os = req.params.os;
   switch (os) {
     case "linux":
@@ -155,11 +155,3 @@ function installer (req, res) {
       throw new NotFound(`No installer for OS: ${os}`);
   }
 }
-
-
-export {
-  download,
-  downloadPRBuild,
-  downloadCIBuild,
-  installer,
-};

--- a/src/endpoints/groups.js
+++ b/src/endpoints/groups.js
@@ -7,7 +7,7 @@ import { slurp } from "../utils/iterators.js";
 import * as options from "./options.js";
 
 
-const setGroup = (nameExtractor) => (req, res, next) => {
+export const setGroup = (nameExtractor) => (req, res, next) => {
   const group = new Group(nameExtractor(req));
 
   authz.assertAuthorized(req.user, authz.actions.Read, group);
@@ -20,7 +20,7 @@ const setGroup = (nameExtractor) => (req, res, next) => {
 /* Group customizations
  */
 
-const optionsGroup = options.forAuthzObject(req => req.context.group);
+export const optionsGroup = options.forAuthzObject(req => req.context.group);
 
 
 /* Group logo
@@ -29,21 +29,21 @@ const optionsGroup = options.forAuthzObject(req => req.context.group);
 
 /* GET
  */
-const getGroupLogo = contentTypesProvided([
+export const getGroupLogo = contentTypesProvided([
   ["image/png", sendGroupLogo],
 ]);
 
 
 /* PUT
  */
-const putGroupLogo = contentTypesConsumed([
+export const putGroupLogo = contentTypesConsumed([
   ["image/png", receiveGroupLogo],
 ]);
 
 
 /* DELETE
  */
-const deleteGroupLogo = async (req, res) => {
+export const deleteGroupLogo = async (req, res) => {
   authz.assertAuthorized(req.user, authz.actions.Write, req.context.group);
 
   const method = "DELETE";
@@ -60,7 +60,7 @@ const deleteGroupLogo = async (req, res) => {
 
 /* GET
  */
-const getGroupOverview = contentTypesProvided([
+export const getGroupOverview = contentTypesProvided([
   ["text/markdown", sendGroupOverview],
   ["text/plain", sendGroupOverview],
 ]);
@@ -68,14 +68,14 @@ const getGroupOverview = contentTypesProvided([
 
 /* PUT
  */
-const putGroupOverview = contentTypesConsumed([
+export const putGroupOverview = contentTypesConsumed([
   ["text/markdown", receiveGroupOverview],
 ]);
 
 
 /* DELETE
  */
-const deleteGroupOverview = async (req, res) => {
+export const deleteGroupOverview = async (req, res) => {
   authz.assertAuthorized(req.user, authz.actions.Write, req.context.group);
 
   const method = "DELETE";
@@ -156,7 +156,7 @@ async function receiveGroupLogo(req, res) {
 
 /* Members and roles
  */
-const listMembers = async (req, res) => {
+export const listMembers = async (req, res) => {
   const group = req.context.group;
 
   authz.assertAuthorized(req.user, authz.actions.Read, group);
@@ -165,7 +165,7 @@ const listMembers = async (req, res) => {
 };
 
 
-const listRoles = (req, res) => {
+export const listRoles = (req, res) => {
   const group = req.context.group;
 
   authz.assertAuthorized(req.user, authz.actions.Read, group);
@@ -175,7 +175,7 @@ const listRoles = (req, res) => {
 };
 
 
-const listRoleMembers = async (req, res) => {
+export const listRoleMembers = async (req, res) => {
   const group = req.context.group;
   const {roleName} = req.params;
 
@@ -185,7 +185,7 @@ const listRoleMembers = async (req, res) => {
 };
 
 
-const getRoleMember = async (req, res) => {
+export const getRoleMember = async (req, res) => {
   const group = req.context.group;
   const {roleName, username} = req.params;
 
@@ -201,7 +201,7 @@ const getRoleMember = async (req, res) => {
 };
 
 
-const putRoleMember = async (req, res) => {
+export const putRoleMember = async (req, res) => {
   const group = req.context.group;
   const {roleName, username} = req.params;
 
@@ -213,7 +213,7 @@ const putRoleMember = async (req, res) => {
 };
 
 
-const deleteRoleMember = async (req, res) => {
+export const deleteRoleMember = async (req, res) => {
   const group = req.context.group;
   const {roleName, username} = req.params;
 
@@ -222,26 +222,4 @@ const deleteRoleMember = async (req, res) => {
   await group.revokeRole(roleName, username);
 
   return res.status(204).end();
-};
-
-
-export {
-  setGroup,
-  optionsGroup,
-
-  getGroupLogo,
-  putGroupLogo,
-  deleteGroupLogo,
-
-  getGroupOverview,
-  putGroupOverview,
-  deleteGroupOverview,
-
-  listMembers,
-  listRoles,
-  listRoleMembers,
-
-  getRoleMember,
-  putRoleMember,
-  deleteRoleMember,
 };

--- a/src/endpoints/index.js
+++ b/src/endpoints/index.js
@@ -1,19 +1,8 @@
-import * as charon from './charon/index.js';
-import * as cli from './cli.js';
-import * as groups from "./groups.js";
-import * as openid from './openid.js';
-import * as options from './options.js';
-import * as sources from './sources.js';
-import * as static_ from './static.js';
-import * as users from './users.js';
-
-export {
-  charon,
-  cli,
-  groups,
-  openid,
-  options,
-  sources,
-  static_ as static,
-  users,
-};
+export * as charon from './charon/index.js';
+export * as cli from './cli.js';
+export * as groups from "./groups.js";
+export * as openid from './openid.js';
+export * as options from './options.js';
+export * as sources from './sources.js';
+export * as static from './static.js';
+export * as users from './users.js';

--- a/src/endpoints/sources.js
+++ b/src/endpoints/sources.js
@@ -15,7 +15,7 @@ import { deleteByUrls, proxyFromUpstream, proxyToUpstream } from "../upstream.js
  *   instance from the request
  * @returns {expressMiddleware}
  */
-const setSource = (sourceExtractor) => (req, res, next) => {
+export const setSource = (sourceExtractor) => (req, res, next) => {
   const source = sourceExtractor(req);
 
   authz.assertAuthorized(req.user, authz.actions.Read, source);
@@ -35,7 +35,7 @@ const setSource = (sourceExtractor) => (req, res, next) => {
  * @param {pathExtractor} pathExtractor - Function to extract a dataset path from the request
  * @returns {expressMiddleware}
  */
-const setDataset = (pathExtractor) => (req, res, next) => {
+export const setDataset = (pathExtractor) => (req, res, next) => {
   req.context.dataset = req.context.source.dataset(pathParts(pathExtractor(req)));
   next();
 };
@@ -48,7 +48,7 @@ const setDataset = (pathExtractor) => (req, res, next) => {
  * @param {pathBuilder} pathBuilder - Function to build a fully-specified path
  * @returns {expressMiddleware}
  */
-const canonicalizeDataset = (pathBuilder) => (req, res, next) => {
+export const canonicalizeDataset = (pathBuilder) => (req, res, next) => {
   const dataset = req.context.dataset;
   const resolvedDataset = dataset.resolve();
 
@@ -71,7 +71,7 @@ const canonicalizeDataset = (pathBuilder) => (req, res, next) => {
  *
  * @type {expressMiddlewareAsync}
  */
-const ifDatasetExists = async (req, res, next) => {
+export const ifDatasetExists = async (req, res, next) => {
   authz.assertAuthorized(req.user, authz.actions.Read, req.context.dataset);
 
   if (!(await req.context.dataset.exists())) throw new NotFound();
@@ -88,7 +88,7 @@ const ifDatasetExists = async (req, res, next) => {
  * want to point Auspice at these endpoints and still support v1.
  *   -trs, 22 Nov 2021
  */
-const sendDatasetSubresource = type =>
+export const sendDatasetSubresource = type =>
   sendSubresource(req => req.context.dataset.subresource(type));
 
 
@@ -104,7 +104,7 @@ const getDatasetTipFrequencies = getDatasetSubresource("tip-frequencies");
 const getDatasetMeasurements   = getDatasetSubresource("measurements");
 
 
-const getDataset = contentTypesProvided([
+export const getDataset = contentTypesProvided([
   ["text/html", ifDatasetExists, sendAuspiceEntrypoint],
   ["application/json", getDatasetMain],
   ["application/vnd.nextstrain.dataset.main+json", getDatasetMain],
@@ -136,7 +136,7 @@ const putDatasetTipFrequencies = putDatasetSubresource("tip-frequencies");
 const putDatasetMeasurements   = putDatasetSubresource("measurements");
 
 
-const putDataset = contentTypesConsumed([
+export const putDataset = contentTypesConsumed([
   ["application/vnd.nextstrain.dataset.main+json", putDatasetMain],
   ["application/vnd.nextstrain.dataset.root-sequence+json", putDatasetRootSequence],
   ["application/vnd.nextstrain.dataset.tip-frequencies+json", putDatasetTipFrequencies],
@@ -174,14 +174,14 @@ const deleteResource = resourceExtractor => async (req, res) => {
 };
 
 
-const deleteDataset = deleteResource(req => req.context.dataset);
-const deleteNarrative = deleteResource(req => req.context.narrative);
+export const deleteDataset = deleteResource(req => req.context.dataset);
+export const deleteNarrative = deleteResource(req => req.context.narrative);
 
 
 /* OPTIONS
  */
-const optionsDataset = options.forAuthzObject(req => req.context.dataset);
-const optionsNarrative = options.forAuthzObject(req => req.context.narrative);
+export const optionsDataset = options.forAuthzObject(req => req.context.dataset);
+export const optionsNarrative = options.forAuthzObject(req => req.context.narrative);
 
 
 /* Narratives
@@ -194,7 +194,7 @@ const optionsNarrative = options.forAuthzObject(req => req.context.narrative);
  * @param {pathExtractor} pathExtractor - Function to extract a narrative path from the request
  * @returns {expressMiddleware}
  */
-const setNarrative = (pathExtractor) => (req, res, next) => {
+export const setNarrative = (pathExtractor) => (req, res, next) => {
   req.context.narrative = req.context.source.narrative(pathParts(pathExtractor(req)));
   next();
 };
@@ -206,7 +206,7 @@ const setNarrative = (pathExtractor) => (req, res, next) => {
  *
  * @type {expressMiddlewareAsync}
  */
-const ifNarrativeExists = async (req, res, next) => {
+export const ifNarrativeExists = async (req, res, next) => {
   authz.assertAuthorized(req.user, authz.actions.Read, req.context.narrative);
 
   if (!(await req.context.narrative.exists())) throw new NotFound();
@@ -216,7 +216,7 @@ const ifNarrativeExists = async (req, res, next) => {
 
 /* GET
  */
-const sendNarrativeSubresource = type =>
+export const sendNarrativeSubresource = type =>
   sendSubresource(req => req.context.narrative.subresource(type));
 
 
@@ -226,7 +226,7 @@ const getNarrativeMarkdown = contentTypesProvided([
 ]);
 
 
-const getNarrative = contentTypesProvided([
+export const getNarrative = contentTypesProvided([
   ["text/html", ifNarrativeExists, sendAuspiceEntrypoint],
   ["text/markdown", getNarrativeMarkdown],
   ["text/vnd.nextstrain.narrative+markdown", getNarrativeMarkdown],
@@ -244,7 +244,7 @@ const putNarrativeMarkdown = contentTypesConsumed([
 ]);
 
 
-const putNarrative = contentTypesConsumed([
+export const putNarrative = contentTypesConsumed([
   ["text/vnd.nextstrain.narrative+markdown", putNarrativeMarkdown],
 ]);
 
@@ -391,26 +391,3 @@ function receiveSubresource(subresourceExtractor) {
  * @param {express.request} req
  * @param {express.response} res
  */
-
-
-export {
-  setSource,
-
-  setDataset,
-  canonicalizeDataset,
-  ifDatasetExists,
-  getDataset,
-  putDataset,
-  deleteDataset,
-  optionsDataset,
-
-  setNarrative,
-  ifNarrativeExists,
-  getNarrative,
-  putNarrative,
-  deleteNarrative,
-  optionsNarrative,
-
-  sendDatasetSubresource,
-  sendNarrativeSubresource,
-};

--- a/src/endpoints/static.js
+++ b/src/endpoints/static.js
@@ -23,9 +23,9 @@ const gatsbyAssetPath = (...subpath) =>
 
 /* Handlers for static assets.
  */
-const auspiceAssets = expressStaticGzip(auspiceAssetPath(), {maxAge: '30d'});
+export const auspiceAssets = expressStaticGzip(auspiceAssetPath(), {maxAge: '30d'});
 
-const gatsbyAssets = express.static(gatsbyAssetPath());
+export const gatsbyAssets = express.static(gatsbyAssetPath());
 
 
 /**
@@ -49,7 +49,7 @@ const gatsbyAssets = express.static(gatsbyAssetPath());
  *
  * @returns {Promise}
  */
-const sendFile = async (res, filePath, options) => {
+export const sendFile = async (res, filePath, options) => {
   return new Promise((resolve, reject) => {
     res.sendFile(filePath, options, (err) => {
       if (err) return reject(new InternalServerError(err));
@@ -68,7 +68,7 @@ const sendFile = async (res, filePath, options) => {
  *
  * @type {asyncExpressHandler}
  */
-const sendAuspiceEntrypoint = async (req, res) => {
+export const sendAuspiceEntrypoint = async (req, res) => {
   utils.verbose(`Sending Auspice entrypoint for ${req.originalUrl}`);
   return await sendFile(
     res,
@@ -92,7 +92,7 @@ const sendAuspiceEntrypoint = async (req, res) => {
  * @param {String} page - Path to a Gatsby page's rendered static HTML file
  * @returns {asyncExpressHandler}
  */
-const sendGatsbyPage = (page) => async (req, res) => {
+export const sendGatsbyPage = (page) => async (req, res) => {
   if (req.app.locals.gatsbyDevUrl) {
     const pageUrl = (new URL(page, req.app.locals.gatsbyDevUrl)).toString();
 
@@ -125,7 +125,7 @@ const sendGatsbyPage = (page) => async (req, res) => {
  *
  * @type {asyncExpressHandler}
  */
-const sendGatsbyEntrypoint = sendGatsbyPage("index.html");
+export const sendGatsbyEntrypoint = sendGatsbyPage("index.html");
 
 
 /**
@@ -137,7 +137,7 @@ const sendGatsbyEntrypoint = sendGatsbyPage("index.html");
  *
  * @type {asyncExpressHandler}
  */
-const sendGatsby404 = async (req, res) => {
+export const sendGatsby404 = async (req, res) => {
   /* When app.locals.gatsbyDevUrl is in use, the following 404 status is
    * overwritten with the upstream response status (usually 200).  Not a big
    * deal during development, but a difference worth noting.  Fixable if
@@ -155,15 +155,3 @@ const sendGatsby404 = async (req, res) => {
  * @param {express.request} req
  * @param {express.response} res
  */
-
-
-export {
-  auspiceAssets,
-  gatsbyAssets,
-
-  sendFile,
-  sendAuspiceEntrypoint,
-  sendGatsbyPage,
-  sendGatsbyEntrypoint,
-  sendGatsby404,
-};

--- a/src/endpoints/users.js
+++ b/src/endpoints/users.js
@@ -23,7 +23,7 @@ const visibleGroups = (user) => ALL_GROUPS
 
 
 // Provide the client-side app with info about the current user
-const getWhoami = contentTypesProvided([
+export const getWhoami = contentTypesProvided([
   ["html", sendGatsbyPage("whoami/index.html")],
   ["json", (req, res) =>
     // Express's JSON serialization drops keys with undefined values
@@ -33,8 +33,3 @@ const getWhoami = contentTypesProvided([
     })
   ],
 ]);
-
-
-export {
-  getWhoami,
-};

--- a/src/exceptions.js
+++ b/src/exceptions.js
@@ -12,7 +12,7 @@ class NextstrainError extends Error {
  * Thrown when a token renewal attempt is made with an invalid refresh token.
  * See {@link module:./authn.renewTokens}.
  */
-class AuthnRefreshTokenInvalid extends NextstrainError {}
+export class AuthnRefreshTokenInvalid extends NextstrainError {}
 
 
 /**
@@ -23,17 +23,10 @@ class AuthnRefreshTokenInvalid extends NextstrainError {}
  *
  * See {@link module:./authn.verifyToken}.
  */
-class AuthnTokenTooOld extends NextstrainError {}
+export class AuthnTokenTooOld extends NextstrainError {}
 
 
 /* Thrown when a user is not authorized to do something.  Turned into an
  * appropriate HTTP response by our server-wide error handler.
  */
-class AuthzDenied extends NextstrainError {}
-
-
-export {
-  AuthnRefreshTokenInvalid,
-  AuthnTokenTooOld,
-  AuthzDenied,
-};
+export class AuthzDenied extends NextstrainError {}

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -8,7 +8,7 @@ const _fetch = __fetch.defaults({
   cacheManager: process.env.FETCH_CACHE || "/tmp/fetch-cache",
 });
 
-const fetch = async (url, options) => {
+export const fetch = async (url, options) => {
   /* "url" may be a URL or a Request object, but always construct our own
    * Request() so the rest of this function only has to deal with a single
    * interface instead of looking for properties like "method" and "cache" on
@@ -28,7 +28,7 @@ const fetch = async (url, options) => {
   return response;
 };
 
-class Request extends __fetch.Request {
+export class Request extends __fetch.Request {
   /* make-fetch-happen's fetch() extends Node's fetch() by adding support for
    * several caching-related features in the WHATWG Fetch spec that Node
    * doesn't implement.  However, make-fetch-happen (unintentionally?) assumes
@@ -69,8 +69,3 @@ class Request extends __fetch.Request {
    */
   get cache() { return this[FETCH_OPTIONS].cache; }
 }
-
-export {
-  fetch,
-  Request,
-};

--- a/src/groups.js
+++ b/src/groups.js
@@ -33,7 +33,7 @@ const GROUP_RECORDS = new Map(
 /**
  * Data model class representing a Nextstrain Group.
  */
-class Group {
+export class Group {
   constructor(name) {
     const groupRecord = GROUP_RECORDS.get(normalizeGroupName(name));
 
@@ -201,7 +201,7 @@ class Group {
  * @param {string} name
  * @throws {Error}
  */
-function assertValidGroupName(name) {
+export function assertValidGroupName(name) {
   const {ok, msg} = validateGroupName(name);
   if (!ok) throw new Error(`invalid group name: ${msg}`);
 }
@@ -219,7 +219,7 @@ function assertValidGroupName(name) {
  * @param {string} name
  * @returns {{ok: boolean, msg: string}} result
  */
-function validateGroupName(name) {
+export function validateGroupName(name) {
   assert(typeof name === "string", "name is a string");
 
   /* XXX TODO: This does not include many Unicode characters people may
@@ -279,7 +279,7 @@ function validateGroupName(name) {
  * @returns {string} Name converted to Unicode Normalization Form NFKC and
  *   lowercased in en-US.
  */
-function normalizeGroupName(name) {
+export function normalizeGroupName(name) {
   return name.normalize("NFKC").toLocaleLowerCase("en-US");
 }
 
@@ -295,14 +295,5 @@ function normalizeGroupName(name) {
  *
  * @type {Group[]}
  */
-const ALL_GROUPS = Array.from(GROUP_RECORDS.keys())
+export const ALL_GROUPS = Array.from(GROUP_RECORDS.keys())
   .map(name => new Group(name));
-
-
-export {
-  Group,
-  assertValidGroupName,
-  validateGroupName,
-  normalizeGroupName,
-  ALL_GROUPS,
-};

--- a/src/json.js
+++ b/src/json.js
@@ -1,11 +1,7 @@
 /**
  * Convert Set and Map objects for {@link JSON.stringify}.
  */
-const replacer = (key, value) =>
+export const replacer = (key, value) =>
   value instanceof Set ?                          [...value] :
   value instanceof Map ? Object.fromEntries(value.entries()) :
                                                        value ;
-
-export {
-  replacer,
-};

--- a/src/metaSources.js
+++ b/src/metaSources.js
@@ -10,7 +10,7 @@ import * as utils from './utils/index.js';
  * us to update this state on our own timeframe, independent
  * of API requests.
  */
-const Groups = (() => {
+export const Groups = (() => {
 
   const publiclyVisible = source =>
     authz.authorized(null, authz.actions.Read, source);
@@ -85,7 +85,3 @@ const Groups = (() => {
   }
   return MetaGroupSource;
 })();
-
-export {
-  Groups,
-};

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -16,7 +16,7 @@ import * as utils from './utils/index.js';
  */
 const allowedCorsMethods = new Set(["GET", "HEAD"]);
 
-const allowPublicReadOnlyCors = (req, res, next) => {
+export const allowPublicReadOnlyCors = (req, res, next) => {
   if (allowedCorsMethods.has(req.method)) {
     /* All origins are ok for GET and HEAD requests.
      *
@@ -75,7 +75,7 @@ const PARENT_TRAVERSALS = new Set(["..", "%2e.", ".%2e", "%2e%2e"]);
 const isParentTraversal = pathPart =>
   PARENT_TRAVERSALS.has(pathPart.toLowerCase());
 
-const rejectParentTraversals = (req, res, next) => {
+export const rejectParentTraversals = (req, res, next) => {
   if (req.path.split("/").some(isParentTraversal)) {
     throw new BadRequest("parent traversal in path");
   }
@@ -91,7 +91,7 @@ const rejectParentTraversals = (req, res, next) => {
  *
  * The copy only happens if the old cookie is sent and the new cookie is not.
  */
-const copyCookie = (oldName, newName) => (req, res, next) => {
+export const copyCookie = (oldName, newName) => (req, res, next) => {
   const rawCookies = cookie.parse(req.headers.cookie ?? "", {decode: String});
 
   const oldCookie = rawCookies[oldName];
@@ -104,11 +104,4 @@ const copyCookie = (oldName, newName) => (req, res, next) => {
   }
 
   return next();
-};
-
-
-export {
-  allowPublicReadOnlyCors,
-  rejectParentTraversals,
-  copyCookie,
 };

--- a/src/negotiate.js
+++ b/src/negotiate.js
@@ -21,7 +21,7 @@ import { NotAcceptable, UnsupportedMediaType } from './httpErrors.js';
  *
  * @returns {Function} An async routing function which will perform the dispatch.
  */
-function contentTypesProvided(providers) {
+export function contentTypesProvided(providers) {
   const types = providers.map(([type, ...handlers]) => type); // eslint-disable-line no-unused-vars
   const handlersByType = Object.fromEntries(providers.map(([type, ...handlers]) => [type, handlers]));
 
@@ -96,7 +96,7 @@ function Links(links) {
  *
  * @returns {Function} An async routing function which will perform the dispatch.
  */
-function contentTypesConsumed(providers) {
+export function contentTypesConsumed(providers) {
   const types = providers.map(([type, handler]) => type); // eslint-disable-line no-unused-vars
   const handlers = Object.fromEntries(providers);
 
@@ -116,9 +116,3 @@ function contentTypesConsumed(providers) {
     throw new UnsupportedMediaType();
   };
 }
-
-
-export {
-  contentTypesProvided,
-  contentTypesConsumed,
-};

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -2,7 +2,7 @@ import url from 'url';
 import { splitPrefixIntoParts } from './utils/prefix.js';
 import { parseNarrativeLanguage } from './utils/index.js';
 
-const setup = (app) => {
+export const setup = (app) => {
 
   /* send auspice to the auspice docs (currently hosted on docs.nextstrain.org) */
   app.route("/auspice")
@@ -140,8 +140,4 @@ const setup = (app) => {
       .get((req, res) => res.redirect(to));
   }
 
-};
-
-export {
-  setup
 };

--- a/src/redis.js
+++ b/src/redis.js
@@ -29,7 +29,7 @@ import * as utils from './utils/index.js';
  * Connection is made at app start if `REDIS_URL` is defined in the
  * environment, such as in our Heroku deployments.  Otherwise remains null.
  */
-const REDIS = process.env.REDIS_URL
+export const REDIS = process.env.REDIS_URL
   ? herokuRedisClient(process.env.REDIS_URL)
   : null;
 
@@ -87,8 +87,3 @@ function scrubUrl(url) {
   scrubbedUrl.password = "XXXXXX";
   return scrubbedUrl;
 }
-
-
-export {
-  REDIS,
-};

--- a/src/routing/index.js
+++ b/src/routing/index.js
@@ -1,29 +1,13 @@
-import * as auspice from './auspice.js';
-import * as canary from './canary.js';
-import * as charon from './charon.js';
-import * as cli from './cli.js';
-import * as community from './community.js';
-import * as core from './core.js';
-import * as errors from "./errors.js";
-import * as fetch from './fetch.js';
-import * as groups from './groups.js';
-import * as openid from './openid.js';
-import * as schemas from './schemas.js';
-import * as staging from './staging.js';
-import * as staticSite from './staticSite.js';
-
-export {
-  auspice,
-  canary,
-  charon,
-  cli,
-  community,
-  core,
-  errors,
-  fetch,
-  groups,
-  openid,
-  schemas,
-  staging,
-  staticSite,
-};
+export * as auspice from './auspice.js';
+export * as canary from './canary.js';
+export * as charon from './charon.js';
+export * as cli from './cli.js';
+export * as community from './community.js';
+export * as core from './core.js';
+export * as errors from "./errors.js";
+export * as fetch from './fetch.js';
+export * as groups from './groups.js';
+export * as openid from './openid.js';
+export * as schemas from './schemas.js';
+export * as staging from './staging.js';
+export * as staticSite from './staticSite.js';

--- a/src/sources/community.js
+++ b/src/sources/community.js
@@ -9,7 +9,7 @@ const authorization = process.env.GITHUB_TOKEN
   ? `token ${process.env.GITHUB_TOKEN}`
   : "";
 
-class CommunitySource extends Source {
+export class CommunitySource extends Source {
   constructor(owner, repoName) {
     super();
 
@@ -199,7 +199,3 @@ class CommunityNarrative extends Narrative {
     return [`narratives/${this.source.repoName}`, ...this.pathParts];
   }
 }
-
-export {
-  CommunitySource,
-};

--- a/src/sources/core.js
+++ b/src/sources/core.js
@@ -9,7 +9,7 @@ const authorization = process.env.GITHUB_TOKEN
   ? `token ${process.env.GITHUB_TOKEN}`
   : "";
 
-class CoreSource extends Source {
+export class CoreSource extends Source {
   get name() { return "core"; }
   async baseUrl() { return "https://nextstrain-data.s3.amazonaws.com/"; }
   get repo() { return "nextstrain/narratives"; }
@@ -85,7 +85,7 @@ class CoreSource extends Source {
   }
 }
 
-class CoreStagingSource extends CoreSource {
+export class CoreStagingSource extends CoreSource {
   get name() { return "staging"; }
   async baseUrl() { return "https://nextstrain-staging.s3.amazonaws.com/"; }
   get repo() { return "nextstrain/narratives"; }
@@ -127,8 +127,3 @@ class CoreDataset extends Dataset {
     return this;
   }
 }
-
-export {
-  CoreSource,
-  CoreStagingSource,
-};

--- a/src/sources/fetch.js
+++ b/src/sources/fetch.js
@@ -2,7 +2,7 @@ import * as authz from '../authz/index.js';
 
 import { Source, Dataset, DatasetSubresource, Narrative, NarrativeSubresource } from './models.js';
 
-class UrlDefinedSource extends Source {
+export class UrlDefinedSource extends Source {
   constructor(authority) {
     super();
 
@@ -112,7 +112,3 @@ class UrlDefinedNarrativeSubresource extends NarrativeSubresource {
     return this.resource.baseName;
   }
 }
-
-export {
-  UrlDefinedSource,
-};

--- a/src/sources/groups.js
+++ b/src/sources/groups.js
@@ -14,7 +14,7 @@ const DATASET_PREFIX = "datasets/";
 const NARRATIVE_PREFIX = "narratives/";
 
 
-class GroupSource extends Source {
+export class GroupSource extends Source {
   constructor(groupOrName) {
     super();
 
@@ -312,8 +312,3 @@ function parseUrl(url) {
     throw err;
   }
 }
-
-
-export {
-  GroupSource,
-};

--- a/src/sources/index.js
+++ b/src/sources/index.js
@@ -2,7 +2,6 @@
  */
 
 import { CoreSource, CoreStagingSource } from './core.js';
-
 import { CommunitySource } from './community.js';
 import { UrlDefinedSource } from './fetch.js';
 import { GroupSource } from './groups.js';

--- a/src/sources/index.js
+++ b/src/sources/index.js
@@ -1,15 +1,7 @@
 /* See ./models.js for an explanation of the design of these classes.
  */
 
-import { CoreSource, CoreStagingSource } from './core.js';
-import { CommunitySource } from './community.js';
-import { UrlDefinedSource } from './fetch.js';
-import { GroupSource } from './groups.js';
-
-export {
-  CoreSource,
-  CoreStagingSource,
-  CommunitySource,
-  UrlDefinedSource,
-  GroupSource,
-};
+export { CoreSource, CoreStagingSource } from './core.js';
+export { CommunitySource } from './community.js';
+export { UrlDefinedSource } from './fetch.js';
+export { GroupSource } from './groups.js';

--- a/src/sources/models.js
+++ b/src/sources/models.js
@@ -87,7 +87,7 @@ import { BadRequest } from '../httpErrors.js';
  *  -trs, Dec 2021
  */
 
-class Source {
+export class Source {
   async baseUrl() {
     throw new Error("async baseUrl() must be implemented by subclasses");
   }
@@ -138,7 +138,7 @@ class Source {
   }
 }
 
-class Resource {
+export class Resource {
   constructor(source, pathParts) {
     this.source = source;
     this.pathParts = pathParts;
@@ -195,7 +195,7 @@ class Resource {
   }
 }
 
-class Subresource {
+export class Subresource {
   constructor(resource, type) {
     if (this.constructor === Subresource) {
       throw new Error("Subresource interface class must be subclassed");
@@ -227,7 +227,7 @@ class Subresource {
 }
 
 
-class Dataset extends Resource {
+export class Dataset extends Resource {
   static get Subresource() {
     return DatasetSubresource;
   }
@@ -270,7 +270,7 @@ class Dataset extends Resource {
   }
 }
 
-class DatasetSubresource extends Subresource {
+export class DatasetSubresource extends Subresource {
   static validTypes = ["main", "root-sequence", "tip-frequencies", "measurements", "meta", "tree"];
 
   mediaType = `application/vnd.nextstrain.dataset.${this.type}+json`;
@@ -297,7 +297,7 @@ class DatasetSubresource extends Subresource {
 }
 
 
-class Narrative extends Resource {
+export class Narrative extends Resource {
   static get Subresource() {
     return NarrativeSubresource;
   }
@@ -318,7 +318,7 @@ class Narrative extends Resource {
   }
 }
 
-class NarrativeSubresource extends Subresource {
+export class NarrativeSubresource extends Subresource {
   static validTypes = ["md"];
 
   mediaType = "text/vnd.nextstrain.narrative+markdown";
@@ -333,16 +333,3 @@ class NarrativeSubresource extends Subresource {
     return `${this.resource.baseName}.md`;
   }
 }
-
-
-export {
-  Source,
-  Resource,
-  Subresource,
-
-  Dataset,
-  DatasetSubresource,
-
-  Narrative,
-  NarrativeSubresource,
-};

--- a/src/upstream.js
+++ b/src/upstream.js
@@ -20,7 +20,7 @@ const pipeline = promisify(stream.pipeline);
  *
  * @param {String[]} urls - URLs of the objects to be deleted.
  */
-async function deleteByUrls(urls) {
+export async function deleteByUrls(urls) {
   const method = "DELETE";
   const responses = await Promise.all(urls.map(url => fetch(url, {method})));
 
@@ -42,7 +42,7 @@ async function deleteByUrls(urls) {
  * @param {String} url - Resource URL
  * @param {String} accept - HTTP Accept header value
  */
-async function proxyFromUpstream(req, res, url, accept) {
+export async function proxyFromUpstream(req, res, url, accept) {
   return await proxyResponseBodyFromUpstream(req, res, new Request(url, {
     headers: {
       Accept: accept,
@@ -83,7 +83,7 @@ async function proxyFromUpstream(req, res, url, accept) {
  * @param {upstreamUrlExtractor} upstreamUrlExtractor - Callback to retrieve resource URL
  * @param {string} contentType - `Content-Type` header value to send
  */
-async function proxyToUpstream(req, res, upstreamUrlExtractor, contentType) {
+export async function proxyToUpstream(req, res, upstreamUrlExtractor, contentType) {
   const method = "PUT";
 
   // eslint-disable-next-line prefer-const
@@ -346,10 +346,3 @@ function copyHeaders(headerSource, headerNames) {
  * @param {string} method - HTTP method
  * @param {Object} headers - HTTP headers
  */
-
-
-export {
-  deleteByUrls,
-  proxyFromUpstream,
-  proxyToUpstream,
-};

--- a/src/user.js
+++ b/src/user.js
@@ -21,7 +21,7 @@ const staleBefore = new KvNamespace("userStaleBefore");
  * @returns {Number|null} timestamp
  * @see markUserStaleBeforeNow
  */
-async function userStaleBefore(username) {
+export async function userStaleBefore(username) {
   const timestamp = parseInt(await staleBefore.get(username), 10);
 
   return Number.isInteger(timestamp)
@@ -41,7 +41,7 @@ async function userStaleBefore(username) {
  * @returns {Boolean} True if set succeeded; false if not.
  * @see userStaleBefore
  */
-async function markUserStaleBeforeNow(username) {
+export async function markUserStaleBeforeNow(username) {
   /* Keying on usernames, instead of say the "sub" (subject) attribute of a
    * user, makes this API more ergonomic and avoids needing to convert from
    * username → sub in contexts where we only have username (e.g. a request
@@ -68,9 +68,3 @@ async function markUserStaleBeforeNow(username) {
 
   return await staleBefore.set(username, now, ttl);
 }
-
-
-export {
-  userStaleBefore,
-  markUserStaleBeforeNow,
-};

--- a/src/utils/datasetConverters.js
+++ b/src/utils/datasetConverters.js
@@ -405,7 +405,7 @@ const setNodeBranchAttrs = (v2) => {
 };
 
 
-const convertFromV1 = ({tree, meta}) => {
+export const convertFromV1 = ({tree, meta}) => {
   const v2 = {version: "v2", meta: {}};
   // set metadata
   setColorings(v2["meta"], meta);
@@ -418,9 +418,4 @@ const convertFromV1 = ({tree, meta}) => {
   setVaccineChoicesOnNodes(v2, meta);
   removeNonV2TreeProps(v2);
   return v2;
-};
-
-
-export {
-  convertFromV1,
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,23 +3,23 @@ import fetch from 'node-fetch';
 import { NotFound } from '../httpErrors.js';
 
 
-const verbose = (msg, ...rest) => {
+export const verbose = (msg, ...rest) => {
   if (global.verbose) {
     console.log(chalk.greenBright(`[verbose]\t${msg}`), ...rest);
   }
 };
-const log = (msg, ...rest) => {
+export const log = (msg, ...rest) => {
   console.log(chalk.blueBright(msg), ...rest);
 };
-const warn = (msg, ...rest) => {
+export const warn = (msg, ...rest) => {
   console.warn(chalk.redBright(`[warning]\t${msg}`), ...rest);
 };
-const error = (msg, ...rest) => {
+export const error = (msg, ...rest) => {
   console.error(chalk.redBright(`[error]\t${msg}`), ...rest);
   process.exit(2);
 };
 
-const fetchJSON = async (url) => {
+export const fetchJSON = async (url) => {
   verbose(`Fetching ${url}`);
   const res = await fetch(url);
 
@@ -46,7 +46,7 @@ const fetchJSON = async (url) => {
   return res.json();
 };
 
-const responseDetails = async (response) => [
+export const responseDetails = async (response) => [
   `${response.status} ${response.statusText}`,
   await response.text()
 ];
@@ -57,7 +57,7 @@ const responseDetails = async (response) => [
  * @param {Array} files. Array of strings.
  * @returns {Array}
  */
-const getDatasetsFromListOfFilenames = (filenames) => {
+export const getDatasetsFromListOfFilenames = (filenames) => {
   /* Please see https://github.com/nextstrain/nextstrain.org/pull/65 for comments
   which indicate that this function "weirdly mixes a functional, stream-based
   approach with a procedural approach" and is a candidate for refactoring.
@@ -88,7 +88,7 @@ const getDatasetsFromListOfFilenames = (filenames) => {
     .join("/"));
 };
 
-const parseNarrativeLanguage = (narrative) => {
+export const parseNarrativeLanguage = (narrative) => {
   const urlParts = narrative.split("/");
   let language = urlParts[urlParts.length - 2];
   if (language === 'sit-rep') language = 'en';
@@ -104,7 +104,7 @@ const parseNarrativeLanguage = (narrative) => {
  * @params {object} headers
  * @returns {object}
  */
-const normalizeHeaders = (headers) => {
+export const normalizeHeaders = (headers) => {
   const withValues =
     Object.entries(headers)
       .filter(([, value]) => value != null && value !== "");
@@ -113,16 +113,4 @@ const normalizeHeaders = (headers) => {
    * lowercasing and combining duplicate headers as appropriate.
    */
   return Object.fromEntries((new fetch.Headers(withValues)).entries());
-};
-
-export {
-  verbose,
-  log,
-  warn,
-  error,
-  fetchJSON,
-  responseDetails,
-  getDatasetsFromListOfFilenames,
-  parseNarrativeLanguage,
-  normalizeHeaders,
 };

--- a/src/utils/prefix.js
+++ b/src/utils/prefix.js
@@ -28,7 +28,7 @@ const sourceClassToName = new Map(
  * The inverse of splitPrefixIntoParts() is joinPartsIntoPrefix(), which should
  * roundtrip losslessly.
  */
-const splitPrefixIntoParts = (prefix) => {
+export const splitPrefixIntoParts = (prefix) => {
   if (!prefix) throw new Error("'prefix' is null or empty");
 
   const prefixParts = prefix
@@ -111,7 +111,7 @@ const splitPrefixIntoParts = (prefix) => {
  * automatically provided reverse URL-construction/interpolation function on
  * the matched route.
  */
-const joinPartsIntoPrefix = async ({source, prefixParts, isNarrative = false}) => {
+export const joinPartsIntoPrefix = async ({source, prefixParts, isNarrative = false}) => {
   const leadingParts = [];
 
   const sourceName = sourceClassToName.get(source.constructor);
@@ -155,12 +155,5 @@ const joinPartsIntoPrefix = async ({source, prefixParts, isNarrative = false}) =
 
 /* Round-trip prefix through split/join to canonicalize it for comparison.
  */
-const canonicalizePrefix = async (prefix) =>
+export const canonicalizePrefix = async (prefix) =>
   joinPartsIntoPrefix(splitPrefixIntoParts(prefix));
-
-
-export {
-  splitPrefixIntoParts,
-  joinPartsIntoPrefix,
-  canonicalizePrefix,
-};

--- a/src/utils/scripts.js
+++ b/src/utils/scripts.js
@@ -10,7 +10,7 @@ import { Transform } from 'stream';
  *
  * @param {{dryRun: boolean}}
  */
-function setupConsole({dryRun = true}) {
+export function setupConsole({dryRun = true}) {
   if (!dryRun) return;
 
   const LinePrefixer = class extends Transform {
@@ -56,7 +56,7 @@ function setupConsole({dryRun = true}) {
  *   - https://nodejs.org/api/process.html#event-unhandledrejection
  *   - https://nodejs.org/api/process.html#event-rejectionhandled
  */
-function reportUnhandledRejectionsAtExit() {
+export function reportUnhandledRejectionsAtExit() {
   const unhandledRejections = new Set();
   process.on("unhandledRejection", (_, promise) => unhandledRejections.add(promise));
   process.on("rejectionHandled", (promise) => unhandledRejections.delete(promise));
@@ -83,7 +83,7 @@ function reportUnhandledRejectionsAtExit() {
  * @param {string[]} argv
  * @returns {Promise<{code, signal, argv}>}
  */
-async function run(argv) {
+export async function run(argv) {
   return new Promise((resolve, reject) => {
     const proc = spawn(argv[0], argv.slice(1), {stdio: ["ignore", "pipe", "pipe"]});
 
@@ -98,10 +98,3 @@ async function run(argv) {
     });
   });
 }
-
-
-export {
-  setupConsole,
-  reportUnhandledRejectionsAtExit,
-  run,
-};


### PR DESCRIPTION
## Description of proposed changes

This a follow-up to "Use cjs-to-es6 to help conversion" (1963fcd7), which left exports at the bottom of the file. That was necessary for CJS, but now ESM syntax can be leveraged for more concise code.

I searched for instances of "export {" and manually applied the conversion where possible. I skipped src/async.js since that's a vendored copy of an external script.

## Related issue(s)

Proposed in https://github.com/nextstrain/nextstrain.org/pull/735#discussion_r1401216668.

## Checklist

- [x] Checks pass
- [x] Review app: clicking around a few pages works
- [x] Locally (because groups doesn't work on review app): Login, logout, accessing groups works

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
