### PR TITLE
Don't condition build status on lint result

### DIFF
--- a/static-site/next.config.mjs
+++ b/static-site/next.config.mjs
@@ -10,7 +10,12 @@ const nextConfig = {
   },
   transpilePackages: [
     'react-virtualized'
-  ]
+  ],
+  eslint: {
+    // Allow builds to complete regardless of linting results. This is ok since
+    // linting is done explicitly in CI.
+    ignoreDuringBuilds: true
+  }
 };
 
 export default withYaml(nextConfig);


### PR DESCRIPTION
## Description of proposed changes

This avoids failure to create Heroku preview apps simply due to linting errors.

## Related issue(s)

N/A

## References

https://nextjs.org/docs/app/api-reference/next-config-js/eslint

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Build passes
- [x] Linting fails on b0376165229c271cb796d8e64c569a5797fa0d35 but review app still builds successfully
- [x] Drop b0376165229c271cb796d8e64c569a5797fa0d35
- [x] ~Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
