### PR TITLE
dev: Unbundle `next build static-site` from `npm run test:ci` and `… dev:ssg`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "start": "npm run server",
     "//test": "echo 'NODE_OPTIONS is required until this issue is resolved: https://github.com/facebook/jest/issues/9430 '",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest --roots ./test/",
-    "test:ci": "next build static-site && start-server-and-test 'USE_PREBUILT_STATIC_SITE=1 RESOURCE_INDEX=test/date_descriptor_index.json node server.js --verbose >./test/server.log 2>&1' http://localhost:5000 test",
+    "test:ci": "start-server-and-test 'USE_PREBUILT_STATIC_SITE=1 RESOURCE_INDEX=test/date_descriptor_index.json node server.js --verbose >./test/server.log 2>&1' http://localhost:5000 test",
     "dev": "NODE_ENV=development nodemon --verbose -- server.js --verbose \"$@\"",
-    "dev:ssg": "next build static-site && NODE_ENV=development USE_PREBUILT_STATIC_SITE=1 nodemon --verbose -- server.js --verbose \"$@\""
+    "dev:ssg": "NODE_ENV=development USE_PREBUILT_STATIC_SITE=1 nodemon --verbose -- server.js --verbose \"$@\""
   },
   "dependencies": {
     "@aws-crypto/client-node": "^3.1.1",


### PR DESCRIPTION
As someone who wants to routinely use the actual built static-site¹, it makes no sense to pay the time cost of `next build` every run of the test suite or restart of the dev server.  We already check that the built assets are available at server start, so if you forget you do get a reminder (in the form of an error).

¹ The hot-reloading static-site is great for working on the static-site
  itself, but when working on the server-side routes, I'd rather have
  higher fidelity with production.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
