### PR TITLE
upstream: Add a Cache-Control header to resource responses

### DIFF
--- a/src/upstream.js
+++ b/src/upstream.js
@@ -238,6 +238,12 @@ async function proxyResponseBodyFromUpstream(req, res, upstreamReq) {
 
   res.set(copyHeaders(upstreamRes.headers, forwardedUpstreamResHeaders));
 
+  /* Allow private (e.g. browser) caches to store this response, but require
+   * them to revalidate it every time before use.  They'll make conditional
+   * requests which we can respond to quickly from our own server-side cache.
+   */
+  res.set("Cache-Control", "private, no-cache");
+
   /* Check if the request conditions (e.g. If-None-Match) are satisfied (e.g.
    * against our response ETag) and short-circuit with a 304 if we can!
    */


### PR DESCRIPTION
This permits private caching (e.g. by browsers), like now, but instructs them to always check for updates (revalidate) before using the cached response (unlike now).  Prior to this, browsers would use their own heuristics to figure out when to revalidate which could lead to staleness and user confusion.

This new caching policy doesn't save a request/response cycle, but it does save response transfer time when a cached response can be used. It also forbids using the cached response when the browser is offline, though I'm not sure we care about that use case (and not sure other bits of nextstrain.org support it, like the Auspice client).

This affects the RESTful API and Charon API endpoints for datasets and narratives, as well as the endpoints for a group's overview and logo.

Resolves <https://github.com/nextstrain/nextstrain.org/issues/707>.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checked caching behaviour locally; seems as expected
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
