### PR TITLE
Make group tiles expandable

### DIFF
--- a/static-site/src/components/Groups/Tiles/index.tsx
+++ b/static-site/src/components/Groups/Tiles/index.tsx
@@ -1,22 +1,22 @@
 import React, { useContext } from "react";
 import * as Styles from "./styles";
-import { H1 } from "../../splash/styles";
-import { MediumSpacer } from "../../../layouts/generalComponents";
+import { width, height } from "./styles";
 import Padlock from "./padlock";
 import { theme } from "../../../layouts/theme";
 import { UserContext } from "../../../layouts/userDataWrapper";
 import { GroupTile } from "./types";
 import { Group } from "../types";
+import { ExpandableTiles } from "../../ExpandableTiles";
 
 
-export const GroupTiles = ({squashed}: { squashed: boolean }) => {
+export const GroupTiles = () => {
   const { visibleGroups } = useContext(UserContext);
   return (
-    <Tiles
-      compactColumns={false}
-      title={""}
+    <ExpandableTiles
       tiles={createGroupTiles(visibleGroups || [])}
-      squashed={squashed}/>
+      tileWidth={width}
+      tileHeight={height}
+      TileComponent={Tile}/>
   );
 };
 
@@ -37,60 +37,23 @@ const createGroupTiles = (groups: Group[], colors = [...theme.titleColors]): Gro
 });
 
 
-const Tiles = ({ compactColumns, title, subtext, tiles, squashed }: {
-  compactColumns: boolean
-  title: string
-  subtext?: string
-  tiles: GroupTile[]
-  squashed: boolean
-}) => {
-  function getTiles(bootstrapColumnSize: number) {
-    return tiles.map((d) => (
-      <div className={`col-sm-${bootstrapColumnSize}`} key={d.name}>
-        <Styles.TileOuter $squashed={squashed}>
-          <Styles.TileInner>
-            <a href={`${d.url}`}>
-              <Styles.TileName $squashed={squashed}>
-                {d.name}
-              </Styles.TileName>
-              {d.private ? (
-                <Styles.BottomRightLabel>
-                  <Padlock/>
-                </Styles.BottomRightLabel>
-              ) : null}
-              {/* eslint-disable-next-line @typescript-eslint/no-var-requires */}
-              {d.img ? <Styles.TileImg src={require(`../../../../static/pathogen_images/${d.img}`).default.src} alt={""} color={d.color}/> : null}
-            </a>
-          </Styles.TileInner>
-        </Styles.TileOuter>
-      </div>
-    ));
-  }
-
-  const bootstrapColumnSize = compactColumns ? 6 : 4;
-  const TILES = getTiles(bootstrapColumnSize);
-
-  return compactColumns ? TILES : (
-    <div>
-      <div className="row">
-        <div className="col-md-1" />
-        <div className="col-md-10">
-          <H1>{title}</H1>
-          {subtext ?
-            (
-              <Styles.SubText>
-                {subtext}
-              </Styles.SubText>
-            ) :
-            null
-          }
-          <MediumSpacer />
-          <div className="row">
-            {TILES}
-          </div>
-        </div>
-      </div>
-      <div className="col-md-1" />
-    </div>
-  );
+const Tile = ({ tile }: { tile: GroupTile }) => {
+  return (
+    <Styles.TileOuter>
+      <Styles.TileInner>
+        <a href={`${tile.url}`}>
+          <Styles.TileName>
+            {tile.name}
+          </Styles.TileName>
+          {tile.private ? (
+            <Styles.BottomRightLabel>
+              <Padlock/>
+            </Styles.BottomRightLabel>
+          ) : null}
+          {/* eslint-disable-next-line @typescript-eslint/no-var-requires */}
+          {tile.img ? <Styles.TileImg src={require(`../../../../static/pathogen_images/${tile.img}`).default.src} alt={""} color={tile.color}/> : null}
+        </a>
+      </Styles.TileInner>
+    </Styles.TileOuter>
+  )
 }

--- a/static-site/src/components/Groups/Tiles/styles.tsx
+++ b/static-site/src/components/Groups/Tiles/styles.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
-export const width = 250;
-export const height = 150;
+export const width = 160;
+export const height = 160;
 
 export const TileImg = styled.img`
   object-fit: contain;
@@ -23,7 +23,6 @@ export const TileOuter = styled.div`
   padding: 0;
   overflow: hidden;
   position: relative;
-  padding: 15px 0px 15px 0px;
   height: ${height}px;
   width: ${width}px;
 `;
@@ -34,8 +33,8 @@ export const TileName = styled.div`
   font-size: 22px;
   position: absolute;
   border-radius: 3px;
-  padding: 10px 20px 10px 20px;
-  top: 40px;
+  padding: 10px 20px 10px 10px;
+  top: 20px;
   left: 20px;
   color: white;
   background: rgba(0, 0, 0, 0.7);

--- a/static-site/src/components/Groups/Tiles/styles.tsx
+++ b/static-site/src/components/Groups/Tiles/styles.tsx
@@ -1,5 +1,8 @@
 import styled from "styled-components";
 
+export const width = 250;
+export const height = 150;
+
 export const TileImg = styled.img`
   object-fit: contain;
   border-radius: 6px;
@@ -15,36 +18,20 @@ export const TileInner = styled.div`
   cursor: pointer;
 `;
 
-export const TileOuter = styled.div<{$squashed: boolean}>`
+export const TileOuter = styled.div`
   background-color: #FFFFFF;
   padding: 0;
   overflow: hidden;
   position: relative;
   padding: 15px 0px 15px 0px;
-  height: ${(props) => props.$squashed ? "150px" : "250px"};
-  width: 250px;
-  @media (max-width: 1200px) {
-    height: ${(props) => props.$squashed ? "150px" : "200px"};
-    width: 200px;
-  }
-  @media (max-width: 768px) {
-    height: 150px;
-    width: 200px;
-  }
-  @media (max-width: 680px) {
-    height: 120px;
-    width: 100%;
-    padding: 20px 0px 20px 0px;
-  }
+  height: ${height}px;
+  width: ${width}px;
 `;
 
-export const TileName = styled.div<{$squashed: boolean}>`
+export const TileName = styled.div`
   font-family: ${(props) => props.theme.generalFont};
   font-weight: 500;
-  font-size: ${(props) => props.$squashed ? "22px" : "26px"};
-  @media (max-width: 768px) {
-    font-size: 22px;
-  }
+  font-size: 22px;
   position: absolute;
   border-radius: 3px;
   padding: 10px 20px 10px 20px;

--- a/static-site/src/pages/groups.jsx
+++ b/static-site/src/pages/groups.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import ScrollableAnchor from '../../vendored/react-scrollable-anchor/index';
-import { SmallSpacer, HugeSpacer, FlexCenter } from "../layouts/generalComponents";
+import { SmallSpacer, BigSpacer, HugeSpacer, FlexCenter } from "../layouts/generalComponents";
 import * as splashStyles from "../components/splash/styles";
 import { fetchAndParseJSON } from "../util/datasetsHelpers";
 import DatasetSelect from "../components/Datasets/dataset-select";
@@ -112,6 +112,10 @@ class GroupsPage extends React.Component {
         {/* These tiles dont go nicely into FlexCenter as they manage their own spacing */}
         <GroupTiles />
         <HugeSpacer />
+
+        <splashStyles.H2>Available Datasets</splashStyles.H2>
+
+        <BigSpacer />
 
         <ListResources
           resourceType="dataset"

--- a/static-site/src/pages/groups.jsx
+++ b/static-site/src/pages/groups.jsx
@@ -110,7 +110,7 @@ class GroupsPage extends React.Component {
         <splashStyles.H2>Available groups</splashStyles.H2>
         <GroupListingInfo/>
         {/* These tiles dont go nicely into FlexCenter as they manage their own spacing */}
-        <GroupTiles squashed/>
+        <GroupTiles />
         <HugeSpacer />
 
         <ListResources


### PR DESCRIPTION
[_preview_](https://nextstrain-s-victorlin--rgwhw6.herokuapp.com/groups)

## Description of proposed changes

ExpandableTiles is already used in two other places where tiles are used. Use it here too for consistency.

## Related issue(s)

https://github.com/nextstrain/nextstrain.org/issues/947

## Checklist

- [ ] Checks pass
- [ ] [Preview](https://nextstrain-s-victorlin--rgwhw6.herokuapp.com/groups) looks good
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
- [ ] Merge base PR #950 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
