### PR TITLE
Fix /whoami

### DIFF
--- a/src/endpoints/users.js
+++ b/src/endpoints/users.js
@@ -23,8 +23,7 @@ const visibleGroups = (user) => ALL_GROUPS
 
 
 /**
- * Returns an array of Nextstrain groups that a given *user* is a member of. The
- * order of groups returned matches the order in the `groups.json` data file.
+ * Returns an array of Nextstrain groups that a given *user* is a member of.
  *
  * @param {Object | undefined} user. `undefined` represents a non-logged-in user
  * @returns {Array} Each element represents a group with a a subset of properties from

--- a/src/endpoints/users.js
+++ b/src/endpoints/users.js
@@ -30,7 +30,14 @@ const visibleGroups = (user) => ALL_GROUPS
  *                  the Group class.
  */
 const groupMemberships = (user) => user?.groups
-  ?.map(name => new Group(name))
+  ?.map(name => {
+      try {
+        return new Group(name);
+      } catch (error) {
+        // Nextstrain Group does not exist for the Cognito group prefix
+        return null;
+      }})
+   .filter(group => group !== null)
    .map(group => ({
      name: group.name,
      isPublic: group.isPublic,

--- a/src/endpoints/users.js
+++ b/src/endpoints/users.js
@@ -1,5 +1,5 @@
 import * as authz from '../authz/index.js';
-import { ALL_GROUPS, Group } from '../groups.js';
+import { ALL_GROUPS } from '../groups.js';
 import { contentTypesProvided } from '../negotiate.js';
 import * as nextJsApp from './nextjs.js';
 
@@ -30,15 +30,7 @@ const visibleGroups = (user) => ALL_GROUPS
  *                  the Group class.
  */
 const groupMemberships = (user) => user?.groups
-  ?.map(name => {
-      try {
-        return new Group(name);
-      } catch (error) {
-        // Nextstrain Group does not exist for the Cognito group prefix
-        return null;
-      }})
-   .filter(group => group !== null)
-   .map(group => ({
+  ?.map(group => ({
      name: group.name,
      isPublic: group.isPublic,
   }))


### PR DESCRIPTION
## Description of proposed changes

#780 broke /whoami for users that are members of old test Cognito groups. This is due to unhandled errors in the case that a Cognito group does not map to a valid group in groups.json. This PR addresses the issue.

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- prompted by https://github.com/nextstrain/nextstrain.org/pull/780#discussion_r1578485451

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Tested locally. Provisioned a `fake-group` in test Cognito user pool and added my user to it. Logging in reproduced the error and these changes fix the issue.
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
