### PR TITLE
CI: fix use of index-resources.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint
       contents: read
     uses: ./.github/workflows/index-resources.yml
+    secrets: inherit
 
   deploy:
     if: |2


### PR DESCRIPTION
Follow up to #841 

Inherit secrets so that the called index-resource.yml workflow has access to repo secrets.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
