### PR TITLE
Separate indexer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,16 +95,28 @@ jobs:
           name: test-logs
           path: test/server.log
 
+  index-resources:
+    if: |2
+         github.repository == 'nextstrain/nextstrain.org'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/master'
+    needs: test
+    permissions:
+      id-token: write # needed to interact with GitHub's OIDC Token endpoint
+      contents: read
+    uses: ./.github/workflows/index-resources.yml
+
   deploy:
     if: |2
          github.repository == 'nextstrain/nextstrain.org'
       && (   (github.event_name == 'push' && github.ref == 'refs/heads/master')
           || (github.event_name == 'workflow_dispatch' && inputs.heroku-app) )
 
-    # Wait for "build" and "test" jobs above to pass.
+    # Wait for "build", "test", and "index-resources" jobs above to pass.
     needs:
       - build
       - test
+      - index-resources
 
     # Only one "deploy" job per Heroku app at a time.
     concurrency: deploy:${{ inputs.heroku-app || 'nextstrain-canary' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,11 @@ jobs:
 
   deploy:
     if: |2
-         github.repository == 'nextstrain/nextstrain.org'
+         !cancelled()
+      && needs.build.result == 'success'
+      && needs.test.result == 'success'
+      && contains(fromJSON('["success", "skipped"]'), needs.index-resources.result)
+      && github.repository == 'nextstrain/nextstrain.org'
       && (   (github.event_name == 'push' && github.ref == 'refs/heads/master')
           || (github.event_name == 'workflow_dispatch' && inputs.heroku-app) )
 

--- a/.github/workflows/index-resources.yml
+++ b/.github/workflows/index-resources.yml
@@ -34,6 +34,21 @@ jobs:
           node resourceIndexer/main.js \
             --gzip --output resources.json.gz \
             --resourceTypes dataset --collections core staging
-      - name: Upload the new index, overwriting the existing index
+      - name: Extract RESOURCE_CONFIG from config module
         run: |
-          aws s3 cp resources.json.gz s3://nextstrain-inventories/resources.json.gz
+          # This conditional is to continue to support servers that are still
+          # using versions of this code that do not include the get-resource-index
+          # script. We can remove it once all the servers have been updated.
+          #   -Jover, 01 May 2024
+          if [[ -f ".scripts/get-resource-index.js" ]]; then
+            resource_index=$(node scripts/get-resource-index.js)
+          else
+            resource_index=$(jq -r '.RESOURCE_INDEX' ./env/production/config.json)
+          fi
+
+          echo "RESOURCE_INDEX=$resource_index" | tee -a "$GITHUB_ENV"
+
+      - name: Upload the new index, overwriting the existing index
+        if: ${{ startsWith(env.RESOURCE_INDEX, 's3://') }}
+        run: |
+          aws s3 cp resources.json.gz "$RESOURCE_INDEX"

--- a/.github/workflows/index-resources.yml
+++ b/.github/workflows/index-resources.yml
@@ -12,9 +12,6 @@ on:
 
   workflow_call:
 
-# Only allow one run of the workflow per branch that triggers the workflow
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
 
 defaults:
   run:
@@ -46,7 +43,12 @@ jobs:
     needs: [build-ref-matrix]
     strategy:
       matrix:
-        ref: ${{ fromJson(needs.build-ref-matrix.outputs.ref-matrix) }}
+        include: ${{ fromJson(needs.build-ref-matrix.outputs.ref-matrix) }}
+    # Only allow one run of the job per resource index
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.resource_index }}
+    env:
+        RESOURCE_INDEX: ${{ matrix.resource_index }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint
@@ -71,20 +73,6 @@ jobs:
           node resourceIndexer/main.js \
             --gzip --output resources.json.gz \
             --resourceTypes dataset --collections core staging
-      - name: Extract RESOURCE_CONFIG from config module
-        run: |
-          # This conditional is to continue to support servers that are still
-          # using versions of this code that do not include the get-resource-index
-          # script. We can remove it once all the servers have been updated.
-          #   -Jover, 01 May 2024
-          if [[ -f ".scripts/get-resource-index.js" ]]; then
-            resource_index=$(node scripts/get-resource-index.js)
-          else
-            resource_index=$(jq -r '.RESOURCE_INDEX' ./env/production/config.json)
-          fi
-
-          echo "RESOURCE_INDEX=$resource_index" | tee -a "$GITHUB_ENV"
-
       - name: Upload the new index, overwriting the existing index
         if: ${{ startsWith(env.RESOURCE_INDEX, 's3://') }}
         run: |

--- a/.github/workflows/index-resources.yml
+++ b/.github/workflows/index-resources.yml
@@ -12,6 +12,10 @@ on:
 
   workflow_call:
 
+# Only allow one run of the workflow per branch that triggers the workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+
 defaults:
   run:
     # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:

--- a/.github/workflows/index-resources.yml
+++ b/.github/workflows/index-resources.yml
@@ -12,8 +12,47 @@ on:
 
   workflow_call:
 
+defaults:
+  run:
+    # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    #
+    # Completely spelling it out here so that GitHub can't change it out from under us
+    # and we don't have to refer to the docs to know the expected behavior.
+    shell: bash --noprofile --norc -eo pipefail {0}
+
 jobs:
+  build-ref-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      ref-matrix: ${{ steps.ref-matrix.outputs.ref-matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+      - id: ref-matrix
+        name: Create ref matrix
+        env:
+          HEROKU_TOKEN: ${{ secrets.HEROKU_TOKEN_READ_PROTECTED }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == 'workflow_call' || \
+               ("$GITHUB_EVENT_NAME" == 'workflow_dispatch' && "$GITHUB_REF" != 'refs/heads/master') ]]; then
+            # This the commit SHA that triggered the workflow.
+            # For the workflow_call, this is in the context of the calling workflow.
+            # <https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows>
+            ref_matrix=$(jq -c --null-input '[ env.GITHUB_SHA ]')
+          else
+            ref_matrix=$(./scripts/get-resource-index-ref-matrix)
+          fi
+
+          echo "ref-matrix=$ref_matrix" | tee -a "$GITHUB_OUTPUT"
+
   rebuild-index:
+    needs: [build-ref-matrix]
+    strategy:
+      matrix:
+        ref: ${{ fromJson(needs.build-ref-matrix.outputs.ref-matrix) }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint
@@ -24,10 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # This the commit SHA that triggered the workflow.
-          # For the workflow_call, this is in the context of the calling workflow.
-          # <https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows>
-          ref: ${{ github.sha }}
+          ref: ${{ matrix.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'

--- a/.github/workflows/index-resources.yml
+++ b/.github/workflows/index-resources.yml
@@ -10,6 +10,8 @@ on:
   # Manually triggered using GitHub's UI
   workflow_dispatch:
 
+  workflow_call:
+
 jobs:
   rebuild-index:
     runs-on: ubuntu-latest
@@ -21,6 +23,11 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
+        with:
+          # This the commit SHA that triggered the workflow.
+          # For the workflow_call, this is in the context of the calling workflow.
+          # <https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows>
+          ref: ${{ github.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'

--- a/.github/workflows/index-resources.yml
+++ b/.github/workflows/index-resources.yml
@@ -40,17 +40,7 @@ jobs:
         env:
           HEROKU_TOKEN: ${{ secrets.HEROKU_TOKEN_READ_PROTECTED }}
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == 'workflow_call' || \
-               ("$GITHUB_EVENT_NAME" == 'workflow_dispatch' && "$GITHUB_REF" != 'refs/heads/master') ]]; then
-            # This the commit SHA that triggered the workflow.
-            # For the workflow_call, this is in the context of the calling workflow.
-            # <https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows>
-            ref_matrix=$(jq -c --null-input '[ env.GITHUB_SHA ]')
-          else
-            ref_matrix=$(./scripts/get-resource-index-ref-matrix)
-          fi
-
-          echo "ref-matrix=$ref_matrix" | tee -a "$GITHUB_OUTPUT"
+          echo "ref-matrix=$(./scripts/get-resource-index-ref-matrix)" | tee -a "$GITHUB_OUTPUT"
 
   rebuild-index:
     needs: [build-ref-matrix]

--- a/aws/iam/policy/NextstrainDotOrgServerInstance-testing.tftpl.json
+++ b/aws/iam/policy/NextstrainDotOrgServerInstance-testing.tftpl.json
@@ -63,7 +63,8 @@
         "s3:GetObject"
       ],
       "Resource": [
-        "arn:aws:s3:::nextstrain-inventories/resources.json.gz"
+        "arn:aws:s3:::nextstrain-inventories/resources.json.gz",
+        "arn:aws:s3:::nextstrain-inventories/resources/*.json.gz"
       ]
     }
   ]

--- a/aws/iam/policy/NextstrainDotOrgServerInstance.tftpl.json
+++ b/aws/iam/policy/NextstrainDotOrgServerInstance.tftpl.json
@@ -52,7 +52,8 @@
         "s3:GetObject"
       ],
       "Resource": [
-        "arn:aws:s3:::nextstrain-inventories/resources.json.gz"
+        "arn:aws:s3:::nextstrain-inventories/resources.json.gz",
+        "arn:aws:s3:::nextstrain-inventories/resources/*.json.gz"
       ]
     }
   ]

--- a/env/production/.terraform.lock.hcl
+++ b/env/production/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.32.0"
   constraints = "~> 4.32"
   hashes = [
+    "h1:7vBuXLVLAnkcLDxIb8QN6O5pD13KtFDTqcnF0hFnraM=",
     "h1:8AKJChT1Sgqjfdn16BayH5DonF3B9g7qQ6N+IKPulP4=",
     "zh:062c30cd8bcf29f8ee34c2b2509e4e8695c2bcac8b7a8145e1c72e83d4e68b13",
     "zh:1503fabaace96a7eea4d73ced36a02a75ec587760850e58162e7eff419dcbb31",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.5.1"
   hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",

--- a/env/production/config.json
+++ b/env/production/config.json
@@ -110,5 +110,5 @@
   "OIDC_GROUPS_CLAIM": "cognito:groups",
   "SESSION_COOKIE_DOMAIN": "nextstrain.org",
   "GROUPS_DATA_FILE": "groups.json",
-  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources.json.gz"
+  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v1.json.gz"
 }

--- a/env/testing/.terraform.lock.hcl
+++ b/env/testing/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.32.0"
   constraints = "~> 4.32"
   hashes = [
+    "h1:7vBuXLVLAnkcLDxIb8QN6O5pD13KtFDTqcnF0hFnraM=",
     "h1:8AKJChT1Sgqjfdn16BayH5DonF3B9g7qQ6N+IKPulP4=",
     "zh:062c30cd8bcf29f8ee34c2b2509e4e8695c2bcac8b7a8145e1c72e83d4e68b13",
     "zh:1503fabaace96a7eea4d73ced36a02a75ec587760850e58162e7eff419dcbb31",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.5.1"
   hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",

--- a/env/testing/config.json
+++ b/env/testing/config.json
@@ -108,5 +108,5 @@
   "OIDC_USERNAME_CLAIM": "cognito:username",
   "OIDC_GROUPS_CLAIM": "cognito:groups",
   "GROUPS_DATA_FILE": "groups.json",
-  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources.json.gz"
+  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v1.json.gz"
 }

--- a/scripts/get-resource-index-ref-matrix
+++ b/scripts/get-resource-index-ref-matrix
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Builds a ref matrix of commit hashes for the `index-resources.yml` GH Action workflow
+# Builds a ref matrix of commit hashes and resource index URLs for the
+# `index-resources.yml` GH Action workflow
 #
 # Uses the GITHUB_SHA if the workflow was called as a reusable workflow or
 # if the workflow was manually run on a branch that is not the default branch.
@@ -22,7 +23,10 @@ main () {
         # This the commit SHA that triggered the workflow.
         # For the workflow_call, this is in the context of the calling workflow.
         # <https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows>
-        ref_matrix=$(jq -c --null-input '[ env.GITHUB_SHA ]')
+        resource_index=$(get_resource_index_at_commit "$GITHUB_SHA")
+        ref_matrix=$(jq -c --null-input \
+                        --arg RESOURCE_INDEX $(get_resource_index_at_commit "$GITHUB_SHA") \
+                        '[ {"ref": env.GITHUB_SHA, "resource_index": $RESOURCE_INDEX} ]')
     else
         ref_matrix=$(build_prod_and_canary_ref_matrix)
     fi
@@ -42,14 +46,19 @@ build_prod_and_canary_ref_matrix() {
     canary_resource_index=$(get_resource_index_at_commit "$canary_commit")
 
     if [[ "$prod_resource_index" == "$canary_resource_index" ]]; then
-        jq_array='[ $PROD_COMMIT ]'
+        jq_array='[ {"ref": $PROD_COMMIT, "resource_index": $PROD_RESOURCE_INDEX} ]'
     else
-        jq_array='[ $PROD_COMMIT, $CANARY_COMMIT ]'
+        jq_array='[
+            {"ref": $PROD_COMMIT, "resource_index": $PROD_RESOURCE_INDEX},
+            {"ref": $CANARY_COMMIT, "resource_index": $CANARY_RESOURCE_INDEX}
+        ]'
     fi
 
     ref_matrix=$(jq -c --null-input \
                     --arg PROD_COMMIT "$prod_commit" \
+                    --arg PROD_RESOURCE_INDEX "$prod_resource_index" \
                     --arg CANARY_COMMIT "$canary_commit" \
+                    --arg CANARY_RESOURCE_INDEX "$canary_resource_index" \
                     "$jq_array")
 
     echo "$ref_matrix"

--- a/scripts/get-resource-index-ref-matrix
+++ b/scripts/get-resource-index-ref-matrix
@@ -23,7 +23,6 @@ main () {
         # This the commit SHA that triggered the workflow.
         # For the workflow_call, this is in the context of the calling workflow.
         # <https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows>
-        resource_index=$(get_resource_index_at_commit "$GITHUB_SHA")
         ref_matrix=$(jq -c --null-input \
                         --arg RESOURCE_INDEX $(get_resource_index_at_commit "$GITHUB_SHA") \
                         '[ {"ref": env.GITHUB_SHA, "resource_index": $RESOURCE_INDEX} ]')

--- a/scripts/get-resource-index-ref-matrix
+++ b/scripts/get-resource-index-ref-matrix
@@ -44,23 +44,16 @@ build_prod_and_canary_ref_matrix() {
     canary_commit=$(get_heroku_slug_commit "$CANARY_APP_NAME")
     canary_resource_index=$(get_resource_index_at_commit "$canary_commit")
 
-    if [[ "$prod_resource_index" == "$canary_resource_index" ]]; then
-        jq_array='[ {"ref": $PROD_COMMIT, "resource_index": $PROD_RESOURCE_INDEX} ]'
-    else
-        jq_array='[
+    jq -c --null-input \
+        --arg PROD_COMMIT "$prod_commit" \
+        --arg PROD_RESOURCE_INDEX "$prod_resource_index" \
+        --arg CANARY_COMMIT "$canary_commit" \
+        --arg CANARY_RESOURCE_INDEX "$canary_resource_index" \
+        '[
             {"ref": $PROD_COMMIT, "resource_index": $PROD_RESOURCE_INDEX},
             {"ref": $CANARY_COMMIT, "resource_index": $CANARY_RESOURCE_INDEX}
-        ]'
-    fi
-
-    ref_matrix=$(jq -c --null-input \
-                    --arg PROD_COMMIT "$prod_commit" \
-                    --arg PROD_RESOURCE_INDEX "$prod_resource_index" \
-                    --arg CANARY_COMMIT "$canary_commit" \
-                    --arg CANARY_RESOURCE_INDEX "$canary_resource_index" \
-                    "$jq_array")
-
-    echo "$ref_matrix"
+         ]
+        | unique_by(.resource_index)'
 }
 
 get_heroku_slug_commit() {

--- a/scripts/get-resource-index-ref-matrix
+++ b/scripts/get-resource-index-ref-matrix
@@ -1,17 +1,36 @@
 #!/bin/bash
-# Checks the Nextstrain production and canary Heroku apps to determine
+# Builds a ref matrix of commit hashes for the `index-resources.yml` GH Action workflow
+#
+# Uses the GITHUB_SHA if the workflow was called as a reusable workflow or
+# if the workflow was manually run on a branch that is not the default branch.
+# Otherwise, checks the Nextstrain production and canary Heroku apps to determine
 # if they are using the same `config.RESOURCE_INDEX` and returns a JSON array
 # of the the commit hashes for the different RESOURCE_INDEX.
-#
-# Intended to be used within the `index-resources.yml` GH Action workflow.
 set -euo pipefail
 
 : "${HEROKU_TOKEN:?The HEROKU_TOKEN environment variable is required.}"
+: "${GITHUB_EVENT_NAME:?The GITHUB_EVENT_NAME environment variable is required.}"
+: "${GITHUB_REF:?The GITHUB_REF environment variable is required.}"
+: "${GITHUB_SHA:?The GITHUB_SHA environment variable is required.}"
 
 : "${PROD_APP_NAME:=nextstrain-server}"
 : "${CANARY_APP_NAME:=nextstrain-canary}"
 
 main () {
+    if [[ "$GITHUB_EVENT_NAME" == 'workflow_call' || \
+          ("$GITHUB_EVENT_NAME" == 'workflow_dispatch' && "$GITHUB_REF" != 'refs/heads/master') ]]; then
+        # This the commit SHA that triggered the workflow.
+        # For the workflow_call, this is in the context of the calling workflow.
+        # <https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows>
+        ref_matrix=$(jq -c --null-input '[ env.GITHUB_SHA ]')
+    else
+        ref_matrix=$(build_prod_and_canary_ref_matrix)
+    fi
+
+    echo "$ref_matrix"
+}
+
+build_prod_and_canary_ref_matrix() {
     local prod_commit prod_resource_index
     local canary_commit canary_resource_index
     local jq_array

--- a/scripts/get-resource-index-ref-matrix
+++ b/scripts/get-resource-index-ref-matrix
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Checks the Nextstrain production and canary Heroku apps to determine
+# if they are using the same `config.RESOURCE_INDEX` and returns a JSON array
+# of the the commit hashes for the different RESOURCE_INDEX.
+#
+# Intended to be used within the `index-resources.yml` GH Action workflow.
+set -euo pipefail
+
+: "${HEROKU_TOKEN:?The HEROKU_TOKEN environment variable is required.}"
+: "${HEROKU_PIPELINE:=38f67fc7-d93c-40c6-a182-501da2f89d9d}"
+
+: "${PROD_APP_NAME:=nextstrain-server}"
+: "${CANARY_APP_NAME:=nextstrain-canary}"
+
+main () {
+    local prod_commit prod_resource_index
+    local canary_commit canary_resource_index
+    local jq_array
+
+    prod_commit=$(get_heroku_slug_commit "$PROD_APP_NAME")
+    prod_resource_index=$(get_resource_index_at_commit "$prod_commit")
+
+    canary_commit=$(get_heroku_slug_commit "$CANARY_APP_NAME")
+    canary_resource_index=$(get_resource_index_at_commit "$canary_commit")
+
+    if [[ "$prod_resource_index" == "$canary_resource_index" ]]; then
+        jq_array='[ $PROD_COMMIT ]'
+    else
+        jq_array='[ $PROD_COMMIT, $CANARY_COMMIT ]'
+    fi
+
+    ref_matrix=$(jq -c --null-input \
+                    --arg PROD_COMMIT "$prod_commit" \
+                    --arg CANARY_COMMIT "$canary_commit" \
+                    "$jq_array")
+
+    echo "$ref_matrix"
+}
+
+get_heroku_slug_commit() {
+    local app_name="$1"
+    local slug_id commit_hash
+    slug_id=$(curl https://api.heroku.com/pipelines/"$HEROKU_PIPELINE"/latest-releases \
+                --fail --silent --show-error \
+                -H "Accept: application/vnd.heroku+json; version=3" \
+                -H "Authorization: Bearer $HEROKU_TOKEN" \
+                | jq -r --arg APP_NAME "$app_name" '.[] | select(.app | .name == $APP_NAME) | .slug.id')
+
+    commit_hash=$(curl https://api.heroku.com/apps/"$app_name"/slugs/"$slug_id" \
+                    --fail --silent --show-error \
+                    -H "Accept: application/vnd.heroku+json; version=3" \
+                    -H "Authorization: Bearer $HEROKU_TOKEN" \
+                    | jq -r '.commit')
+
+    echo "$commit_hash"
+}
+
+
+get_resource_index_at_commit() {
+    local commit_hash="$1"
+    local repo repo_archive resource_index
+    repo="$(mktemp -dt nextstrain-dot-org-repo-$commit_hash-XXXXXX)"
+    repo_archive="$repo/nextstrain.org.tar.gz"
+
+    trap "rm -rf '$repo'" EXIT
+
+    curl -fsSL \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        https://api.github.com/repos/nextstrain/nextstrain.org/tarball/"$commit_hash" \
+        > "$repo_archive"
+
+    tar xz --file="$repo_archive" \
+        --strip-components=1 \
+        -C "$repo"
+
+    # This conditional is to continue to support servers that are still
+    # using versions of this code that do not include the get-resource-index
+    # script. We can remove it once all the servers have been updated.
+    #   -Jover, 01 May 2024
+    if [[ -f "$repo/scripts/get-resource-index.js" ]]; then
+        npm ci --silent --prefix "$repo"
+        resource_index=$(node "$repo"/scripts/get-resource-index.js)
+    else
+        resource_index=$(jq -r '.RESOURCE_INDEX' "$repo"/env/production/config.json)
+    fi
+
+    echo "$resource_index"
+}
+
+
+main "$@"

--- a/scripts/get-resource-index-ref-matrix
+++ b/scripts/get-resource-index-ref-matrix
@@ -7,7 +7,6 @@
 set -euo pipefail
 
 : "${HEROKU_TOKEN:?The HEROKU_TOKEN environment variable is required.}"
-: "${HEROKU_PIPELINE:=38f67fc7-d93c-40c6-a182-501da2f89d9d}"
 
 : "${PROD_APP_NAME:=nextstrain-server}"
 : "${CANARY_APP_NAME:=nextstrain-canary}"
@@ -40,11 +39,12 @@ main () {
 get_heroku_slug_commit() {
     local app_name="$1"
     local slug_id commit_hash
-    slug_id=$(curl https://api.heroku.com/pipelines/"$HEROKU_PIPELINE"/latest-releases \
+    slug_id=$(curl https://api.heroku.com/apps/"$app_name"/releases \
                 --fail --silent --show-error \
                 -H "Accept: application/vnd.heroku+json; version=3" \
                 -H "Authorization: Bearer $HEROKU_TOKEN" \
-                | jq -r --arg APP_NAME "$app_name" '.[] | select(.app | .name == $APP_NAME) | .slug.id')
+                -H "Range: version ..; order=desc,max=1" \
+                | jq -r '.[0].slug.id')
 
     commit_hash=$(curl https://api.heroku.com/apps/"$app_name"/slugs/"$slug_id" \
                     --fail --silent --show-error \

--- a/scripts/get-resource-index.js
+++ b/scripts/get-resource-index.js
@@ -1,0 +1,20 @@
+/**
+ * Bare bones script to get the `RESOURCE_INDEX` from the config module
+ *
+ * This does not address the edge case of the config.RESOURCE_INDEX in the live
+ * server being different than the config.RESOURCE_INDEX in GitHub Actions, which can
+ * happen if we set the `RESOURCE_INDEX` envvar on in Heroku.
+ *
+ * We can improve on this in the future by surfacing the deployment metadata
+ * from our servers via our own API endpoint as suggested by @tsibley in
+ * <https://github.com/nextstrain/nextstrain.org/pull/841#discussion_r1588227761>
+ */
+
+import { RESOURCE_INDEX } from '../src/config.js';
+
+
+function main() {
+  console.log(RESOURCE_INDEX)
+}
+
+main();


### PR DESCRIPTION
## Description of proposed changes

This PR starts the use of versioned resource index JSONs so that we no longer run into out-of-sync issues between the canary and production servers. 

Major changes:
- the scheduled index resources workflow updates both canary and production resource index JSONs if they are different versions
- the CI workflow rebuilds the resource index before deployment of canary
- the CI workflow builds a `/tmp/<branch>` prefixed resource index for review apps

## Related issue(s)

Related to https://github.com/nextstrain/nextstrain.org/issues/829

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [index resources workflow for canary/production](https://github.com/nextstrain/nextstrain.org/actions/runs/8840814930)
- [x] [CI run builds/uploads `/tmp/<branch>` resource index](https://github.com/nextstrain/nextstrain.org/actions/runs/8914280686/job/24481649899#step:8:28)  
- [x] Deploy env/production Terraform changes
- ~[ ] Tick the wait for CI box in Heroku~
- [ ] post-merge: verify CI rebuilds index for deployment
- [ ] post-merge: [update S3 lifecycle](https://github.com/nextstrain/nextstrain.org/pull/841/commits/4c7a293231ecded2e7b72eaa9460d7eb7c2dd39c#r1587035296)
- [x] Write up changes that require bumping the resource index version

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
