### PR TITLE
Replace Datasets DatasetSelect component on groups page with ListResources [#870]

### DIFF
--- a/static-site/src/components/ListResources/IndividualResource.tsx
+++ b/static-site/src/components/ListResources/IndividualResource.tsx
@@ -86,7 +86,7 @@ export function TooltipWrapper({description, children}) {
       {children}
     </div>
   )
-} 
+}
 
 interface IconContainerProps {
   Icon: IconType
@@ -194,5 +194,5 @@ export const ResourceLinkWrapper = ({children, onShiftClick}) => {
     <div onClick={onClick}>
       {children}
     </div>
-  )  
+  )
 }

--- a/static-site/src/components/ListResources/IndividualResource.tsx
+++ b/static-site/src/components/ListResources/IndividualResource.tsx
@@ -144,7 +144,7 @@ export const IndividualResource = ({resource, isMobile}: IndividualResourceProps
 
   // add history if mobile and resource has version info
   let history: React.JSX.Element | null = null
-  if (!isMobile && resource.updateCadence && resource.nVersions) {
+  if (!isMobile && resource.updateCadence && resource.nVersions && resource.lastUpdated) {
     history = (
       <TooltipWrapper description={resource.updateCadence.description +
         `<br/>Last known update on ${resource.lastUpdated}` +
@@ -158,12 +158,14 @@ export const IndividualResource = ({resource, isMobile}: IndividualResourceProps
     )
   }
 
+  const description = resource.lastUpdated ? `Last known update on ${resource.lastUpdated}` : "";
+
   return (
     <Container ref={ref}>
 
       <FlexRow>
 
-        <TooltipWrapper description={`Last known update on ${resource.lastUpdated}`}>
+        <TooltipWrapper description={description}>
           <ResourceLinkWrapper onShiftClick={() => setModalResource(resource)}>
             <Name displayName={resource.displayName} href={resource.url} topOfColumn={topOfColumn}/>
           </ResourceLinkWrapper>

--- a/static-site/src/components/ListResources/ResourceGroup.tsx
+++ b/static-site/src/components/ListResources/ResourceGroup.tsx
@@ -49,7 +49,7 @@ const ResourceGroupHeader = ({group, isMobile, setCollapsed, collapsible, isColl
             <TooltipWrapper description={`The most recently updated datasets in this group were last updated on ${group.lastUpdated}` +
                 '<br/>(however there may have been a more recent update since we indexed the data)'}>
               <span>
-                {`Most recent snapshot: ${group.lastUpdated}`}
+                {group.lastUpdated && `Most recent snapshot: ${group.lastUpdated}`}
               </span>
             </TooltipWrapper>
           )}

--- a/static-site/src/components/ListResources/ResourceGroup.tsx
+++ b/static-site/src/components/ListResources/ResourceGroup.tsx
@@ -31,7 +31,7 @@ const ResourceGroupHeader = ({group, isMobile, setCollapsed, collapsible, isColl
       <NextstrainLogo/>
 
       <FlexColumnContainer>
-        
+
         <HeaderRow>
           {group.groupUrl ? (
             <TooltipWrapper description={`Click to load the default (and most recent) analysis for ${group.groupDisplayName || group.groupName}`}>
@@ -164,7 +164,7 @@ const ResourceGroupContainer = styled.div`
 `;
 
 const IndividualResourceContainer = styled.div<{$maxResourceWidth: number}>`
-  /* Columns are a simple CSS solution which works really well _if_ we can calculate the expected maximum 
+  /* Columns are a simple CSS solution which works really well _if_ we can calculate the expected maximum
   resource width */
   column-width: ${(props) => props.$maxResourceWidth}px;
   column-gap: 20px;
@@ -239,7 +239,7 @@ function NextstrainLogo() {
 /**
  * Adds the `displayName` property to each resource.
  * Given successive nameParts:
- *      [ seasonal-flu, h1n1pdm]   
+ *      [ seasonal-flu, h1n1pdm]
  *      [ seasonal-flu, h3n2]
  * We want to produce two names: a default name, which contains all parts,
  * and a displayName which hides the fields that match the preceding name.
@@ -255,7 +255,7 @@ function _setDisplayName(resources: Resource[]) {
       name = r.nameParts.join(sep);
     } else {
       let matchIdx = r.nameParts.map((word, j) => word === resources[i-1]?.nameParts[j]).findIndex((v) => !v);
-      if (matchIdx===-1) { // -1 means every word is in the preceding name, but we should display the last word anyway 
+      if (matchIdx===-1) { // -1 means every word is in the preceding name, but we should display the last word anyway
         matchIdx = r.nameParts.length-2;
       }
       name = r.nameParts.map((word, j) => j < matchIdx ? ' '.repeat(word.length) : word).join(sep);

--- a/static-site/src/components/ListResources/index.tsx
+++ b/static-site/src/components/ListResources/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback, createContext, useContext } from 'react';
+import React, { FormEvent, useState, useRef, useEffect, useCallback, createContext, useContext } from 'react';
 import styled from 'styled-components';
 import Select, { MultiValue } from 'react-select';
 import ScrollableAnchor, { goToAnchor } from '../../../vendored/react-scrollable-anchor/index';
@@ -170,8 +170,8 @@ export default ListResourcesResponsive
 
 
 function SortOptions({sortMethod, changeSortMethod}) {
-  function onChangeValue(event) {
-    changeSortMethod(event.target.value);
+  function onChangeValue(event:FormEvent<HTMLInputElement>): void {
+    changeSortMethod(event.currentTarget.value);
   }
   return (
     <SortContainer>

--- a/static-site/src/components/ListResources/index.tsx
+++ b/static-site/src/components/ListResources/index.tsx
@@ -76,17 +76,25 @@ function ListResources({
   return (
     <ListResourcesContainer>
 
-      <Byline>
-        Showcase resources: click to filter the resources to a pathogen
-      </Byline>
+      { showcaseCards.length > 0 && (
+        <>
+        <Byline>
+          Showcase resources: click to filter the resources to a pathogen
+        </Byline>
 
-      <SetSelectedFilterOptions.Provider value={setSelectedFilterOptions}>
-        <Showcase cards={showcaseCards} CardComponent={FilterShowcaseTile} />
-      </SetSelectedFilterOptions.Provider>
+        <SetSelectedFilterOptions.Provider value={setSelectedFilterOptions}>
+          <Showcase cards={showcaseCards} CardComponent={FilterShowcaseTile} />
+        </SetSelectedFilterOptions.Provider>
+        </>
+      )}
 
       <Filter options={availableFilterOptions} selectedFilterOptions={selectedFilterOptions} setSelectedFilterOptions={setSelectedFilterOptions}/>
 
-      <SortOptions sortMethod={sortMethod} changeSortMethod={changeSortMethod}/>
+      { groups?.[0]?.lastUpdated && (
+        <SortOptions sortMethod={sortMethod} changeSortMethod={changeSortMethod}/>
+      ) || (
+        <HugeSpacer/>
+      )}
 
       <SetModalResourceContext.Provider value={setModalResource}>
         <ScrollableAnchor id={LIST_ANCHOR}>

--- a/static-site/src/components/ListResources/index.tsx
+++ b/static-site/src/components/ListResources/index.tsx
@@ -12,7 +12,8 @@ import { ErrorContainer } from "../../pages/404";
 import { TooltipWrapper } from "./IndividualResource";
 import {ResourceModal, SetModalResourceContext} from "./Modal";
 import { CardImgWrapper, CardInner, CardOuter, CardTitle, Showcase } from "../Showcase";
-import { FilterCard, FilterOption, Group, GroupDisplayNames, QuickLink, Resource } from './types';
+import { FilterCard, FilterOption, Group, GroupDisplayNames, QuickLink, Resource, ResourceListingInfo } from './types';
+import { HugeSpacer } from "../../layouts/generalComponents";
 
 interface ListResourcesProps extends ListResourcesResponsiveProps {
   elWidth: number
@@ -23,23 +24,29 @@ const LIST_ANCHOR = "list";
 const SetSelectedFilterOptions = createContext<React.Dispatch<React.SetStateAction<readonly FilterOption[]>> | null>(null);
 
 /**
- * A React component to fetch data and display the available resources,
- * including past versions ("snapshots").
+ * A React component that uses a callback to fetch data about
+ * available resources, and then display them, including past versions
+ * ("snapshots"), if those exist.
  *
  * Note that currently this only uses 'dataset' resources. In the future this
  * will be expanded. Similarly, we define versioned: boolean here in the UI whereas
  * this may be better expressed as a property of the API response.
  */
 function ListResources({
-  sourceId,
   versioned=true,
   elWidth,
   quickLinks,
   defaultGroupLinks=false,
   groupDisplayNames,
   showcase,
+  resourceListingCallback: resourceListingCallback,
 }: ListResourcesProps) {
-  const {groups, dataFetchError} = useDataFetch(sourceId, versioned, defaultGroupLinks, groupDisplayNames);
+  const {groups, dataFetchError} = useDataFetch(
+    versioned,
+    defaultGroupLinks,
+    groupDisplayNames,
+    resourceListingCallback,
+  );
   const showcaseCards = useShowcaseCards(showcase, groups);
   const [selectedFilterOptions, setSelectedFilterOptions] = useState<readonly FilterOption[]>([]);
   const [sortMethod, changeSortMethod] = useState("alphabetical");
@@ -50,7 +57,7 @@ function ListResources({
 
   if (dataFetchError) {
     return (
-      <ErrorContainer>  
+      <ErrorContainer>
         {"Whoops - listing resources isn't working!"}
         <br/>
         {'Please '}<a href="/contact" style={{fontWeight: 300}}>get in touch</a>{" if this keeps happening"}
@@ -108,7 +115,6 @@ function ListResources({
 
 
 interface ListResourcesResponsiveProps {
-  sourceId: string
   versioned: boolean
   quickLinks: QuickLink[]
 
@@ -116,6 +122,7 @@ interface ListResourcesResponsiveProps {
   defaultGroupLinks: boolean
   groupDisplayNames: GroupDisplayNames
   showcase: FilterCard[]
+  resourceListingCallback: () => Promise<ResourceListingInfo>;
 }
 
 /**
@@ -160,7 +167,7 @@ function SortOptions({sortMethod, changeSortMethod}) {
   }
   return (
     <SortContainer>
-      Sort pathogens by: 
+      Sort pathogens by:
       <input id="alphabetical" type="radio" onChange={onChangeValue} value="alphabetical"
         checked={"alphabetical"===sortMethod} style={{cursor: "alphabetical"===sortMethod ? 'default' : 'pointer'}}/>
       <TooltipWrapper description={'Pathogen groups ordered alphabetically. ' +

--- a/static-site/src/components/ListResources/types.ts
+++ b/static-site/src/components/ListResources/types.ts
@@ -34,6 +34,11 @@ export interface ResourceDisplayName {
   default: string
 }
 
+export interface ResourceListingInfo {
+  pathPrefix: string
+  pathVersions: PathVersions
+}
+
 /**
  * Mapping from group name -> display name
  */

--- a/static-site/src/components/ListResources/types.ts
+++ b/static-site/src/components/ListResources/types.ts
@@ -22,7 +22,7 @@ export interface Resource {
   nameParts: string[]
   sortingName: string
   url: string
-  lastUpdated: string  // date
+  lastUpdated?: string  // date
   firstUpdated?: string  // date
   dates?: string[]
   nVersions?: number

--- a/static-site/src/components/ListResources/useDataFetch.ts
+++ b/static-site/src/components/ListResources/useDataFetch.ts
@@ -59,7 +59,7 @@ interface Partitions {
 /**
  * Groups the provided array of pathVersions into an object with keys
  * representing group names (pathogen names) and values which are arrays of
- * resource objects. 
+ * resource objects.
  */
 function partitionByPathogen(pathVersions: PathVersions, pathPrefix: string, versioned: boolean) {
   return Object.entries(pathVersions).reduce((store: Partitions, [name, dates]) => {

--- a/static-site/src/components/ListResources/useDataFetch.ts
+++ b/static-site/src/components/ListResources/useDataFetch.ts
@@ -65,9 +65,6 @@ function partitionByPathogen(pathVersions: PathVersions, pathPrefix: string, ver
   return Object.entries(pathVersions).reduce((store: Partitions, [name, dates]) => {
     const sortedDates = [...dates].sort();
 
-    // do nothing if resource has no dates
-    if (sortedDates.length < 1) return store
-
     const nameParts = name.split('/');
     // split() will always return at least 1 string
     const groupName = nameParts[0]!;
@@ -78,11 +75,10 @@ function partitionByPathogen(pathVersions: PathVersions, pathPrefix: string, ver
       nameParts,
       sortingName: _sortableName(nameParts),
       url: `/${pathPrefix}${name}`,
-      lastUpdated: sortedDates.at(-1)!,
+      lastUpdated: sortedDates.at(-1),
     };
     if (versioned) {
       resourceDetails.firstUpdated = sortedDates[0]!;
-      resourceDetails.lastUpdated = sortedDates.at(-1)!;
       resourceDetails.dates = sortedDates;
       resourceDetails.nVersions = sortedDates.length;
       resourceDetails.updateCadence = updateCadence(sortedDates.map((date)=> new Date(date)));

--- a/static-site/src/sections/pathogens.jsx
+++ b/static-site/src/sections/pathogens.jsx
@@ -21,6 +21,18 @@ const abstract = (
   </>
 );
 
+const resourceListingCallback = async () => {
+  const sourceId = "core"
+  const sourceUrl = `list-resources/${sourceId}`;
+
+  const response = await fetch(sourceUrl, {headers: {accept: "application/json"}});
+  if (response.status !== 200) {
+    throw new Error(`fetching data from "${sourceUrl}" returned status code ${response.status}`);
+  }
+
+  return (await response.json()).dataset[sourceId];
+};
+
 class Index extends React.Component {
   render() {
     return (
@@ -35,9 +47,13 @@ class Index extends React.Component {
         </FlexCenter>
 
         <HugeSpacer/>
-        <ListResources sourceId="core" resourceType="dataset"
+
+        <ListResources resourceType="dataset"
           showcase={coreShowcase}
-          quickLinks={coreQuickLinks} defaultGroupLinks groupDisplayNames={coreGroupDisplayNames}/>
+          quickLinks={coreQuickLinks} defaultGroupLinks
+          groupDisplayNames={coreGroupDisplayNames}
+          resourceListingCallback={resourceListingCallback}/>
+
         <HugeSpacer/>
       </GenericPage>
     );

--- a/static-site/src/sections/staging-page.jsx
+++ b/static-site/src/sections/staging-page.jsx
@@ -42,7 +42,7 @@ class Index extends React.Component {
     We update state which results in an error banner being shown. */
     if (!this.state.resourcePath && this.props.router.query?.staging) {
       this.setState({resourcePath: "staging/"+this.props.router.query.staging.join("/")})
-    }    
+    }
   }
 
   componentDidMount() {this.checkRouterParams()}

--- a/static-site/src/sections/staging-page.jsx
+++ b/static-site/src/sections/staging-page.jsx
@@ -18,6 +18,18 @@ const abstract = (
   </>
 );
 
+const resourceListingCallback = async () => {
+  const sourceId = "staging"
+  const sourceUrl = `list-resources/${sourceId}`;
+
+  const response = await fetch(sourceUrl, {headers: {accept: "application/json"}});
+  if (response.status !== 200) {
+    throw new Error(`fetching data from "${sourceUrl}" returned status code ${response.status}`);
+  }
+
+  return (await response.json()).dataset[sourceId];
+};
+
 class Index extends React.Component {
   constructor(props) {
     super(props);
@@ -62,7 +74,8 @@ class Index extends React.Component {
         </FlexCenter>
         <HugeSpacer />
 
-        <ListResources sourceId="staging" resourceType="dataset" versioned={false}/>
+        <ListResources resourceType="dataset" versioned={false}
+          resourceListingCallback={resourceListingCallback}/>
 
         <HugeSpacer />
 


### PR DESCRIPTION
## Description of proposed changes

Replaces the current "datasets" DatasetSelect component with a ListResources component that hits the same backend `charon` API. Also refactors in `useDataFetch` to change the hard-coded parser into a passed-in (mandatory) callback function, and updates two existing uses to the new pattern. Finally, adds in conditional display logic to the ListResources component to hide or otherwise not set UI elements that don't make sense with the `groups` dataset (e.g., last modified dates, since we don't have those). 

[Preview](https://nextstrain-s-group-reso-fafosr.herokuapp.com/groups)

## Related issue(s)

#870 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
