### PR TITLE
Send Content-Disposition header with our conventional filename in RESTful API responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "chalk": "^2.4.1",
         "compression": "^1.7.3",
         "connect-redis": "^4.0.3",
+        "content-disposition": "^0.5.4",
         "content-type": "^1.0.4",
         "d3": "^7.9.0",
         "debug": "^4.3.4",
@@ -12008,15 +12009,34 @@
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "node_modules/content-disposition": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dependencies": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.1"
       },
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/content-type": {
       "version": "1.0.4",
@@ -14427,6 +14447,17 @@
       "dependencies": {
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
       },
       "engines": {
         "node": ">= 0.6"
@@ -34854,11 +34885,18 @@
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "content-disposition": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
       }
     },
     "content-type": {
@@ -36594,6 +36632,14 @@
           "requires": {
             "mime-types": "~2.1.24",
             "negotiator": "0.6.2"
+          }
+        },
+        "content-disposition": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+          "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+          "requires": {
+            "safe-buffer": "5.1.2"
           }
         },
         "cookie": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "chalk": "^2.4.1",
     "compression": "^1.7.3",
     "connect-redis": "^4.0.3",
+    "content-disposition": "^0.5.4",
     "content-type": "^1.0.4",
     "d3": "^7.9.0",
     "debug": "^4.3.4",

--- a/src/endpoints/sources.js
+++ b/src/endpoints/sources.js
@@ -1,3 +1,5 @@
+import contentDisposition from 'content-disposition';
+
 import { NotFound } from '../httpErrors.js';
 
 import * as authz from '../authz/index.js';
@@ -301,6 +303,8 @@ function sendSubresource(subresourceExtractor) {
     const subresource = subresourceExtractor(req);
 
     authz.assertAuthorized(req.user, authz.actions.Read, subresource.resource);
+
+    res.set("Content-Disposition", contentDisposition(subresource.conventionalFilename));
 
     return await proxyFromUpstream(req, res,
       await subresource.url(),

--- a/src/sources/models.js
+++ b/src/sources/models.js
@@ -343,6 +343,12 @@ class DatasetSubresource extends Subresource {
       ? `${this.resource.baseName}.json`
       : `${this.resource.baseName}_${this.type}.json`;
   }
+
+  get conventionalFilename() {
+    return this.type === "main"
+      ? `${this.resource.pathParts.join("_")}.json`
+      : `${this.resource.pathParts.join("_")}_${this.type}.json`;
+  }
 }
 
 
@@ -389,6 +395,10 @@ class NarrativeSubresource extends Subresource {
 
   get baseName() {
     return `${this.resource.baseName}.md`;
+  }
+
+  get conventionalFilename() {
+    return `${this.resource.pathParts.join("_")}.md`;
   }
 }
 


### PR DESCRIPTION
Useful for downloads not via `nextstrain remote download` that still want to use our conventional file naming.

For example, with curl:

    curl https://nextstrain.org/avian-flu/h5n1/ha/all-time \
        --header 'Accept: application/vnd.nextstrain.dataset.main+json' \
        --remote-name --remote-header-name

    curl https://nextstrain.org/groups/blab/ncov/wa/2m \
        --header 'Accept: application/vnd.nextstrain.dataset.main+json' \
        --remote-name --remote-header-name

and wget:

    wget https://nextstrain.org/avian-flu/h5n1/ha/all-time \
        --header 'Accept: application/vnd.nextstrain.dataset.main+json' \
        --content-disposition

    wget https://nextstrain.org/groups/blab/ncov/wa/2m \
        --header 'Accept: application/vnd.nextstrain.dataset.main+json' \
        --content-disposition

the filenames will be:

    avian-flu_h5n1_ha_all-time.json
    ncov_wa_2m.json

instead of:

    all-time
    2m

This would have been useful in the workaround to a bug I provided¹, and I actually had a WIP branch for this laying around from an earlier time when it occurred to me it would be useful.

¹ <https://discussion.nextstrain.org/t/download-and-rename-all-builds-from-nextstrain-org-groups/1688/2>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
