### PR TITLE
Move concurrency limit to the workflow level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   push:
     branches:
@@ -10,6 +11,7 @@ on:
         description: Deploy to Heroku app (if set)
         type: string
         required: false
+
 defaults:
   run:
     # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
@@ -18,6 +20,7 @@ defaults:
     # Completely spelling it out here so that GitHub can't change it out from under us
     # and we don't have to refer to the docs to know the expected behavior.
     shell: bash --noprofile --norc -eo pipefail {0}
+
 jobs:
   # Lint regardless of build or test status and lint early.
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ on:
         type: string
         required: false
 
+# Only one run per branch at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
@@ -125,9 +130,6 @@ jobs:
       - build
       - test
       - index-resources
-
-    # Only one "deploy" job per Heroku app at a time.
-    concurrency: deploy:${{ inputs.heroku-app || 'nextstrain-canary' }}
 
     # Name a GitHub environment configuration¹ to auto-create deployment
     # records in GitHub based on this job's progress/status.  Also grants


### PR DESCRIPTION
## Description of proposed changes

The concurrency limit on the deploy step was meant to prevent multiple deployment processes from running at the same time. However, most of the time spent on the deployment process is in the build step, which means there is not likely to be any overlap on the deploy step.

Set the limit on the workflow level to capture the entire deployment process. This will also affect runs that don't deploy (e.g. PR updates), but most of the time only the latest push to a PR is important so it's fine that older runs are canceled.

## Related issue(s)

Closes #935

## Checklist

- [x] Existing PR run is canceled on 6f1ad0e49be0adf2b4cd2fca294002925d610623
- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
