### PR TITLE
index-resources.yml: Add `is-workflow-call` input

### DIFF
--- a/.github/workflows/index-resources.yml
+++ b/.github/workflows/index-resources.yml
@@ -11,7 +11,14 @@ on:
   workflow_dispatch:
 
   workflow_call:
-
+    inputs:
+      is-workflow-call:
+        description: |
+          To distinguish workflow_call from other events.
+          Unable to use `GITHUB_EVENT_NAME` because it points to the caller workflow's github context
+        type: boolean
+        default: true
+        required: false
 
 defaults:
   run:
@@ -36,6 +43,7 @@ jobs:
         name: Create ref matrix
         env:
           HEROKU_TOKEN: ${{ secrets.HEROKU_TOKEN_READ_PROTECTED }}
+          IS_WORKFLOW_CALL: ${{ inputs.is-workflow-call }}
         run: |
           echo "ref-matrix=$(./scripts/get-resource-index-ref-matrix)" | tee -a "$GITHUB_OUTPUT"
 

--- a/scripts/get-resource-index-ref-matrix
+++ b/scripts/get-resource-index-ref-matrix
@@ -13,12 +13,13 @@ set -euo pipefail
 : "${GITHUB_EVENT_NAME:?The GITHUB_EVENT_NAME environment variable is required.}"
 : "${GITHUB_REF:?The GITHUB_REF environment variable is required.}"
 : "${GITHUB_SHA:?The GITHUB_SHA environment variable is required.}"
+: "${IS_WORKFLOW_CALL:?The IS_WORKFLOW_CALL environment variable is required.}"
 
 : "${PROD_APP_NAME:=nextstrain-server}"
 : "${CANARY_APP_NAME:=nextstrain-canary}"
 
 main () {
-    if [[ "$GITHUB_EVENT_NAME" == 'workflow_call' || \
+    if [[ "$IS_WORKFLOW_CALL" == true || \
           ("$GITHUB_EVENT_NAME" == 'workflow_dispatch' && "$GITHUB_REF" != 'refs/heads/master') ]]; then
         # This the commit SHA that triggered the workflow.
         # For the workflow_call, this is in the context of the calling workflow.


### PR DESCRIPTION
Working around the issue that `GITHUB_EVENT_NAME` points to the caller workflow context by using an input to flag the workflow_call event.

Workaround based on GitHub Actions discussion
<https://github.com/actions/runner/discussions/1884#discussioncomment-6377587>

## Related issue(s)

Follow up to #841 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
