### PR TITLE
CI: Use GitHub Actions token for higher rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.DEV_SERVER_AWS_SECRET_ACCESS_KEY }}
       - run: aws sts get-caller-identity
       - run: npm run test:ci
+        env:
+          # Tests make GitHub API requests which are rate limited.
+          # Use the GitHub Actions token for a limit of 1,000 requests per hour.
+          # <https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#primary-rate-limit-for-github_token-in-github-actions>
+          GITHUB_TOKEN: ${{ github.token }}
 
       - if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description of proposed changes

Previously, the unauthenticated requests were limited to [60 per hour per IP address](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#primary-rate-limit-for-unauthenticated-users) which are likely shared by other jobs using the same GitHub-hosted runners.

## Related issue(s)

Prompted by https://github.com/nextstrain/nextstrain.org/pull/810#discussion_r1556421873

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Updated repo's [Actions settings](https://github.com/nextstrain/nextstrain.org/settings/actions) to use read-only permissions on `GITHUB_TOKEN`
- [x] Checks pass
- [x] Not testing the new rate limit - will monitor CI on other builds.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
