### PR TITLE
Surface previous dataset versions across URL redirects

### DIFF
--- a/docs/resource-collection.rst
+++ b/docs/resource-collection.rst
@@ -23,17 +23,28 @@ Local index generation
 The resource index may be regenerated locally, see ``node
 ./resourceIndexer/main.js --help`` for details. By default, this will access S3
 manifest files in order to create the index (see necessary AWS permissions
-below), however you can point the indexer to local files if desired. To use
-local files, download a suitable manifest and inventory from
-``s3://nextstrain-inventories`` and name them like so:
+below), however you can use local copies of the (S3) manifest + inventory for a
+smoother development experience.
 
-* For ``nextstrain-data``: ``./devData/core.manifest.json`` and ``core.inventory.csv.gz``
-* For ``nexstrain-staging``: ``./devData/staging.manifest.json`` and ``staging.inventory.csv.gz``
+To save a local copy of the latest S3 manifest & inventory:
+```
+mkdir -p devData
+node ./resourceIndexer/main.js --save-inventories ...
+```
 
-then run the indexer with the ``--local`` flag.
+This will create ``./devData/core.manifest.json`` and
+``./devData/core.inventory.csv.gz`` for the core (nextstrain-data) source and
+``./devData/staging.manifest.json`` and ``./devData/staging.inventory.csv.gz``
+for the staging source. Alternately you can manually obtain a suitable manifest
+and inventory from ``s3://nextstrain-inventories`` 
 
-To use a locally produced index, set the env variable ``RESOURCE_INDEX`` to
-point to the (JSON) file when you run the server.
+To generate the index using these local files run the indexer with the ``--local`` flag.
+
+Using a local index
+===================
+
+Set the env variable ``RESOURCE_INDEX`` to point to the local JSON file when you
+run the server.
 
 
 Automated index generation

--- a/resourceIndexer/coreStagingS3.js
+++ b/resourceIndexer/coreStagingS3.js
@@ -1,6 +1,7 @@
 import { SOURCE, VALID_AUSPICE_PATTERNS, INVALID_AUSPICE_PATTERNS,
   DATESTAMP_REGEX, SIDECAR_TYPES } from './constants.js';
 import { collectInventory } from './inventory.js';
+import { remapCoreUrl } from "./coreUrlRemapping.js";
 
 /**
  * The inventory of buckets (especially the core bucket) is in some ways a
@@ -75,15 +76,12 @@ function categoriseCoreObjects(item, staging) {
   item.subresourceType = auspiceFileInfo.subresourceType;
   
   /**
-   * Currently the resourcePath is based completely off the key name,
-   * paralleling how the nextstrain.org URLs of datasets are mapped to resource
-   * paths and then to S3 keys. In the future we may change this in order to
-   * group together files with different s3 key names but which we want to
-   * associate with the same nextstrain.org URL. For example, we may which to
-   * combine the auspice datasets behind `ncov/gisaid/africa` and
-   * `ncov/gisaid/africa/all-time`.
+   * We remap the expected URls (created from the S3 key name) using the same
+   * underlying data that the server uses to redirect certain URLs. This allows
+   * "new" URLs (i.e. where the client gets redirected to) to contain the entire
+   * history of the resource
    */
-  item.resourcePath = auspiceFileInfo.urlPath;
+  item.resourcePath = remapCoreUrl(auspiceFileInfo.urlPath);
 
   return item;
 }

--- a/resourceIndexer/coreStagingS3.js
+++ b/resourceIndexer/coreStagingS3.js
@@ -269,10 +269,11 @@ function validIntermediate(id, date, objects) {
 
 export const coreS3Data = {
   name: 'core',
-  async collect({local}) {
+  async collect({local, save}) {
     return await collectInventory({
       name: this.name,
       local,
+      save,
       inventoryBucket: "nextstrain-inventories",
       inventoryPrefix: "nextstrain-data/config-v1/"
     })

--- a/resourceIndexer/coreUrlRemapping.js
+++ b/resourceIndexer/coreUrlRemapping.js
@@ -1,0 +1,54 @@
+import { readFileSync } from "fs";
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { convertManifestJsonToAvailableDatasetList } from "../src/endpoints/charon/parseManifest.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __basedir = path.join(__dirname, "..");
+
+let resolvedPath;
+
+/**
+ * Remaps an incomplete URL core dataset path to the path it will be redirected
+ * to by the server via the "nextstrain manifest". If the provided URL would not
+ * be redirected we return the provided path unchanged.
+ * @param {string} urlPath nextstrain.org URL path
+ * @returns {string}
+ */
+export const remapCoreUrl = (urlPath) => {
+  if (!resolvedPath) {
+    /* map only computed the first time this function is run */
+    const serverManifest = JSON.parse(readFileSync(path.join(__basedir, "data", "manifest_core.json")));
+    resolvedPath = resolveAll(
+      convertManifestJsonToAvailableDatasetList(serverManifest).defaults
+    )
+  }
+  return resolvedPath[urlPath] || urlPath;
+}
+
+
+/**
+ * The server contains a map of partial paths and their next (default) path,
+ * e.g. flu → seasonal
+ *      flu/seasonal → h3n2
+ *      etc
+ * and uses an iterative approach to resolve the final path. Here we want to
+ * resolve the entire path for every partial path, for instance
+ *      flu → flu/seasonal/h3n2/h2/2y
+ *      flu/seasonal → flu/seasonal/h3n2/h2/2y
+ * @param {Object} defaults 
+ * @returns {Object}
+ */
+function resolveAll(defaults) {
+  const urlMap = {};
+  Object.entries(defaults).forEach(([partialPath, nextPathPart]) => {
+    if (partialPath==='') return; // manifest has a base default of zika!
+    let resolvedPath = `${partialPath}/${nextPathPart}`;
+    while (resolvedPath in defaults) {
+      resolvedPath += `/${defaults[resolvedPath]}`;
+    }
+    urlMap[partialPath] = resolvedPath;
+  })
+  return urlMap;
+}

--- a/src/endpoints/charon/parseManifest.js
+++ b/src/endpoints/charon/parseManifest.js
@@ -1,0 +1,96 @@
+
+/**
+ * Generates second tree options for a given dataset.
+ *
+ * Replaces segment within urlParts with every other segment in
+ * given segments array
+ *
+ * @param {[String]} urlParts
+ * @param {[String]} segments
+ */
+const generateSecondTreeOptions = (urlParts, segments) => {
+  // Return empty array if there are no segments
+  if (segments.length === 0) return [];
+
+  // Find segment in urlParts
+  const currentSegment = segments.filter((seg) => urlParts.indexOf(seg) !== -1)[0];
+  const segmentIndex = urlParts.indexOf(currentSegment);
+
+  // Generate second tree options by replacing segment in urlParts
+  const secondTreeOptions = segments
+    .filter((segment) => segment !== currentSegment) // Remove current segment from segments array
+    .map((segment) => {
+      const newUrl = urlParts.slice();
+      newUrl[segmentIndex] = segment;
+      return newUrl.join("/");
+    });
+
+  return secondTreeOptions;
+};
+
+export const convertManifestJsonToAvailableDatasetList = (old) => {
+  const allUrls = {}; /* holds all URLs as keys and second tree options as value */
+  const defaults = {}; /* holds the defaults, used to complete incomplete paths */
+  let segments = []; /* holds the genome segments, used to find second tree options */
+
+  /*
+    if there's only one key in the object it's the "name" of the level
+    in the hierarchy, e.g. "category" or "lineage", which we skip over.
+    Note that for levels with only 1 option there's 2 keys (one is "default")
+  */
+  const skipLevelNameKeys = (obj) => {
+    const keys = Object.keys(obj);
+    if (keys.length === 1) {
+      obj = obj[keys[0]];
+    }
+    return obj;
+  };
+
+  /**
+   * Iterates over an object to build an array of URL components to be used
+   * for a future data request.
+   *
+   * SIDE EFFECT: sets segments based on obj keys and resets segments based on
+   * lenght of partsSoFar.
+   *
+   * @param {[String]} partsSoFar
+   * @param {Object} obj
+   */
+  const recursivelyBuildUrlParts = (partsSoFar, obj) => {
+    if (typeof obj === "string") {
+      allUrls[partsSoFar.join("/")] = generateSecondTreeOptions(partsSoFar, segments);
+    }
+
+    const flattenedObj = skipLevelNameKeys(obj);
+    const keys = Object.keys(flattenedObj);
+
+    const defaultValue = flattenedObj.default;
+    if (!defaultValue) {
+      return;
+    }
+    defaults[partsSoFar.join("/")] = defaultValue;
+
+    const orderedKeys = keys.filter((k) => k !== "default");
+
+    if (partsSoFar.length === 1) {
+      segments = [];
+    }
+    if (Object.keys(obj)[0] === "segment") {
+      segments = orderedKeys.slice();
+    }
+
+    orderedKeys.forEach((key) => {
+      const newParts = partsSoFar.slice();
+      newParts.push(key);
+      recursivelyBuildUrlParts(newParts, flattenedObj[key]);
+    });
+  };
+
+  recursivelyBuildUrlParts([], old.pathogen);
+
+  return {
+    datasets: Object.keys(allUrls),
+    secondTreeOptions: allUrls,
+    defaults
+  };
+};

--- a/src/endpoints/charon/setAvailableDatasets.js
+++ b/src/endpoints/charon/setAvailableDatasets.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { convertManifestJsonToAvailableDatasetList } from './parseManifest.js';
 import * as utils from '../../utils/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -22,101 +23,6 @@ global.availableDatasets = {
   defaults: {}
 };
 
-/**
- * Generates second tree options for a given dataset.
- *
- * Replaces segment within urlParts with every other segment in
- * given segments array
- *
- * @param {[String]} urlParts
- * @param {[String]} segments
- */
-const generateSecondTreeOptions = (urlParts, segments) => {
-  // Return empty array if there are no segments
-  if (segments.length === 0) return [];
-
-  // Find segment in urlParts
-  const currentSegment = segments.filter((seg) => urlParts.indexOf(seg) !== -1)[0];
-  const segmentIndex = urlParts.indexOf(currentSegment);
-
-  // Generate second tree options by replacing segment in urlParts
-  const secondTreeOptions = segments
-    .filter((segment) => segment !== currentSegment) // Remove current segment from segments array
-    .map((segment) => {
-      const newUrl = urlParts.slice();
-      newUrl[segmentIndex] = segment;
-      return newUrl.join("/");
-    });
-
-  return secondTreeOptions;
-};
-
-const convertManifestJsonToAvailableDatasetList = (old) => {
-  const allUrls = {}; /* holds all URLs as keys and second tree options as value */
-  const defaults = {}; /* holds the defaults, used to complete incomplete paths */
-  let segments = []; /* holds the genome segments, used to find second tree options */
-
-  /*
-    if there's only one key in the object it's the "name" of the level
-    in the hierarchy, e.g. "category" or "lineage", which we skip over.
-    Note that for levels with only 1 option there's 2 keys (one is "default")
-  */
-  const skipLevelNameKeys = (obj) => {
-    const keys = Object.keys(obj);
-    if (keys.length === 1) {
-      obj = obj[keys[0]];
-    }
-    return obj;
-  };
-
-  /**
-   * Iterates over an object to build an array of URL components to be used
-   * for a future data request.
-   *
-   * SIDE EFFECT: sets segments based on obj keys and resets segments based on
-   * lenght of partsSoFar.
-   *
-   * @param {[String]} partsSoFar
-   * @param {Object} obj
-   */
-  const recursivelyBuildUrlParts = (partsSoFar, obj) => {
-    if (typeof obj === "string") {
-      allUrls[partsSoFar.join("/")] = generateSecondTreeOptions(partsSoFar, segments);
-    }
-
-    const flattenedObj = skipLevelNameKeys(obj);
-    const keys = Object.keys(flattenedObj);
-
-    const defaultValue = flattenedObj.default;
-    if (!defaultValue) {
-      return;
-    }
-    defaults[partsSoFar.join("/")] = defaultValue;
-
-    const orderedKeys = keys.filter((k) => k !== "default");
-
-    if (partsSoFar.length === 1) {
-      segments = [];
-    }
-    if (Object.keys(obj)[0] === "segment") {
-      segments = orderedKeys.slice();
-    }
-
-    orderedKeys.forEach((key) => {
-      const newParts = partsSoFar.slice();
-      newParts.push(key);
-      recursivelyBuildUrlParts(newParts, flattenedObj[key]);
-    });
-  };
-
-  recursivelyBuildUrlParts([], old.pathogen);
-
-  return {
-    datasets: Object.keys(allUrls),
-    secondTreeOptions: allUrls,
-    defaults
-  };
-};
 
 /* setAvailableDatasetsFromManifest
  * Collect available datasets by fetching the manifest JSON

--- a/src/endpoints/sources.js
+++ b/src/endpoints/sources.js
@@ -43,7 +43,8 @@ export const setDataset = (pathExtractor) => (req, res, next) => {
 
 /**
  * Generate Express middleware that redirects to the canonical path for the
- * current {@link Dataset} if it is not fully resolved.
+ * current {@link Dataset} if it is not fully resolved. Any provided version
+ * descriptor is included in the redirect.
  *
  * @param {pathBuilder} pathBuilder - Function to build a fully-specified path
  * @returns {expressMiddleware}
@@ -54,9 +55,11 @@ export const canonicalizeDataset = (pathBuilder) => (req, res, next) => {
 
   if (dataset === resolvedDataset) return next();
 
+  const version = dataset.versionDescriptor ? `@${dataset.versionDescriptor}` : '';
+
   const canonicalPath = pathBuilder.length >= 2
-    ? pathBuilder(req, resolvedDataset.pathParts.join("/"))
-    : pathBuilder(resolvedDataset.pathParts.join("/"));
+    ? pathBuilder(req, resolvedDataset.pathParts.join("/") + version)
+    : pathBuilder(resolvedDataset.pathParts.join("/") + version);
 
   /* 307 Temporary Redirect preserves request method, unlike 302 Found, which
    * is important since this middleware function may be used in non-GET routes.

--- a/src/sources/models.js
+++ b/src/sources/models.js
@@ -144,7 +144,6 @@ export class Resource {
     this.source = source;
     this.pathParts = pathParts;
     this.versionDescriptor = versionDescriptor;
-    [this.versionDate, this.versionUrls] = this.versionInfo(versionDescriptor);
 
     // Require baseParts, otherwise we have no actual dataset/narrative path.
     // This inspects baseParts because some of the pathParts (above) may not
@@ -241,12 +240,15 @@ export class Subresource {
      * Note that the URL is not signed, and changes will be required to support
      * this as needed.
      */
-    if (this.resource.versionUrls) {
+
+    const versionUrls = this.resource.versionInfo(this.resource.versionDescriptor)[1];
+
+    if (versionUrls) {
       if (!['HEAD', 'GET'].includes(method)) {
         throw new InternalServerError(`Only the GET and HEAD methods are available for previous resource versions`);
       }
-      if (this.resource.versionUrls[this.type]) {
-        return this.resource.versionUrls[this.type];
+      if (versionUrls[this.type]) {
+        return versionUrls[this.type];
       }
       throw new NotFound(`This version of the resource does not have a subresource for ${this.type}`);
     }

--- a/test/date_descriptor.test.js
+++ b/test/date_descriptor.test.js
@@ -10,7 +10,7 @@
 /**
  * Example dev use:
  * run the server in a separate process via:
- * RESOURCE_INDEX="./devData/index.json" node server.js --verbose
+ * RESOURCE_INDEX="./test/date_descriptor_index.json" node server.js --verbose
  * Then run this test file via:
  * NODE_OPTIONS='--experimental-vm-modules' npx jest test/date_descriptor.test.js
  */

--- a/test/date_descriptor.test.js
+++ b/test/date_descriptor.test.js
@@ -301,6 +301,54 @@ describe("Valid narratives", () => {
   }
 })
 
+const redirects = [
+  ["WNV", "WNV/NA"],
+  /* Note that WNV is not in the index, so this versioned test ensures we are
+  not checking the existence/validity of any version descriptor against the WNV
+  resource, rather we are redirecting and deferring those checks */
+  ["WNV@2020-01-01", "WNV/NA@2020-01-01"],
+]
+
+describe("Paths redirect with version descriptors", () => {
+  /* See <https://github.com/node-fetch/node-fetch#manual-redirect> for how
+  fetch stores the redirect location when {redirect: 'manual'} */
+  
+  redirects.forEach(([fromUrl, toUrl]) => {
+    /* test RESTful API */
+    (['html', 'json']).forEach((type) => {
+      it(`REST API: ${fromUrl} goes to ${toUrl} (${type})`, async () => {
+        const res = await fetchType(`${BASE_URL}/${fromUrl}`, type);
+        expect(res.status).toEqual(307);
+        expect(res.headers.get('location')).toEqual(`${BASE_URL}/${toUrl}`);
+      })
+    })
+
+
+    /* test Charon API */
+    const charonUrl = (path, sidecar) =>
+      `${BASE_URL}/charon/getDataset?prefix=${path}${sidecar ? `&type=root-sequence` : ''}`;
+
+    /* note that the redirect URL of charon requests is constructed by creating
+    a URL object (the RESTful API does not) which results in '/' and '@' being
+    escaped in the query. This isn't necessary, but it's also fine to do so. */
+
+    it(`Charon main dataset: ${fromUrl} goes to ${toUrl} `, async () => {
+      const res = await fetch(charonUrl(fromUrl, false), {redirect: 'manual'});
+      expect(res.status).toEqual(307);
+      expect(decodeURIComponent(res.headers.get('location'))).toEqual(charonUrl(toUrl, false));
+    })
+
+    it(`Charon sidecar: ${fromUrl} goes to ${toUrl} `, async () => {
+      const res = await fetch(charonUrl(fromUrl, true), {redirect: 'manual'});
+      expect(res.status).toEqual(307);
+      expect(decodeURIComponent(res.headers.get('location'))).toEqual(charonUrl(toUrl, true));
+    })
+
+  })
+
+})
+
+
 /**
  * Map the sidecar names we use day-to-day to their content types
  * used within the server

--- a/test/inventory_parsing.test.js
+++ b/test/inventory_parsing.test.js
@@ -3,6 +3,7 @@
  */
 
 import { parseInventory } from '../resourceIndexer/inventory.js';
+import { remapCoreUrl } from '../resourceIndexer/coreUrlRemapping.js';
 
 /**
  * Following is all the versions for s3://nextstrain-data/zika_meta.json as of
@@ -48,6 +49,26 @@ test('back-to-back delete markers', async () => {
   const shuffled = await parseInventory({objects: shuffle(test_data), versionsExist: true})
     expect(shuffled.map((el) => el.versionId))
       .toEqual(should_be.map((el) => el.VersionId))   
+})
+
+/**
+ * Core URL remapping involves the (committed) `manifest_core.json` and our
+ * parsing of that file in the server code
+ * `convertManifestJsonToAvailableDatasetList`, as well as some resource indexer
+ * specific code. Adding some simple sanity tests here guards against
+ * inadvertent changes.
+ */
+test('core URL redirects (via our manifest) are correctly obtained', async () => {
+  const expected_url_redirects = {
+    'dengue/denv1': 'dengue/denv1/genome',
+    WNV: 'WNV/NA',
+    'flu/seasonal': 'flu/seasonal/h3n2/ha/2y',
+    'flu/seasonal/h3n2': 'flu/seasonal/h3n2/ha/2y',
+    'flu/seasonal/h3n2/ha': 'flu/seasonal/h3n2/ha/2y',
+  }
+  Object.entries(expected_url_redirects).forEach(([from, to]) => {
+    expect(remapCoreUrl(from)).toEqual(to);
+  })
 })
 
 


### PR DESCRIPTION
Closes #777. See that issue or the commit messages for full details.

### Example URLs which are enabled via this work:

The earliest nCoV dataset we have is from 2020-01-19, and was back then accessed via `/ncov`. Now `/ncov@2020-01-19` redirects to `/ncov/gisaid/global/6m@2020-01-19` and loads that dataset. 

We can access the `/dengue/denv1` datasets prior to Jan 2024 via either `/dengue/denv1@YYYY-MM-DD` or `/dengue/denv1/genome@YYYY-MM-DD`, with the former redirecting to the latter.

### Testing

Best done locally, via something like
```bash
mkdir -p devData
node resourceIndexer/main.js --output devData/index.json --save-inventories \
  --indent --resourceTypes dataset --collections core # needs AWS creds to access s3://nextstrain-inventories
RESOURCE_INDEX="devData/index.json" node server.js --verbose
```

The heroku review app will not correctly use this functionality as the live index has not been updated with the changes in  this PR. If you want a non-local way to test this let me know and I'll make it happen. (You can test a subset of the functionality, e.g. [/dengue/denv1@2024-01-03](https://nextstrain-s-james-reso-uw9ge9.herokuapp.com/dengue/denv1@2024-01-03) works as expected.)
