### PR TITLE
Add script to update GitHub token on Heroku apps

### DIFF
--- a/scripts/update-github-token
+++ b/scripts/update-github-token
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Updates nextstrain.org Heroku apps with a new GitHub token.
+#
+set -euo pipefail
+
+main() {
+    if [ "$#" -ne 1 ]; then
+      echo "Usage: $0 <GITHUB_TOKEN>"
+      exit 1
+    fi
+
+    check-deps
+
+    check-heroku-access
+
+    update-github-token "$1"
+}
+
+check-deps () {
+    echo "This script depends on heroku and jq. Checking that they are available..."
+
+    heroku --help > /dev/null
+    jq --help > /dev/null
+
+    echo "Done."
+}
+
+check-heroku-access() {
+    echo "Checking that you are logged in. If you see an error, please log in to Heroku CLI."
+
+    heroku whoami >/dev/null
+
+    echo "You are logged in. Checking access..."
+
+    is_nextstrain_admin=$(heroku teams --json | jq '.[] | select(.name == "nextstrain" and .role == "admin") | length == 1')
+    if [[ -z "$is_nextstrain_admin" ]]; then
+      echo "ERROR: Insufficient access with Heroku CLI. Please log out then log back in to Heroku CLI as a member of the Nextstrain team."
+      exit 1
+    fi
+
+    echo "You have access."
+}
+
+update-github-token() {
+    new_token="$1"
+
+    echo "Updating tokens..."
+
+    for app in "nextstrain-dev" "nextstrain-canary" "nextstrain-server"
+    do
+        old_token=$(heroku config:get GITHUB_TOKEN --app "$app")
+        echo "[$app] Replacing old token $old_token with $new_token"
+        heroku config:set GITHUB_TOKEN="$new_token" --app "$app"
+    done
+
+    echo "Done."
+}
+
+main "$@"


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Using a script allows for minimal time between GitHub token regeneration and config var updates, especially when the same token is used across multiple apps. Also useful to somewhat automate the process given GitHub requires token regeneration at least once every year.

Note that it'll still take some time between manually regenerating the token on the GitHub UI, pasting it as an argument to this script, then running the script. In the case of this GitHub token, it's not currently being used at a level where this matters critically.

In the future if this becomes more critical, the downtime could be eliminated by generating a new token while keeping the old one valid.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

N/A

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Used after the latest token regeneration
- [ ] Post-merge: Update [internal wiki page](https://nextstrain.atlassian.net/wiki/spaces/NEXTSTRAIN/pages/170688571/GitHub+nextstrain-bot+usage)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
