### PR TITLE
[resource indexer] include dataset redirects in index

### DIFF
--- a/resourceIndexer/coreUrlRemapping.js
+++ b/resourceIndexer/coreUrlRemapping.js
@@ -1,7 +1,9 @@
 import { readFileSync } from "fs";
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { ResourceIndexerError } from "./errors.js";
 import { convertManifestJsonToAvailableDatasetList } from "../src/endpoints/charon/parseManifest.js";
+import { datasetRedirects } from "../src/redirects.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -29,7 +31,13 @@ export const remapCoreUrl = (urlPath) => {
 
 
 /**
- * The server contains a map of partial paths and their next (default) path,
+ * The server redirects core dataset URLs via two (complementary) approaches.
+ * 
+ * First, there is a set of hardcoded redirects (src/redirects.js), as exposed by
+ * the `datasetRedirects` function.
+ * 
+ * Secondly, we use our own "manifest JSON" to compute a map of partial paths
+ * and their next (default) path,
  * e.g. flu → seasonal
  *      flu/seasonal → h3n2
  *      etc
@@ -37,11 +45,15 @@ export const remapCoreUrl = (urlPath) => {
  * resolve the entire path for every partial path, for instance
  *      flu → flu/seasonal/h3n2/h2/2y
  *      flu/seasonal → flu/seasonal/h3n2/h2/2y
+ * 
+ * This function combines those approaches and returns a complete list of
+ * URL paths and the final URL path they would be redirected to.
  * @param {Object} defaults 
  * @returns {Object}
  */
 function resolveAll(defaults) {
   const urlMap = {};
+
   Object.entries(defaults).forEach(([partialPath, nextPathPart]) => {
     if (partialPath==='') return; // manifest has a base default of zika!
     let resolvedPath = `${partialPath}/${nextPathPart}`;
@@ -50,5 +62,28 @@ function resolveAll(defaults) {
     }
     urlMap[partialPath] = resolvedPath;
   })
+
+  /**
+   * Process server-hardcoded dataset redirects after the above defaults, as the
+   * path we redirect to may itself be further redirected by the defaults.
+   */
+  const redirects = datasetRedirects().map((paths) => paths.map(_removeSlashes));
+  for (const [requestUrlPath, redirectUrlPath] of redirects) {
+    // The datasetRedirects are simple paths, with no version descriptors or
+    // queries or patterns/regex like behaviour. Nonetheless it's prudent
+    // to add some basic checks for these
+    if (requestUrlPath.includes('@') || requestUrlPath.includes(':') || requestUrlPath.includes('?')) {
+      throw new ResourceIndexerError(`Hardcoded server redirect '${requestUrlPath}' is invalid.`);
+    }
+    urlMap[requestUrlPath] = urlMap[redirectUrlPath] || redirectUrlPath;
+  }
+
   return urlMap;
+}
+
+/**
+ * Remove any leading & trailing slashes
+ */
+function _removeSlashes(path) {
+  return path.replace(/^\/+/, "").replace(/\/+$/, "");
 }

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -27,6 +27,12 @@ export const setup = (app) => {
     app.route(requestPath).get((req, res) =>
       res.redirect(url.format({pathname: redirectPath, query: req.query}))
     )
+    /* redirect versioned requests as well. The format or existence of the
+    version isn't checked here, but it will be when the (redirected) request is
+    handled */
+    app.route(`${requestPath}@:version`).get((req, res) =>
+      res.redirect(url.format({pathname: `${redirectPath}@${req.params.version}`, query: req.query}))
+    )
   }
 
   /*

--- a/src/resourceIndex.js
+++ b/src/resourceIndex.js
@@ -96,12 +96,12 @@ async function updateResourceVersions() {
   if (RESOURCE_INDEX.startsWith("s3://")) {
     const parts = RESOURCE_INDEX.match(/^s3:\/\/(.+?)\/(.+)$/);
     const [Bucket, Key] = [parts[1], parts[2]];
-    utils.verbose(`Updating available resources index from s3://${Bucket}/${Key}`);
+    utils.verbose(`[RESOURCE INDEX UPDATE S3] Fetching index from s3://${Bucket}/${Key}`);
     try {
       const newETag = (await fetch(await signedUrl({bucket:Bucket, key:Key, method: 'HEAD'}), {method: 'HEAD'}))
         .headers.get('etag'); // value is enclosed in double quotes, but that doesn't matter for our purposes
       if (newETag && newETag === eTag) {
-        utils.verbose("Skipping available resource update as eTag hasn't changed");
+        utils.verbose(`[RESOURCE INDEX UPDATE S3] Skipping as eTag hasn't changed: ${eTag}`);
         return;
       }
       const res = await fetch(await signedUrl({bucket:Bucket, key:Key, method: 'GET'}), {method: 'GET'})
@@ -110,8 +110,9 @@ async function updateResourceVersions() {
       }
       const newResources = JSON.parse(await gunzip(await res.buffer()));
       [resources, eTag] = [newResources, newETag];
+      utils.verbose(`[RESOURCE INDEX UPDATE S3] Updated. New eTag: ${eTag}`);
     } catch (err) {
-      utils.warn(`Resource updating failed: ${err.message}`)
+      utils.warn(`[RESOURCE INDEX UPDATE S3] updating failed: ${err.message}`)
     }
     return;
   }

--- a/test/date_descriptor.test.js
+++ b/test/date_descriptor.test.js
@@ -349,6 +349,26 @@ describe("Paths redirect with version descriptors", () => {
 })
 
 
+const redirectsRestOnly = [
+  /* Following paths are redirected early on in our routing stack and doesn't involve
+  any checking of the version provided */
+  ["monkeypox/mpxv", "mpox/all-clades"],
+  ["monkeypox/mpxv@anything", "mpox/all-clades@anything"]
+]
+
+describe("Paths redirect according to hardcoded top-level redirects", () => {
+  redirectsRestOnly.forEach(([fromUrl, toUrl]) => {
+    (['html', 'json']).forEach((type) => {
+      it(`REST API: ${fromUrl} goes to ${toUrl} (${type})`, async () => {
+        const res = await fetchType(`${BASE_URL}/${fromUrl}`, type);
+        expect(res.status).toEqual(302); // res.redirect() has a default of 302
+        expect(res.headers.get('location')).toEqual(`${BASE_URL}/${toUrl}`);
+      })
+    })
+  })
+})
+
+
 /**
  * Map the sidecar names we use day-to-day to their content types
  * used within the server


### PR DESCRIPTION
Recent work surfaced previous dataset versions across URL redirects¹ by
mirroring the dataset-name resolution process we use for requests on the
server. However it neglected to consider the redirects which are handled
prior to this in the server. This commit adds that functionality as
well. This situation was recently discussed in slack².

To use mpox as an example: the dataset (URL) path "mpox/all-clades" now includes previous versions which were named "monkeypox_mpxv.json", thus extending the snapshot history of this dataset from 2023-09-23 to 2022-06-12.

Our usage of `ncov_global.json` (similarly for other regions) is a lot more complex, because we didn't make clean dataset name switches like monkeypox/mpox.

Looking at the current live index (i.e. before this PR) the `ncov.json` dataset stops being uploaded 2020-04-23 and then starts being uploaded again on 2020-09-03, leaving a large gap in the snapshot history. When we do consider `ncov_global.json` (this PR), we fill in this gap with 99 snapshots. Great!

However `ncov.json` continued to be uploaded through 2021-02-15. In cases such as this the indexer will pick the last uploaded version in a given day. However looking at the data it's clear `ncov.json` was not being rebuilt, simply re-uploaded. For instance, here are nextstrain.org URLs you can view the data in:

* 2020-09-03: [ncov.json](https://nextstrain.org/fetch/nextstrain-data.s3.amazonaws.com/ncov.json%3FversionId=U74n6nPfuAYtFoJZDy5mTffmRL9k.91f), [ncov_global.json](https://nextstrain.org/fetch/nextstrain-data.s3.amazonaws.com/ncov_global.json%3FversionId=y9aBoREy41se0iYGH1.y7i7BtSoGleN.)

* 2021-02-15: [ncov.json](https://nextstrain.org/fetch/nextstrain-data.s3.amazonaws.com/ncov.json%3FversionId=WiHRklbcFMB.WpgFMh2PG7g69PK3_Xcl), [ncov_global.json](https://nextstrain.org/fetch/nextstrain-data.s3.amazonaws.com/ncov_global.json%3FversionId=ANBYqAHGJWpFuzusK2gD6e5X_VdTZF6B)

Looking at this data it's clear that we should drop any `ncov.json` datasets after 2020-04-23, which ~I'll add to this PR now~ _update: no need to programmatically drop, see next message in this PR_

Closes #784

¹ <https://github.com/nextstrain/nextstrain.org/pull/783>
² <https://bedfordlab.slack.com/archives/CSKMU6YUC/p1706483980082939>