### PR TITLE
whoami: List public group memberships…

### DIFF
--- a/static-site/src/pages/whoami.jsx
+++ b/static-site/src/pages/whoami.jsx
@@ -12,9 +12,21 @@ const UserPage = () => {
     <Fragment>
       You&apos;re logged in as <strong>{user.username}</strong>.
       <SubText>
-        You have access to the following private Nextstrain groups, which each
+        You have access to the following Nextstrain groups, which each
         contain a collection of datasets and/or narratives:
       </SubText>
+
+      Public:
+
+      <UserGroupsList>
+        {visibleGroups.filter((group) => !group.private).map((group) => (
+          <li>
+            <a href={`/groups/${group.name}`}>{group.name}</a>
+          </li>
+        ))}
+      </UserGroupsList>
+
+      Private:
 
       <UserGroupsList>
         {visibleGroups.filter((group) => group.private).map((group) => (
@@ -23,6 +35,7 @@ const UserPage = () => {
           </li>
         ))}
       </UserGroupsList>
+
       <a href="/logout">Logout</a>
     </Fragment>
   );


### PR DESCRIPTION
… in addition to private group memberships.

If anything, I think it's even more valuable to have the list of public group memberships, as private group memberships can be easily found by logging in, going to the Groups index page, scrolling to the bottom, and looking for groups with a padlock icon.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

N/A, came across this while testing Groups stuff.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
