### PR TITLE
Remove `versioned` attribute from Resource interface

### DIFF
--- a/static-site/src/components/ListResources/IndividualResource.tsx
+++ b/static-site/src/components/ListResources/IndividualResource.tsx
@@ -135,9 +135,9 @@ export const IndividualResource = ({resource, isMobile}: IndividualResourceProps
   // don't show anything if display name is unavailable
   if (!resource.displayName) return null
 
-  // add history if mobile and resource is versioned
+  // add history if mobile and resource has version info
   let history: React.JSX.Element | null = null
-  if (!isMobile && resource.versioned && resource.updateCadence && resource.nVersions) {
+  if (!isMobile && resource.updateCadence && resource.nVersions) {
     history = (
       <TooltipWrapper description={resource.updateCadence.description +
         `<br/>Last known update on ${resource.lastUpdated}` +

--- a/static-site/src/components/ListResources/types.ts
+++ b/static-site/src/components/ListResources/types.ts
@@ -21,7 +21,6 @@ export interface Resource {
   sortingName: string
   url: string
   lastUpdated: string  // date
-  versioned: boolean
   firstUpdated?: string  // date
   dates?: string[]
   nVersions?: number

--- a/static-site/src/components/ListResources/useDataFetch.ts
+++ b/static-site/src/components/ListResources/useDataFetch.ts
@@ -80,7 +80,6 @@ function partitionByPathogen(pathVersions: PathVersions, pathPrefix: string, ver
       sortingName: _sortableName(nameParts),
       url: `/${pathPrefix}${name}`,
       lastUpdated: sortedDates.at(-1)!,
-      versioned
     };
     if (versioned) {
       resourceDetails.firstUpdated = sortedDates[0]!;


### PR DESCRIPTION
## Description of proposed changes

This attribute only served as an alias to determine if the optional attributes `firstUpdated|dates|nVersions|updateCadence` are available. It's more direct (and preferred by the compiler) to check for presence of the individual attributes directly where needed.

`versioned` at the top level on ListResourcesResponsiveProps is still valuable and should be kept.

## Related issue(s)

- follow-up to https://github.com/nextstrain/nextstrain.org/pull/874#discussion_r1626764829

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Preview: [/pathogens](https://nextstrain-s-victorlin--exbkjc.herokuapp.com/pathogens) and [/staging](https://nextstrain-s-victorlin--exbkjc.herokuapp.com/staging) look normal (apart from #896)
- [x] Checks pass
- [x] ~Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
