### PR TITLE
scripts/heroku-build: Set HOME=/tmp for build

### DIFF
--- a/scripts/heroku-build
+++ b/scripts/heroku-build
@@ -63,6 +63,7 @@ docker run \
   --volume "$(realpath build/pack)":/build/pack:ro \
   --volume "$(realpath build/cache)":/build/cache:rw \
   --volume "$(realpath build/env)":/build/env:ro \
+  --env HOME=/tmp \
   --env STACK=heroku-20 \
   --env SOURCE_VERSION \
   --env SOURCE_DESCRIPTION \


### PR DESCRIPTION
Some things (Puppeteer during `npm` install, in some cases; `next build` when SWC deps are missing) want to store files in $HOME/.cache/ and that doesn't work due to permissions when HOME=/ (the fallback value provided by bash because it can't lookup a user for the uid we use).

I believe these caches are needed at build-time only and can be safely discarded afterwards.  If that turns out to not be the case, then we can switch to setting HOME=/build/app instead to include them in the slug.

Resolves: <https://github.com/nextstrain/nextstrain.org/issues/895>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
