### PR TITLE
upstream: Forward Content-Type from upstream if we don't already have one

### DIFF
--- a/src/upstream.js
+++ b/src/upstream.js
@@ -234,6 +234,11 @@ async function proxyResponseBodyFromUpstream(req, res, upstreamReq) {
      * client can decode the body itself.
      */
     ...(!upstreamReq.compress ? ["Content-Encoding"] : []),
+
+    /* Forward Content-Type if our response doesn't already have a preferred
+     * type set (e.g. from prior content negotiation).
+     */
+    ...(!res.get("Content-Type") ? ["Content-Type"] : []),
   ];
 
   res.set(copyHeaders(upstreamRes.headers, forwardedUpstreamResHeaders));


### PR DESCRIPTION
For example, our RESTful endpoints perform content negotiation and use the result to determine Content-Type (and also what to Accept in the request to upstream), but our Charon endpoints do not set Content-Type at all.  Set it based on the upstream response in that situation.

I noticed this bug (while investigating another issue¹) because the automatic compression middleware wasn't applying to the /charon/getDataset endpoint due to the lack of Content-Type.

¹ <https://github.com/nextstrain/nextstrain.org/issues/832>



## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
