### PR TITLE
Make showcase expandable

### DIFF
--- a/static-site/src/components/ListResources/Showcase.tsx
+++ b/static-site/src/components/ListResources/Showcase.tsx
@@ -11,6 +11,8 @@ import { Card, FilterOption, Group } from './types';
 
 const cardWidthHeight = 160; // pixels
 const expandPreviewHeight = 50 //pixels
+const transitionDuration = "0.3s"
+const transitionTimingFunction = "ease"
 
 type ShowcaseProps = {
     cards: Card[]
@@ -20,6 +22,7 @@ type ShowcaseProps = {
 export const Showcase = ({cards, setSelectedFilterOptions}: ShowcaseProps) => {
 
   const [numRows, setNumRows] = useState<number>(0);
+  const [expandedHeight, setExpandedHeight] = useState<number>(0);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   const toggleExpand = () => {
@@ -32,6 +35,10 @@ export const Showcase = ({cards, setSelectedFilterOptions}: ShowcaseProps) => {
    */
   function cardsContainerRef(cardsContainer: HTMLDivElement) {
     if (!cardsContainer) return;
+
+    if(expandedHeight != cardsContainer.clientHeight) {
+      setExpandedHeight(cardsContainer.clientHeight)
+    }
 
     const cards = cardsContainer.children;
 
@@ -57,13 +64,13 @@ export const Showcase = ({cards, setSelectedFilterOptions}: ShowcaseProps) => {
       <Byline>
         Showcase resources: click to filter the resources to a pathogen
       </Byline>
-      <ShowcaseContainer $isExpanded={isExpanded} $isExpandable={isExpandable}>
+      <ShowcaseContainer className={!isExpandable ? "" : isExpanded ? "expanded" : "collapsed"} $expandedHeight={expandedHeight}>
         <CardsContainer ref={cardsContainerRef}>
           {cards.map((el) => (
             <ShowcaseTile card={el} key={el.name} setSelectedFilterOptions={setSelectedFilterOptions}/>
             ))}
         </CardsContainer>
-        {isExpandable && !isExpanded && <PreviewOverlay onClick={toggleExpand} />}
+        <PreviewOverlay onClick={toggleExpand} className={!isExpandable || isExpanded ? "hidden" : "visible"} />
       </ShowcaseContainer>
       {isExpandable && <>
         <ArrowButton onClick={toggleExpand}>
@@ -107,16 +114,19 @@ const ShowcaseTile = ({card, setSelectedFilterOptions}: ShowcaseTileProps) => {
 }
 
 
-const ShowcaseContainer = styled.div<{$isExpanded: boolean, $isExpandable: boolean}>`
+const ShowcaseContainer = styled.div<{$expandedHeight: number}>`
   position: relative;
-  height: ${(props) =>
-    props.$isExpandable ? 
-      props.$isExpanded ?
-        "" : `${cardWidthHeight + expandPreviewHeight}px`
-      : `${cardWidthHeight}px`
-
-  };
   overflow-y: hidden;
+
+  &.collapsed {
+    max-height: ${cardWidthHeight + expandPreviewHeight}px;
+  }
+
+  &.expanded {
+    max-height: ${(props) => `${props.$expandedHeight}px`};
+  }
+
+  transition: max-height ${transitionDuration} ${transitionTimingFunction};
 `
 
 const ArrowButton = styled.div`
@@ -138,6 +148,16 @@ const PreviewOverlay = styled.div`
   width: 100%;
   height: ${expandPreviewHeight}px;
   cursor: pointer;
+
+  &.visible {
+    opacity: 1;
+  }
+
+  &.hidden {
+    opacity: 0;
+  }
+
+  transition: opacity ${transitionDuration} ${transitionTimingFunction};
 `;
 
 const CardsContainer = styled.div`

--- a/static-site/src/components/ListResources/Showcase.tsx
+++ b/static-site/src/components/ListResources/Showcase.tsx
@@ -166,7 +166,7 @@ const CardsContainer = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   overflow: hidden;
-  justify-content: space-between;
+  justify-content: flex-start;
 `;
 
 const Spacer = styled.div`

--- a/static-site/src/components/ListResources/Showcase.tsx
+++ b/static-site/src/components/ListResources/Showcase.tsx
@@ -21,8 +21,7 @@ type ShowcaseProps = {
 
 export const Showcase = ({cards, setSelectedFilterOptions}: ShowcaseProps) => {
 
-  const [numRows, setNumRows] = useState<number>(0);
-  const [expandedHeight, setExpandedHeight] = useState<number>(0);
+  const [cardsContainerHeight, setCardsContainerHeight] = useState<number>(0);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   const toggleExpand = () => {
@@ -31,40 +30,24 @@ export const Showcase = ({cards, setSelectedFilterOptions}: ShowcaseProps) => {
 
   /**
    * Function that runs on changes to the container.
-   * Used to compute the number of rows of cards upon resize.
+   * Used to determine the height upon resize.
    */
   function cardsContainerRef(cardsContainer: HTMLDivElement) {
     if (!cardsContainer) return;
 
-    if(expandedHeight != cardsContainer.clientHeight) {
-      setExpandedHeight(cardsContainer.clientHeight)
-    }
-
-    const cards = cardsContainer.children;
-
-    if (cards && cards.length > 0) {
-      const leftBorder = (cards[0] as HTMLElement).offsetLeft;
-
-      let newNumRows = 0;
-      for (let i = 0; i < cards.length; i++) {
-        if ((cards[i] as HTMLElement).offsetLeft == leftBorder) {
-          newNumRows++;
-        }
-      }
-      if (numRows != newNumRows) {
-        setNumRows(newNumRows);
-      }
+    if(cardsContainerHeight != cardsContainer.clientHeight) {
+      setCardsContainerHeight(cardsContainer.clientHeight)
     }
   }
 
-  const isExpandable = numRows > 1;
+  const isExpandable = cardsContainerHeight > cardWidthHeight;
 
   return (
     <div>
       <Byline>
         Showcase resources: click to filter the resources to a pathogen
       </Byline>
-      <ShowcaseContainer className={!isExpandable ? "" : isExpanded ? "expanded" : "collapsed"} $expandedHeight={expandedHeight}>
+      <ShowcaseContainer className={!isExpandable ? "" : isExpanded ? "expanded" : "collapsed"} $expandedHeight={cardsContainerHeight}>
         <CardsContainer ref={cardsContainerRef}>
           {cards.map((el) => (
             <ShowcaseTile card={el} key={el.name} setSelectedFilterOptions={setSelectedFilterOptions}/>

--- a/static-site/src/components/ListResources/Showcase.tsx
+++ b/static-site/src/components/ListResources/Showcase.tsx
@@ -166,7 +166,6 @@ const CardsContainer = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   overflow: hidden;
-  overflow: hidden;
   justify-content: space-between;
 `;
 

--- a/static-site/src/components/ListResources/Showcase.tsx
+++ b/static-site/src/components/ListResources/Showcase.tsx
@@ -145,11 +145,11 @@ const PreviewOverlay = styled.div`
 
 const CardsContainer = styled.div`
   /* background-color: #ffeab0; */
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(${cardWidthHeight}px, max-content));
+  grid-gap: 1%;
   overflow: hidden;
-  justify-content: flex-start;
+  justify-content: center;
 `;
 
 const Spacer = styled.div`


### PR DESCRIPTION
[_preview_](https://nextstrain-s-victorlin--ptoszr.herokuapp.com/pathogens)

## Description of proposed changes

Previously, the showcase would drop cards as the width decreases. This is presumably to prevent the showcase from taking up too much height. Instead of hiding the unused cards, allow them to be accessed by making the showcase expandable.

## Related issue(s)

- Based on #874
- Prepping for #849
- Alternative to (closes #873)
    - [Suggested](https://github.com/nextstrain/nextstrain.org/pull/873#issuecomment-2125430386) by @trvrb, [designed](https://github.com/nextstrain/nextstrain.org/pull/873#issuecomment-2125606373) by @tsibley

## Checklist

- [x] Checks pass
- [x] ~Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)~
