### PR TITLE
Add carousel to /pathogens showcase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "react-helmet": "^6.1.0",
         "react-icons": "^5.0.1",
         "react-map-gl": "^7.1.7",
+        "react-multi-carousel": "^2.8.5",
         "react-select": "^5.8.0",
         "react-tooltip": "^4.5.1",
         "react-tooltip-v5": "npm:react-tooltip@^5.26.3",
@@ -21662,6 +21663,14 @@
         }
       }
     },
+    "node_modules/react-multi-carousel": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/react-multi-carousel/-/react-multi-carousel-2.8.5.tgz",
+      "integrity": "sha512-C5DAvJkfzR2JK9YixZ3oyF9x6R4LW6nzTpIXrl9Oujxi4uqP9SzVVCjl+JLM3tSdqdjAx/oWZK3dTVBSR73Q+w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/react-select": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.8.0.tgz",
@@ -41743,6 +41752,11 @@
         "@maplibre/maplibre-gl-style-spec": "^19.2.1",
         "@types/mapbox-gl": ">=1.0.0"
       }
+    },
+    "react-multi-carousel": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/react-multi-carousel/-/react-multi-carousel-2.8.5.tgz",
+      "integrity": "sha512-C5DAvJkfzR2JK9YixZ3oyF9x6R4LW6nzTpIXrl9Oujxi4uqP9SzVVCjl+JLM3tSdqdjAx/oWZK3dTVBSR73Q+w=="
     },
     "react-select": {
       "version": "5.8.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-helmet": "^6.1.0",
     "react-icons": "^5.0.1",
     "react-map-gl": "^7.1.7",
+    "react-multi-carousel": "^2.8.5",
     "react-select": "^5.8.0",
     "react-tooltip": "^4.5.1",
     "react-tooltip-v5": "npm:react-tooltip@^5.26.3",

--- a/static-site/src/components/ListResources/Showcase.jsx
+++ b/static-site/src/components/ListResources/Showcase.jsx
@@ -1,5 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { useCallback, useEffect, useState } from 'react';
+import Carousel from "react-multi-carousel";
+import "react-multi-carousel/lib/styles.css";
 import styled from 'styled-components';
 import {CardInner, CardImg, CardTitle} from "../Cards/styles";
 import { theme } from "../../layouts/theme";
@@ -10,18 +12,35 @@ const cardWidthHeight = 160; // pixels
 
 export const Showcase = ({cards, setSelectedFilterOptions}) => {
   if (!cards.length) return null;
+
+  // Generate options for carousel
+  let responsiveOptions = {};
+
+  for (let i = 0; i < cards.length; i++) {
+    const breakpointMin = i * cardWidthHeight;
+    let breakpointMax = (i + 1) * cardWidthHeight;
+
+    // Don't limit max otherwise carousel won't render at all on larger screens
+    if (i == cards.length - 1) {
+      breakpointMax = 999999
+    }
+
+    responsiveOptions[i] = {
+      breakpoint: { max: breakpointMax, min: breakpointMin },
+      items: i
+    };
+  }
+
   return (
     <div>
       <Byline>
         Showcase resources: click to filter the resources to a pathogen
       </Byline>
-      <SingleRow>
-        <ShowcaseContainer>
-          {cards.map((el) => (
-            <ShowcaseTile data={el} key={el.name} setSelectedFilterOptions={setSelectedFilterOptions}/>
-            ))}
-        </ShowcaseContainer>
-      </SingleRow>
+      <Carousel responsive={responsiveOptions} renderButtonGroupOutside={true}>
+        {cards.map((el) => (
+          <ShowcaseTile data={el} key={el.name} setSelectedFilterOptions={setSelectedFilterOptions}/>
+          ))}
+      </Carousel>
       <Spacer/>
     </div>
   )
@@ -52,26 +71,6 @@ const ShowcaseTile = ({data, setSelectedFilterOptions}) => {
     </CardOuter>
   )
 }
-
-
-/* SingleRow only shows a single row of tiles. By using this to wrap a flexbox
-element we can leverage the intelligent wrapping of the flexbox to decide how
-many tiles to show in a single row. The downside is that showcase tiles are
-still in the DOM, and the images are still fetched etc */
-const SingleRow = styled.div`
-  max-height: ${cardWidthHeight}px;
-  overflow-y: clip;
-`
-
-const ShowcaseContainer = styled.div`
-  /* background-color: #ffeab0; */
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  overflow: hidden;
-  overflow: hidden;
-  justify-content: space-between;
-`;
 
 const Spacer = styled.div`
   min-height: 25px;


### PR DESCRIPTION
[_preview_](https://nextstrain-s-victorlin--phhwcc.herokuapp.com/pathogens)

## Description of proposed changes

Previously, the showcase would drop cards as the width decreases. This is presumably to prevent the showcase from taking up too much height. Instead of hiding the unused cards, allow them to be accessed in a carousel via scroll/arrow clicking.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- Prompted by https://github.com/nextstrain/nextstrain.org/issues/849#issuecomment-2121064824

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] ~Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
