### PR TITLE
Allow require() outside of import statements

### DIFF
--- a/static-site/.eslintrc.yaml
+++ b/static-site/.eslintrc.yaml
@@ -31,6 +31,13 @@ rules:
   '@next/next/no-img-element': off # Remove this if we use next.js optimisations for <img>
   '@next/next/no-html-link-for-pages': off
 
+overrides:
+  # require() is used for images that are not under static-site/public
+  - files:
+      - '**.[jt]sx'
+    rules:
+      '@typescript-eslint/no-var-requires': off
+
 parserOptions:
   sourceType: module
   ecmaVersion: 2022

--- a/static-site/src/components/Groups/Tiles/index.tsx
+++ b/static-site/src/components/Groups/Tiles/index.tsx
@@ -50,7 +50,6 @@ const Tile = ({ tile }: { tile: GroupTile }) => {
               <Padlock/>
             </Styles.BottomRightLabel>
           ) : null}
-          {/* eslint-disable-next-line @typescript-eslint/no-var-requires */}
           {tile.img ? <Styles.TileImg src={require(`../../../../static/pathogen_images/${tile.img}`).default.src} alt={""} color={tile.color}/> : null}
         </a>
       </Styles.TileInner>

--- a/static-site/src/components/ListResources/index.tsx
+++ b/static-site/src/components/ListResources/index.tsx
@@ -356,10 +356,8 @@ const TileImg = styled.img`
 const TileImgWrapper = ({filename}) => {
   let src;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     src = require(`../../../static/pathogen_images/${filename}`).default.src;
   } catch {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     src = require(`../../../static/pathogen_images/empty.png`).default.src;
   }
   return <TileImg src={src} alt={""} />

--- a/static-site/src/components/People/avatars.jsx
+++ b/static-site/src/components/People/avatars.jsx
@@ -97,7 +97,6 @@ export const TeamPageList = ({membersKey}) => {
       {people.map((person) => 
         <Sideways key={person.name} style={{alignItems: person.blurb ? "top" : "center"}}>
           <MaybeLinked link={person.link}>
-              {/* eslint-disable-next-line @typescript-eslint/no-var-requires */}
               <img alt={person.name} src={require("../../../static/team/"+person.image).default.src}/>
             </MaybeLinked>
           <UpDown>
@@ -122,7 +121,6 @@ export const FooterList = () => {
       {people.map((person, i) => 
         <div key={person.name}>
           <MaybeLinked link={person.link}>
-            {/* eslint-disable-next-line @typescript-eslint/no-var-requires */}
             <img alt={person.name} src={require("../../../static/team/"+person.image).default.src}/>
             <Name>{person.name}</Name>
           </MaybeLinked>

--- a/static-site/src/components/logos.jsx
+++ b/static-site/src/components/logos.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 import * as Styles from "./splash/styles";
 
-/* eslint-disable @typescript-eslint/no-var-requires */
 const fredHutchLogo = require("../../static/logos/fred-hutch-logo-small.png");
 const uniBasLogo = require("../../static/logos/unibas-logo.svg");
 const nihLogo = require("../../static/logos/nih-logo.jpg");
@@ -11,7 +10,6 @@ const mapBoxLogo = require("../../static/logos/mapbox-logo-black.svg");
 const sibLogo = require("../../static/logos/sib-logo.png");
 const ospLogo = require("../../static/logos/osp-logo-small.png");
 const bzLogo = require("../../static/logos/bz_logo.png");
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 const AllLogosContainer = styled.div`
   display: flex;

--- a/static-site/src/components/splash/index.tsx
+++ b/static-site/src/components/splash/index.tsx
@@ -248,10 +248,8 @@ function TileSourceIcon({ url, isNarrative }: {
   url: string
   isNarrative: boolean
 }) {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const gitHubLogo = require(`../../../static/logos/github-mark.png`).default.src;
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const nextstrainLogo = require(`../../../static/logos/nextstrain-logo-tiny.png`).default.src;
 
   let maintainers: string, image: React.JSX.Element;
@@ -282,7 +280,6 @@ function TileSourceIcon({ url, isNarrative }: {
 }
 
 function GroupImage({ group }) {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const faUsers = require(`../../../static/logos/fa-users-solid.svg`).default.src;
   const [groupLogo, setGroupLogo] = useState(faUsers);
 
@@ -304,7 +301,6 @@ function GroupImage({ group }) {
 }
 
 function NarrativeIcon() {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const faBookOpen = require(`../../../static/logos/fa-book-open-solid.svg`).default.src;
 
   return (
@@ -396,10 +392,8 @@ const TileImgWrapper = ({filename}: {
 }) => {
   let src;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     src = require(`../../../static/pathogen_images/${filename}`).default.src;
   } catch {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     src = require(`../../../static/pathogen_images/empty.png`).default.src;
   }
   return <TileImg src={src} alt={""} />

--- a/static-site/src/sections/sars-cov-2-forecasts-page.jsx
+++ b/static-site/src/sections/sars-cov-2-forecasts-page.jsx
@@ -8,7 +8,6 @@ import {
 import GenericPage from "../layouts/generic-page";
 import * as splashStyles from "../components/splash/styles";
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const gisaidLogo = require("../../static/logos/gisaid.png");
 
 // Hard-coded content


### PR DESCRIPTION
## Description of proposed changes

The pattern of using require("path/to/image").default.src is project-wide rather than individual one-offs. In this case, it makes more sense to disable the rule across the project in files which may import images.

## Related issue(s)

Closes #959

## Checklist

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
