### PR TITLE
Fix styles for blog pages

### DIFF
--- a/static-site/src/components/nav-bar/index.tsx
+++ b/static-site/src/components/nav-bar/index.tsx
@@ -22,16 +22,16 @@ const NavContainer = styled.div`
   // TODO: Put this component in a container which sets these styles for all pages.
   // This isn't trivial with the current split in page-level components.
   @media (min-width: 768px) {
-    width: 728px;
+    max-width: 728px;
   }
   @media (min-width: 992px) {
-    width: 952px;
+    max-width: 952px;
   }
   @media (min-width: 1200px) {
-    width: 1150px;
+    max-width: 1150px;
   }
   @media (min-width: 1550px) {
-    width: 1500px;
+    max-width: 1500px;
   }
 `;
 

--- a/static-site/src/templates/displayMarkdown.jsx
+++ b/static-site/src/templates/displayMarkdown.jsx
@@ -69,7 +69,7 @@ export default class GenericTemplate extends React.Component {
           <title>{title}</title>
         </Helmet>
         <SEO title={title} description={description} blogUrlName={blogUrlName} />
-        <SidebarBodyFlexContainer className="container">
+        <SidebarBodyFlexContainer>
           <SidebarContainer $sidebarOpen={this.state.sidebarOpen}>
             <UserDataWrapper>
               <NavBar minified location={this.props.location} />
@@ -104,7 +104,6 @@ const SidebarBodyFlexContainer = styled.div`
   overflow: hidden;  /*makes the body non-scrollable (we will add scrolling to the sidebar and main content containers)*/
   display: flex;  /*enables flex content for its children*/
   flex-direction: row;
-  width: 100% !important;
 `;
 const SidebarContainer = styled.div`
   flex-grow: 1;  /*ensures that the container will take up the full height of the parent container*/


### PR DESCRIPTION
Follow-up to #958 which caused regressions on blog pages. Noted by @trvrb [on Slack](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1722453675360609).

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] H5N1 blog page [preview](https://nextstrain-s-victorlin--tgjdfb.herokuapp.com/blog/2024-06-18-h5n1-cattle-outbreak-analysis-and-resources) is identical to [production](https://nextstrain.org/blog/2024-06-18-h5n1-cattle-outbreak-analysis-and-resources)
- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
