### PR TITLE
Update manifest with h5n1-cattle-outbreak segments

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -6,6 +6,14 @@
           "h5n1-cattle-outbreak": {
               "segment": {
                   "genome": "",
+                  "ha": "",
+                  "mp": "",
+                  "na": "",
+                  "ns": "",
+                  "np": "",
+                  "ps": "",
+                  "pb1": "",
+                  "pb2": "",
                   "default": "genome"
               }
           },


### PR DESCRIPTION
See <https://github.com/nextstrain/avian-flu/pull/69> and <https://github.com/nextstrain/avian-flu/pull/72> for details of the new datasets themselves.

Segments ordered following the other avian-flu builds in the manifest, although note that this order differs from the canonical order of "pb2", "pb1", "pa", "ha","np", "na", "mp", "ns" which is used to order segments in the avian-flu/h5n1-cattle-outbreak/genome build.

## Blocked on

- [x] Deployment of underlying datasets to nextstrain-data

## Checklist

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)


