### PR TITLE
Add lassa build to manifest

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -193,6 +193,13 @@
           "default": "seasonal"
         }
       },
+      "lassa": {
+        "resolution": {
+          "l": "",
+          "s": "",
+          "default": "s"
+        }
+      },
       "measles": "",
       "mpox": {
         "resolution": {


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

The lassa repo¹ has a link to nextstrain.org/lassa that doesn't work. This should fix it.

¹ <https://github.com/nextstrain/lassa>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] `/lassa` works on preview build: https://nextstrain-s-victorlin--gc6piw.herokuapp.com/lassa
- [x] Checks pass
- [ ] Post-merge: create a PR for adding a lassa card to the pathogens page

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
