### PR TITLE
endpoints/cli: Make installer OS param accept `uname -s` output…

### DIFF
--- a/src/endpoints/cli.js
+++ b/src/endpoints/cli.js
@@ -181,9 +181,10 @@ function assertStatusOk(response) {
 
 function installer (req, res) {
   const os = req.params.os;
-  switch (os) {
+  switch (os.toLowerCase()) {
     case "linux":
     case "mac":
+    case "darwin": // `uname -s` on macOS
       return res.redirect("https://raw.githubusercontent.com/nextstrain/cli/HEAD/bin/standalone-installer-unix");
 
     case "windows":


### PR DESCRIPTION
…by making it case-insensitive (so "Linux" matches "linux") and accepting "Darwin" as alias for "mac".

Accepting `uname -s` make it easier to give cross-platform instructions for Linux/macOS.  This is intended for ad-hoc installations for internal usage by developers; it's not a suggestion to change our general installation docs.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
