### PR TITLE
Use server-side rendering on internal links

### DIFF
--- a/static-site/src/components/Misc/internal-link.tsx
+++ b/static-site/src/components/Misc/internal-link.tsx
@@ -1,10 +1,9 @@
-import { PropsWithChildren } from 'react'
-import Link, { LinkProps } from 'next/link'
+import { PropsWithChildren, AnchorHTMLAttributes } from 'react'
 
-export const InternalLink = (props: PropsWithChildren<LinkProps>) => {
+export const InternalLink = (props: PropsWithChildren<AnchorHTMLAttributes<HTMLAnchorElement>>) => {
   return (
-    <Link {...props}>
+    <a {...props}>
       {props.children}
-    </Link>
+    </a>
   )
 }


### PR DESCRIPTION
## Description of proposed changes

Client-side rendering is buggy at the moment, not working well with browser navigation features.

Server-side rendering is a bit slower but has no major issues.

## Related issue(s)

- Based on #885
- Workaround for #882

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Merge #885
- [x] Checks pass (doc building failure is unrelated)
- [x] [Bug](https://github.com/nextstrain/nextstrain.org/issues/882) is not reproducible in [preview](https://nextstrain-s-victorlin--73jmxp.herokuapp.com)
- [x] ~Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
