### PR TITLE
dev: Wait up to 60s for the Heroku build status to change to "succeeded"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,16 +115,27 @@ jobs:
       - name: Check Heroku build
         run: |
           id="$(jq -r .id build.json)"
+          SECONDS=0
+          maxwait=60
 
-          curl https://api.heroku.com/apps/"$HEROKU_APP"/builds/"$id" \
-            --fail --silent --show-error --location --netrc \
-            --header 'Accept: application/vnd.heroku+json; version=3' \
-              | tee build.json
+          while [[ $SECONDS -lt $maxwait ]]; do
+            curl https://api.heroku.com/apps/"$HEROKU_APP"/builds/"$id" \
+              --fail --silent --show-error --location --netrc \
+              --header 'Accept: application/vnd.heroku+json; version=3' \
+                | tee build.json
 
-          status="$(jq -r .status build.json)"
+            status="$(jq -r .status build.json)"
+
+            if [[ "$status" == succeeded ]]; then
+              break
+            else
+              echo "build status is $status (not succeeded); will check again" >&2
+              sleep 5
+            fi
+          done
 
           if [[ "$status" != succeeded ]]; then
-            echo "build status is $status (not succeeded)" >&2
+            echo "build status is $status (not succeeded) after waiting $SECONDS seconds" >&2
             exit 1
           fi
 


### PR DESCRIPTION
It used to be that once the Heroku build log stream response completed, their API would return a build status of "succeeded".  Recently however it seems like now there's a delay between the log stream response completing and their API returning the up-to-date build status.  Build in a 60s buffer wait time to account for that.

Resolves <https://github.com/nextstrain/nextstrain.org/issues/794>.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
