### PR TITLE
Remove scroll handler

### DIFF
--- a/static-site/vendored/react-scrollable-anchor/Manager.js
+++ b/static-site/vendored/react-scrollable-anchor/Manager.js
@@ -18,17 +18,14 @@ class Manager {
     this.forcedHash = false
     this.config = defaultConfig
 
-    this.scrollHandler = debounce(this.handleScroll, 100)
     this.forceHashUpdate = debounce(this.handleHashChange, 1)
   }
 
   addListeners = () => {
-    window.addEventListener('scroll', this.scrollHandler, false)
     window.addEventListener('hashchange', this.handleHashChange)
   }
 
   removeListeners = () => {
-    window.removeEventListener('scroll', this.scrollHandler, false)
     window.removeEventListener('hashchange', this.handleHashChange)
   }
 
@@ -59,18 +56,6 @@ class Manager {
     // if this is the last anchor, remove listeners
     if (Object.keys(this.anchors).length === 0) {
       this.removeListeners()
-    }
-  }
-
-  handleScroll = () => {
-    const {offset, keepLastAnchorHash} = this.config
-    const bestAnchorId = getBestAnchorGivenScrollLocation(this.anchors, offset)
-
-    if (bestAnchorId && getHash() !== bestAnchorId) {
-      this.forcedHash = true
-      updateHash(bestAnchorId, false)
-    } else if (!bestAnchorId && !keepLastAnchorHash) {
-      removeHash()
     }
   }
 

--- a/static-site/vendored/react-scrollable-anchor/index.js
+++ b/static-site/vendored/react-scrollable-anchor/index.js
@@ -2,5 +2,5 @@ import Manager from './Manager'
 export const goToTop = Manager.goToTop
 export const configureAnchors = Manager.configure
 
-export { updateHash as goToAnchor, removeHash } from './utils/hash'
+export { updateHash as goToAnchor } from './utils/hash'
 export { default } from './ScrollableAnchor'

--- a/static-site/vendored/react-scrollable-anchor/utils/hash.js
+++ b/static-site/vendored/react-scrollable-anchor/utils/hash.js
@@ -9,12 +9,3 @@ export const updateHash = (hash, affectHistory) => {
     window.location.replace(`#${hash}`)
   }
 }
-
-// remove hash in url without affecting history or forcing reload
-export const removeHash = () => {
-  history.replaceState(
-    "",
-    document.title,
-    window.location.pathname + window.location.search
-  )
-}


### PR DESCRIPTION
## Description of proposed changes

This (mainly `utils/hash.removeHash()`) modifies the current history entry which messes with browser navigation functions.

The handler's main purpose is to update the URL if the user scrolls to or away from an anchor, which isn't something that's necessary for our usage.

## Related issue(s)

- Fixes #882

## Checklist

- [x] Checks pass
- [x] [Bug](https://github.com/nextstrain/nextstrain.org/issues/882) is not reproducible in [preview](https://nextstrain-s-victorlin--m5j7wq.herokuapp.com)
- [x] ~Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)~
