### PR TITLE
Update tests now that zika root sequence is inline

### DIFF
--- a/test/requests.test.js
+++ b/test/requests.test.js
@@ -35,7 +35,7 @@ describe("datasets", () => {
     testPaths([
       { case: "nested",        path: "/flu/seasonal/h3n2/ha/2y" },
       { case: "canonicalized", path: "/flu/seasonal" },
-      { case: "top-level",     path: "/zika", tipFrequencies: false, missingResourcePageExists: false },
+      { case: "top-level",     path: "/zika", rootSequence: false, tipFrequencies: false, missingResourcePageExists: false },
     ]);
     describe("bogus", () => {
       testBadRequest("/flu/seasonal/h3n2_ha_2y");


### PR DESCRIPTION
https://github.com/nextstrain/zika/pull/57 removed the zika root sequence sidecar (as it's inlined in the main JSON). Note that the staging/zika dataset still has the root sequence sidecar and we assert its existence in tests here!

