### PR TITLE
Add mpox/clade-I to manifest

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -417,6 +417,7 @@
       "mpox": {
         "resolution": {
           "all-clades": "",
+          "clade-I": "",
           "clade-IIb": "",
           "lineage-B.1": "",
           "default": "clade-IIb"


### PR DESCRIPTION
See https://github.com/nextstrain/mpox/pull/254 for context on the dataset itself.

The [dataset itself is live](https://nextstrain.org/mpox/clade-I) (via [this action run](https://github.com/nextstrain/mpox/actions/runs/9606998203/job/26497445439)), this PR just adds it to the sidebar dropdown in Auspice.

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions) -- The resource indexer should handle this appropriately regardless of these changes. 


