### PR TITLE
dev: Swap out a few long options for equivalent but more available short options

### DIFF
--- a/scripts/heroku-build
+++ b/scripts/heroku-build
@@ -57,7 +57,7 @@ echo "---> Buildpack version is $(git -C build/pack describe --always --dirty)"
 echo
 echo "---> Running buildpack"
 docker run \
-  --rm --interactive $(tty --quiet && echo --tty) \
+  --rm --interactive $(tty -s && echo --tty) \
   --user $(id -u):$(id -g) \
   --volume "$(realpath build/app)":/build/app:rw \
   --volume "$(realpath build/pack)":/build/pack:ro \
@@ -104,7 +104,7 @@ echo
 echo "---> Packing build/app/ into build/slug.tar.gz"
 tar --create --gzip --file build/slug.tar.gz -C build/ ./app/
 sha256sum build/slug.tar.gz > build/slug.tar.gz.sha256sum
-du --human-readable --si --summarize build/app/ build/slug.tar.gz
+du -h --si -s build/app/ build/slug.tar.gz
 
 # <https://devcenter.heroku.com/articles/platform-api-reference#slug-create>
 echo


### PR DESCRIPTION
The long options are from GNU coreutils, but macOS ships a BSD tty and du.  Only one of the swapped options is POSIX.

Noted by @joverlee521 in post-merge review.¹

¹ <https://github.com/nextstrain/nextstrain.org/pull/857#pullrequestreview-2053748042>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
