### PR TITLE
Simplify hover detection

### DIFF
--- a/static-site/src/components/ListResources/IndividualResource.tsx
+++ b/static-site/src/components/ListResources/IndividualResource.tsx
@@ -184,10 +184,8 @@ export const ResourceLinkWrapper = ({children, onShiftClick}) => {
     }
   };
   return (
-    <div>
-      <div onMouseOver={() => setHovered(true)} onMouseOut={() => setHovered(false)} onClick={onClick}>
-        {React.cloneElement(children, { $hovered: hovered })}
-      </div>
+    <div onMouseOver={() => setHovered(true)} onMouseOut={() => setHovered(false)} onClick={onClick}>
+      {React.cloneElement(children, { $hovered: hovered })}
     </div>
   )  
 }

--- a/static-site/src/components/ListResources/IndividualResource.tsx
+++ b/static-site/src/components/ListResources/IndividualResource.tsx
@@ -33,25 +33,32 @@ export const getMaxResourceWidth = (displayResources: Resource[]) => {
   }, 200); // 200 (pixels) is the minimum
 }
 
-export const ResourceLink = styled.a<{$hovered?: boolean}>`
+export const ResourceLink = styled.a`
   font-size: ${resourceFontSize}px;
   font-family: monospace;
   white-space: pre; /* don't collapse back-to-back spaces */
-  color: ${(props) => props.$hovered ? LINK_HOVER_COLOR : LINK_COLOR} !important;
+  color: ${LINK_COLOR} !important;
   text-decoration: none !important;
+
+  &:hover {
+    color: ${LINK_HOVER_COLOR} !important;
+  }
 `;
 
 interface NameProps {
   displayName: ResourceDisplayName
-  $hovered?: boolean
   href: string
   topOfColumn: boolean
 }
 
-function Name({displayName, $hovered = false, href, topOfColumn}: NameProps) {
+function Name({displayName, href, topOfColumn}: NameProps) {
+  const [hovered, setHovered] = useState(false);
+
   return (
-    <ResourceLink href={href} target="_blank" rel="noreferrer" $hovered={$hovered}>
-      {'• '}{($hovered||topOfColumn) ? displayName.hovered : displayName.default}
+    <ResourceLink href={href} target="_blank" rel="noreferrer"
+      onMouseOver={() => setHovered(true)}
+      onMouseOut={() => setHovered(false)}>
+      {'• '}{(hovered||topOfColumn) ? displayName.hovered : displayName.default}
     </ResourceLink>
   )
 }
@@ -172,11 +179,9 @@ export const IndividualResource = ({resource, isMobile}: IndividualResourceProps
 
 
 /**
- * Wrapper component which monitors for mouse-over events and injects a
- * `hovered: boolean` prop into the child.
+ * Wrapper component to add shift-click behavior.
  */
 export const ResourceLinkWrapper = ({children, onShiftClick}) => {
-  const [hovered, setHovered] = useState(false);
   const onClick = (e) => {
     if (e.shiftKey) {
       onShiftClick();
@@ -184,8 +189,8 @@ export const ResourceLinkWrapper = ({children, onShiftClick}) => {
     }
   };
   return (
-    <div onMouseOver={() => setHovered(true)} onMouseOut={() => setHovered(false)} onClick={onClick}>
-      {React.cloneElement(children, { $hovered: hovered })}
+    <div onClick={onClick}>
+      {children}
     </div>
   )  
 }


### PR DESCRIPTION
[_preview_](https://nextstrain-s-victorlin--kg9kva.herokuapp.com/pathogens)

## Description of proposed changes

- Use CSS hover selector instead of relying on a prop
- Limit the scope of ResourceLinkWrapper to just adding shift-click behavior

## Related issue(s)

N/A, thought of this while working on #874 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Hover still changes text color on quick links and individual resources
- [x] Shift+click still opens modal for quick links and individual resources
- [x] ~Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
