### PR TITLE
Revert "whoami: List public group memberships…"

### DIFF
--- a/static-site/src/pages/whoami.jsx
+++ b/static-site/src/pages/whoami.jsx
@@ -12,21 +12,9 @@ const UserPage = () => {
     <Fragment>
       You&apos;re logged in as <strong>{user.username}</strong>.
       <SubText>
-        You have access to the following Nextstrain groups, which each
+        You have access to the following private Nextstrain groups, which each
         contain a collection of datasets and/or narratives:
       </SubText>
-
-      Public:
-
-      <UserGroupsList>
-        {visibleGroups.filter((group) => !group.private).map((group) => (
-          <li>
-            <a href={`/groups/${group.name}`}>{group.name}</a>
-          </li>
-        ))}
-      </UserGroupsList>
-
-      Private:
 
       <UserGroupsList>
         {visibleGroups.filter((group) => group.private).map((group) => (
@@ -35,7 +23,6 @@ const UserPage = () => {
           </li>
         ))}
       </UserGroupsList>
-
       <a href="/logout">Logout</a>
     </Fragment>
   );


### PR DESCRIPTION
This reverts #769, which shows all public groups instead of just public group memberships as intended.

Will re-implement in another PR.