### PR TITLE
index-resources.yml: Create separate indexes for Heroku apps

### DIFF
--- a/.github/workflows/index-resources.yml
+++ b/.github/workflows/index-resources.yml
@@ -19,8 +19,40 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      HEROKU_TOKEN: ${{ secrets.HEROKU_TOKEN_READ_PROTECTED }}
+      HEROKU_PIPELINE: 38f67fc7-d93c-40c6-a182-501da2f89d9d
+      APP_NAME: ${{ matrix.app_name }}
+    strategy:
+      matrix:
+        app_name: ["nextstrain-server", "nextstrain-canary"]
     steps:
+      - name: Get latest slug ID for ${{ env.APP_NAME }}
+        run: |
+          slug_id=$(
+            curl -n https://api.heroku.com/pipelines/"$HEROKU_PIPELINE"/latest-releases \
+              --fail --silent --show-error \
+              -H "Accept: application/vnd.heroku+json; version=3" \
+              -H "Authorization: Bearer $HEROKU_TOKEN" \
+              | jq -r '.[] | select(.app | .name == env.APP_NAME) | .slug.id')
+
+          echo "SLUG_ID=$slug_id" | tee -a "$GITHUB_ENV"
+
+      - name: Get latest commit hash for ${{ env.app_name }}
+        run: |
+          commit_hash=$(
+            curl -n https://api.heroku.com/apps/"$APP_NAME"/slugs/"$SLUG_ID" \
+              --fail --silent --show-error \
+              -H "Accept: application/vnd.heroku+json; version=3" \
+              -H "Authorization: Bearer $HEROKU_TOKEN" \
+              | jq -r '.commit')
+
+          echo "COMMIT_HASH=$commit_hash" | tee -a "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT_HASH }}
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
@@ -36,4 +68,4 @@ jobs:
             --resourceTypes dataset --collections core staging
       - name: Upload the new index, overwriting the existing index
         run: |
-          aws s3 cp resources.json.gz s3://nextstrain-inventories/resources.json.gz
+          aws s3 cp resources.json.gz s3://nextstrain-inventories/"$APP_NAME"/resources.json.gz

--- a/aws/iam/policy/NextstrainDotOrgServerInstance-testing.tftpl.json
+++ b/aws/iam/policy/NextstrainDotOrgServerInstance-testing.tftpl.json
@@ -63,7 +63,9 @@
         "s3:GetObject"
       ],
       "Resource": [
-        "arn:aws:s3:::nextstrain-inventories/resources.json.gz"
+        "arn:aws:s3:::nextstrain-inventories/resources.json.gz",
+        "arn:aws:s3:::nextstrain-inventories/nextstrain-server/resources.json.gz",
+        "arn:aws:s3:::nextstrain-inventories/nextstrain-canary/resources.json.gz"
       ]
     }
   ]

--- a/aws/iam/policy/NextstrainDotOrgServerInstance.tftpl.json
+++ b/aws/iam/policy/NextstrainDotOrgServerInstance.tftpl.json
@@ -52,7 +52,9 @@
         "s3:GetObject"
       ],
       "Resource": [
-        "arn:aws:s3:::nextstrain-inventories/resources.json.gz"
+        "arn:aws:s3:::nextstrain-inventories/resources.json.gz",
+        "arn:aws:s3:::nextstrain-inventories/nextstrain-server/resources.json.gz",
+        "arn:aws:s3:::nextstrain-inventories/nextstrain-canary/resources.json.gz"
       ]
     }
   ]

--- a/env/production/.terraform.lock.hcl
+++ b/env/production/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.32.0"
   constraints = "~> 4.32"
   hashes = [
+    "h1:7vBuXLVLAnkcLDxIb8QN6O5pD13KtFDTqcnF0hFnraM=",
     "h1:8AKJChT1Sgqjfdn16BayH5DonF3B9g7qQ6N+IKPulP4=",
     "zh:062c30cd8bcf29f8ee34c2b2509e4e8695c2bcac8b7a8145e1c72e83d4e68b13",
     "zh:1503fabaace96a7eea4d73ced36a02a75ec587760850e58162e7eff419dcbb31",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.5.1"
   hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",

--- a/env/testing/.terraform.lock.hcl
+++ b/env/testing/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.32.0"
   constraints = "~> 4.32"
   hashes = [
+    "h1:7vBuXLVLAnkcLDxIb8QN6O5pD13KtFDTqcnF0hFnraM=",
     "h1:8AKJChT1Sgqjfdn16BayH5DonF3B9g7qQ6N+IKPulP4=",
     "zh:062c30cd8bcf29f8ee34c2b2509e4e8695c2bcac8b7a8145e1c72e83d4e68b13",
     "zh:1503fabaace96a7eea4d73ced36a02a75ec587760850e58162e7eff419dcbb31",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.5.1"
   hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",


### PR DESCRIPTION
## Description of proposed changes

We are running into out-of-sync issues between the resources index and the production site when canary is not immediately promoted.

This change creates separate indexes for the nextstrain-server and nextstrain-canary Heroku apps by checking out the commit of their latest released slug.

The separate resources JSONs are uploaded to separate paths prefixed by the app name, which required updating the permissions for `GitHubActionsRoleResourceIndexer` outside of this commit.


## Related issue(s)

Resolves #829 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Test run of indexer ](https://github.com/nextstrain/nextstrain.org/actions/runs/8696800252)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
