### PR TITLE
aws/cognito: Extend validity of the CLI's refresh tokens from 30 → 90 days

### DIFF
--- a/aws/cognito/clients.tf
+++ b/aws/cognito/clients.tf
@@ -97,7 +97,7 @@ resource "aws_cognito_user_pool_client" "nextstrain-cli" {
   # Token lifetimes dictate background refresh (and re-login) rates for the CLI.
   id_token_validity      = 60
   access_token_validity  = 60
-  refresh_token_validity = 30
+  refresh_token_validity = 90
   token_validity_units {
     access_token  = "minutes"
     id_token      = "minutes"


### PR DESCRIPTION
In practice, 30 days seems too short.

I've observed users who get the CLI installed and logged in but then don't get to uploading their datasets until more than 30 days later (i.e. they spend time producing the datasets or on other work) and so then have to log in again when it's time to upload.  This has been a minor frustration and stumbling block for them.

In a different use case, @corneliusroemer has also found 30 days to be too short in automation contexts.  Although I'd suggest a different approach for automation¹, I suspect his approach will not be an uncommon one for users to take so we should ensure it's not too onerous when they do.

Resolves <https://github.com/nextstrain/cli/issues/337>.

¹ <https://github.com/nextstrain/cli/issues/337#issuecomment-1883534419>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
