### PR TITLE
manifest: update rsv resolutions

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -649,17 +649,59 @@
         "type": {
           "a": {
             "region":{
-              "genome":"",
-              "G":"",
-              "F":"",
+              "genome": {
+                "resolution":{
+                  "all-time":"",
+                  "6y":"",
+                  "3y":"",
+                  "default":"6y"
+                }
+              },
+              "G": {
+                "resolution":{
+                  "all-time":"",
+                  "6y":"",
+                  "3y":"",
+                  "default":"6y"
+                }
+              },
+              "F": {
+                "resolution":{
+                  "all-time":"",
+                  "6y":"",
+                  "3y":"",
+                  "default":"6y"
+                }
+              },
               "default":"genome"
             }
           },
           "b": {
             "region":{
-              "genome":"",
-              "G":"",
-              "F":"",
+              "genome": {
+                "resolution":{
+                  "all-time":"",
+                  "6y":"",
+                  "3y":"",
+                  "default":"6y"
+                }
+              },
+              "G": {
+                "resolution":{
+                  "all-time":"",
+                  "6y":"",
+                  "3y":"",
+                  "default":"6y"
+                }
+              },
+              "F": {
+                "resolution":{
+                  "all-time":"",
+                  "6y":"",
+                  "3y":"",
+                  "default":"6y"
+                }
+              },
               "default":"genome"
             }
           },


### PR DESCRIPTION
Add different time resolution to the RSV builds to produce the hierarchy (defaults in italics):

- a
  - *genome*
    - all-time
    - *6y*
    - 3y
  - F
    - all-time
    - *6y*
    - 3y
  - G 
    - all-time
    - *6y*
    - 3y
- b
  - *genome*
    - all-time
    - *6y*
    - 3y
  - F
    - all-time
    - *6y*
    - 3y
  - G 
    - all-time
    - *6y*
    - 3y
