### PR TITLE
Remove PathVersions comment

### DIFF
--- a/static-site/src/components/ListResources/types.ts
+++ b/static-site/src/components/ListResources/types.ts
@@ -58,7 +58,6 @@ export interface QuickLink {
   groupName?: string
 }
 
-// This is what's returned by the API call to `/list-resources/:sourceName`
 export interface PathVersions {
   [name: string]: string[]  // versions
 }


### PR DESCRIPTION
## Description of proposed changes

The comment was inaccurate - PathVersions does not describe the exact response value of the API call but rather the the value of a nested key within the response.

The comment could be updated with that clarification, but it's also prone to becoming out of date (not always going to be from the /list-resources API call).

## Related issue(s)

Thought of this while reviewing #904

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [x] ~Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
