### PR TITLE
Add Nextclade section on splash

### DIFF
--- a/static-site/src/components/splash/index.jsx
+++ b/static-site/src/components/splash/index.jsx
@@ -79,6 +79,13 @@ const Splash = () => {
           buttonLink="/sars-cov-2"
         />
         <Section
+          id="nextclade"
+          title="Nextclade"
+          abstract="Nextclade allows you to analyze virus genome sequences in the web browser. It will align your sequence data to a reference genome, call mutations relative to that reference, and place your sequences on a phylogeny. It also reports clade assignments and quality of your sequence data."
+          buttonText="Go to Nextclade"
+          buttonLink="https://clades.nextstrain.org"
+        />
+        <Section
           id="groups"
           title="Nextstrain Groups"
           abstract="We want to enable research labs, public health entities and others to share their datasets and narratives through Nextstrain with complete control of their data and audience."


### PR DESCRIPTION
[_preview_](https://nextstrain-s-victorlin--n9zj3t.herokuapp.com/)

## Description of proposed changes

Now that sections aren't required to have preview cards, a section for Nextclade without any cards can visually fit in.

## Related issue(s)

- Based on #901
- #849

## Open questions

1. ~Where should the new Nextclade section be placed? I added it to the end but it should probably go elsewhere.~ [done](https://github.com/nextstrain/nextstrain.org/pull/902#discussion_r1632415779)
2. Does the description/button text look ok?

## Checklist

- [x] Decide on placement
- [x] Checks pass
- [x] ~Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)~
- [x] Merge base branch PR #901

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
