### PR TITLE
Changing the avian-flu default page from h5n1 to h5nx

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -110,7 +110,7 @@
                   "default": "ha"
                 }
               },
-              "default": "h5n1"
+              "default": "h5nx"
             }
           },
           "seasonal": {


### PR DESCRIPTION
This pull request changes the default display for the avian-flu builds to be H5Nx, instead of H5N1. Avian influenza H5 epidemiology has changed in the past few years due to the expansion of clade 2.3.4.4, which now represents the major group of viruses circulating in the world. These viruses reassort frequently, and the HA was associated with N8, N2, and N6s prior to global expansion. H5Nx captures this history, while H5N1 does not. 

## Description of proposed changes

This pull request changes a single line in `manifest_core.json`