### PR TITLE
adding in time resolution for avian influenza builds to allow 2y and …

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -231,7 +231,7 @@
               "default": "ha"
             }
           },
-          "default": "h5nx"
+          "default": "h5n1"
         }
       },
       "dengue": {

--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -5,55 +5,231 @@
         "subtype": {
           "h5n1": {
             "segment": {
-              "ha": "",
-              "mp": "",
-              "na": "",
-              "ns": "",
-              "np": "",
-              "pa": "",
-              "pb1": "",
-              "pb2": "",
+              "ha": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "mp": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "na": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "ns": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "np": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "pa": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "pb1": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "pb2": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
               "default": "ha"
             }
           },
           "h5nx": {
             "segment": {
-              "ha": "",
-              "mp": "",
-              "na": "",
-              "ns": "",
-              "np": "",
-              "pa": "",
-              "pb1": "",
-              "pb2": "",
+              "ha": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "mp": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "na": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "ns": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "np": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "pa": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "pb1": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
+              "pb2": {
+                "resolution": {
+                  "all-time": "",
+                  "2y": "",
+                  "default": "2y"
+                }
+              },
               "default": "ha"
             }
           },
           "h7n9": {
             "segment": {
-              "ha": "",
-              "mp": "",
-              "na": "",
-              "ns": "",
-              "np": "",
-              "pa": "",
-              "pb1": "",
-              "pb2": "",
+              "ha": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "mp": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "na": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "ns": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "np": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "pa": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "pb1": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "pb2": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
               "default": "ha"
             }
           },
           "h9n2": {
             "segment": {
-              "ha": "",
-              "mp": "",
-              "na": "",
-              "ns": "",
-              "np": "",
-              "pa": "",
-              "pb1": "",
-              "pb2": "",
+              "ha": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "mp": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "na": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "ns": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "np": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "pa": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "pb1": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "pb2": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
               "default": "ha"
-              }
+            }
           },
           "default": "h5nx"
         }


### PR DESCRIPTION
…all-time builds for h5nx and h5n1, and all-time builds only for h9n2 and h7n9

## Description of proposed changes

We recently made a series of updates to the avian-flu builds to provide a more in-depth view of the ongoing H5Nx outbreak of 2.3.4.4b viruses. We now have 2 different time resolutions for H5Nx and H5N1: 2y and all-time. This pull request updates `manifest_core.json` to reflect these changes. 
