### PR TITLE
Sort group tiles alphabetically

### DIFF
--- a/static-site/src/components/Groups/Tiles/index.tsx
+++ b/static-site/src/components/Groups/Tiles/index.tsx
@@ -22,20 +22,22 @@ export const GroupTiles = () => {
 
 
 function createGroupTiles(groups: Group[], colors = [...theme.titleColors]): GroupTile[] {
-  return groups.map((group) => {
-    const groupColor = colors[0]!;
-    colors.push(colors.shift()!);
+  return groups
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((group) => {
+      const groupColor = colors[0]!;
+      colors.push(colors.shift()!);
 
-    const tile: GroupTile = {
-      img: "empty.png",
-      url: `/groups/${group.name}`,
-      name: group.name,
-      color: groupColor,
-      private: group.private
-    };
+      const tile: GroupTile = {
+        img: "empty.png",
+        url: `/groups/${group.name}`,
+        name: group.name,
+        color: groupColor,
+        private: group.private
+      };
 
-    return tile;
-  });
+      return tile;
+    });
 }
 
 

--- a/static-site/src/components/Groups/Tiles/index.tsx
+++ b/static-site/src/components/Groups/Tiles/index.tsx
@@ -21,20 +21,22 @@ export const GroupTiles = () => {
 };
 
 
-const createGroupTiles = (groups: Group[], colors = [...theme.titleColors]): GroupTile[] => groups.map((group) => {
-  const groupColor = colors[0]!;
-  colors.push(colors.shift()!);
+function createGroupTiles(groups: Group[], colors = [...theme.titleColors]): GroupTile[] {
+  return groups.map((group) => {
+    const groupColor = colors[0]!;
+    colors.push(colors.shift()!);
 
-  const tile: GroupTile = {
-    img: "empty.png",
-    url: `/groups/${group.name}`,
-    name: group.name,
-    color: groupColor,
-    private: group.private
-  };
+    const tile: GroupTile = {
+      img: "empty.png",
+      url: `/groups/${group.name}`,
+      name: group.name,
+      color: groupColor,
+      private: group.private
+    };
 
-  return tile;
-});
+    return tile;
+  });
+}
 
 
 const Tile = ({ tile }: { tile: GroupTile }) => {


### PR DESCRIPTION
_[preview](https://nextstrain-s-victorlin--3ajzg9.herokuapp.com/groups)_

## Description of proposed changes

There's no good reason to keep the order from the groups.json file and I can't imagine any users finding that order useful. Alphabetical could make it easier to find and see related groups (e.g. public/private pairs that share a prefix).

## Related issue(s)

Closes #953

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] [Preview](https://nextstrain-s-victorlin--3ajzg9.herokuapp.com/groups) looks good
- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
