### PR TITLE
Add page for listing Group members 

### DIFF
--- a/src/endpoints/groups.js
+++ b/src/endpoints/groups.js
@@ -5,6 +5,7 @@ import {contentTypesProvided, contentTypesConsumed} from "../negotiate.js";
 import {deleteByUrls, proxyFromUpstream, proxyToUpstream} from "../upstream.js";
 import { slurp } from "../utils/iterators.js";
 import * as options from "./options.js";
+import * as nextJsApp from "./nextjs.js";
 
 
 const setGroup = (nameExtractor) => (req, res, next) => {
@@ -156,13 +157,16 @@ async function receiveGroupLogo(req, res) {
 
 /* Members and roles
  */
-const listMembers = async (req, res) => {
-  const group = req.context.group;
+const listMembers = contentTypesProvided([
+  ["html", nextJsApp.handleRequest],
+  ["json", async (req, res) => {
+    const group = req.context.group;
+    authz.assertAuthorized(req.user, authz.actions.Read, group);
 
-  authz.assertAuthorized(req.user, authz.actions.Read, group);
-
-  return res.json(await group.members());
-};
+    return res.json(await group.members());
+    }
+  ],
+]);
 
 
 const listRoles = (req, res) => {

--- a/src/groups.js
+++ b/src/groups.js
@@ -69,7 +69,7 @@ class Group {
 
     /**
      * Map of generic roles a member of this Group can hold to fully-qualified
-     * authz roles.
+     * authz roles. The roles should be listed in order from least to most privileged.
      *
      * The fully-qualified names are used in authz policies, and a user's authz
      * roles are stored using membership in AWS Cognito groups of the same

--- a/src/routing/groups.js
+++ b/src/routing/groups.js
@@ -71,18 +71,25 @@ export function setup(app) {
     ;
 
   app.routeAsync("/groups/:groupName/settings/members")
-    .getAsync(endpoints.groups.listMembers);
+    .getAsync(endpoints.groups.listMembers)
+    .optionsAsync(optionsGroup)
+    ;
 
   app.routeAsync("/groups/:groupName/settings/roles")
-    .getAsync(endpoints.groups.listRoles);
+    .getAsync(endpoints.groups.listRoles)
+    .optionsAsync(optionsGroup)
+    ;
 
   app.routeAsync("/groups/:groupName/settings/roles/:roleName/members")
-    .getAsync(endpoints.groups.listRoleMembers);
+    .getAsync(endpoints.groups.listRoleMembers)
+    .optionsAsync(optionsGroup)
+    ;
 
   app.routeAsync("/groups/:groupName/settings/roles/:roleName/members/:username")
     .getAsync(endpoints.groups.getRoleMember)
     .putAsync(endpoints.groups.putRoleMember)
     .deleteAsync(endpoints.groups.deleteRoleMember)
+    .optionsAsync(optionsGroup)
     ;
 
   app.route("/groups/:groupName/settings/*")

--- a/static-site/pages/groups/[...groupName].jsx
+++ b/static-site/pages/groups/[...groupName].jsx
@@ -1,12 +1,14 @@
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 const IndividualGroupPage = dynamic(() => import("../../src/sections/individual-group-page"), {ssr: false})
+const GroupMembersPage = dynamic(() => import("../../src/sections/group-members-page.tsx"), {ssr: false})
 const GroupSettingsPage = dynamic(() => import("../../src/sections/group-settings-page"), {ssr: false})
 
 
 /**
  * NextJS dynamic routing doesn't allow us to set up routes where we have (e.g.)
  * groups/:groupName/settings -> <GroupSettingsPage>
+ * groups/:groupName/settings/members -> <GroupMembersPage>
  * groups/:groupName[/*] -> <IndividualGroupPage>
  * so we use some JS routing here to serve the right component
  */
@@ -20,6 +22,10 @@ const Index = () => {
 
   if (resourcePath === 'settings') {
     return <GroupSettingsPage groupName={groupName}/>
+  }
+
+  if (resourcePath === 'settings/members') {
+    return <GroupMembersPage groupName={groupName}/>
   }
 
   return (

--- a/static-site/pages/groups/[...groupName].jsx
+++ b/static-site/pages/groups/[...groupName].jsx
@@ -14,19 +14,17 @@ const Index = () => {
   const {query} = useRouter();
   if (!query.groupName) return null; // wait until query ready
 
-
-
-
   /* nextJs dynamic routing will set the part parts _beyond_ "groups/" as query.groupName */
-  if (query.groupName.length===2 && query.groupName[1]==='settings') {
+  const groupName = query.groupName[0]
+  const resourcePath = query.groupName.slice(1).join("/")
+
+  if (resourcePath === 'settings') {
     // param location TODO!!!
-    return <GroupSettingsPage groupName={query.groupName[0]}/>
+    return <GroupSettingsPage groupName={groupName}/>
   }
 
-  const resourcePath = query.groupName.slice(1);
-
   return (
-    <IndividualGroupPage groupName={query.groupName[0]} resourcePath={resourcePath.length ? resourcePath : undefined}/>
+    <IndividualGroupPage groupName={groupName} resourcePath={resourcePath.length ? resourcePath : undefined}/>
   );
 
 }

--- a/static-site/pages/groups/[...groupName].jsx
+++ b/static-site/pages/groups/[...groupName].jsx
@@ -20,18 +20,17 @@ const Index = () => {
   const groupName = query.groupName[0]
   const resourcePath = query.groupName.slice(1).join("/")
 
-  if (resourcePath === 'settings') {
-    return <GroupSettingsPage groupName={groupName}/>
+  switch(resourcePath) {
+    case 'settings':
+      return <GroupSettingsPage groupName={groupName}/>
+    case 'settings/members':
+      return <GroupMembersPage groupName={groupName}/>
+    default:
+      return <IndividualGroupPage
+                groupName={groupName}
+                resourcePath={resourcePath.length ? resourcePath : undefined}
+             />
   }
-
-  if (resourcePath === 'settings/members') {
-    return <GroupMembersPage groupName={groupName}/>
-  }
-
-  return (
-    <IndividualGroupPage groupName={groupName} resourcePath={resourcePath.length ? resourcePath : undefined}/>
-  );
-
 }
 
 export default Index;

--- a/static-site/pages/groups/[...groupName].jsx
+++ b/static-site/pages/groups/[...groupName].jsx
@@ -19,7 +19,6 @@ const Index = () => {
   const resourcePath = query.groupName.slice(1).join("/")
 
   if (resourcePath === 'settings') {
-    // param location TODO!!!
     return <GroupSettingsPage groupName={groupName}/>
   }
 

--- a/static-site/src/layouts/generic-page.jsx
+++ b/static-site/src/layouts/generic-page.jsx
@@ -7,13 +7,13 @@ import UserDataWrapper from "../layouts/userDataWrapper";
 import { BigSpacer, HugeSpacer, Line } from "../layouts/generalComponents";
 import * as splashStyles from "../components/splash/styles";
 
-const GenericPage = ({location, children, banner}) => (
+const GenericPage = ({children, banner}) => (
   <MainLayout>
     <div className="index-container">
       <Helmet title={siteTitle} />
       <main>
         <UserDataWrapper>
-          <NavBar location={location} />
+          <NavBar/>
           {banner}
           <splashStyles.Container>
             <HugeSpacer /><HugeSpacer />

--- a/static-site/src/pages/contact.jsx
+++ b/static-site/src/pages/contact.jsx
@@ -5,7 +5,7 @@ import { H1, NarrowFocusParagraph } from "../components/splash/styles";
 
 
 const Contact = props => (
-  <GenericPage location={props.location}>
+  <GenericPage>
       <H1>Contact Us</H1>
 
       <FlexCenter>

--- a/static-site/src/pages/contact.jsx
+++ b/static-site/src/pages/contact.jsx
@@ -4,7 +4,7 @@ import { BigSpacer, FlexCenter} from "../layouts/generalComponents";
 import { H1, NarrowFocusParagraph } from "../components/splash/styles";
 
 
-const Contact = props => (
+const Contact = () => (
   <GenericPage>
       <H1>Contact Us</H1>
 

--- a/static-site/src/pages/groups.jsx
+++ b/static-site/src/pages/groups.jsx
@@ -61,7 +61,7 @@ const GroupListingInfo = () => {
 // GenericPage needs to be a parent of GroupsPage for the latter to know about
 // UserContext, specifically for class functions to be able to use `this.context`.
 // We `export default Index` below.
-const Index = props => (
+const Index = () => (
   <GenericPage>
     <GroupsPage/>
   </GenericPage>

--- a/static-site/src/pages/groups.jsx
+++ b/static-site/src/pages/groups.jsx
@@ -62,7 +62,7 @@ const GroupListingInfo = () => {
 // UserContext, specifically for class functions to be able to use `this.context`.
 // We `export default Index` below.
 const Index = props => (
-  <GenericPage location={props.location}>
+  <GenericPage>
     <GroupsPage/>
   </GenericPage>
 );

--- a/static-site/src/pages/index.jsx
+++ b/static-site/src/pages/index.jsx
@@ -23,7 +23,7 @@ class Index extends React.Component {
           <SEO/>
           <main>
             <UserDataWrapper>
-              <NavBar location={this.props.location} />
+              <NavBar/>
               <Splash/>
             </UserDataWrapper>
           </main>

--- a/static-site/src/pages/team.jsx
+++ b/static-site/src/pages/team.jsx
@@ -65,7 +65,7 @@ const TeamPage = () => {
 };
 
 
-const Team = props => (
+const Team = () => (
   <GenericPage>
     <TeamPage/>
   </GenericPage>

--- a/static-site/src/pages/team.jsx
+++ b/static-site/src/pages/team.jsx
@@ -66,10 +66,9 @@ const TeamPage = () => {
 
 
 const Team = props => (
-  <GenericPage location={props.location}>
+  <GenericPage>
     <TeamPage/>
   </GenericPage>
 );
 
 export default Team;
-

--- a/static-site/src/sections/community-page.jsx
+++ b/static-site/src/sections/community-page.jsx
@@ -72,7 +72,7 @@ class Index extends React.Component {
   render() {
     const banner = this.banner();
     return (
-      <GenericPage location={this.props.location} banner={banner}>
+      <GenericPage banner={banner}>
         <splashStyles.H1>{title}</splashStyles.H1>
         <SmallSpacer />
 

--- a/static-site/src/sections/community-repo-page.jsx
+++ b/static-site/src/sections/community-repo-page.jsx
@@ -85,22 +85,21 @@ class Index extends React.Component {
   }
 
   render() {
-    const location = this.props.location;
     const banner = this.banner();
     if (this.state.repoNotFound) {
       return (
-        <GenericPage location={location} banner={banner} />
+        <GenericPage banner={banner} />
       );
     }
     if (!this.state.sourceInfo) {
       return (
-        <GenericPage location={location} banner={banner}>
+        <GenericPage banner={banner}>
           <splashStyles.H2>Data loading...</splashStyles.H2>
         </GenericPage>
       );
     }
     return (
-      <GenericPage location={location} banner={banner}>
+      <GenericPage banner={banner}>
         <SourceInfoHeading sourceInfo={this.state.sourceInfo}/>
         <HugeSpacer />
         {this.state.sourceInfo.showDatasets && (

--- a/static-site/src/sections/group-members-page.tsx
+++ b/static-site/src/sections/group-members-page.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import styled from "styled-components";
 import { startCase } from "lodash"
 import { uri } from "../../../src/templateLiterals.js";
 import GenericPage from "../layouts/generic-page.jsx";
@@ -82,6 +83,22 @@ const GroupMembersPage = ({ groupName }: {groupName: string}) => {
   )
 };
 
+const MembersTableContainer = styled.div`
+  border: 1px solid #CCC;
+  .row {
+    border-bottom: 1px solid #CCC;
+  }
+  .row:last-child {
+    border-bottom: 0;
+  }
+  .row:nth-child(even) {
+    background-color: #F1F1F1;
+  }
+  p {
+    margin: 10px;
+  }
+`;
+
 const MembersTable = ({ roles, members }: { roles: string[], members: GroupMember[]}) => {
   const sortedMembers = members.toSorted((a, b) => a.username.localeCompare(b.username));
   function mostPrivilegedRole(memberRoles: string[]) {
@@ -93,33 +110,35 @@ const MembersTable = ({ roles, members }: { roles: string[], members: GroupMembe
 
   return (
     <CenteredContainer>
-      <div className="row">
-        <div className="col-6">
-          <splashStyles.CenteredFocusParagraph>
-            <strong>Username</strong>
-          </splashStyles.CenteredFocusParagraph>
+      <MembersTableContainer>
+        <div className="row no-gutters">
+          <div className="col">
+            <splashStyles.CenteredFocusParagraph>
+              <strong>Username</strong>
+            </splashStyles.CenteredFocusParagraph>
+          </div>
+          <div className="col">
+            <splashStyles.CenteredFocusParagraph>
+              <strong>Role</strong>
+            </splashStyles.CenteredFocusParagraph>
+          </div>
         </div>
-        <div className="col-6">
-          <splashStyles.CenteredFocusParagraph>
-            <strong>Role</strong>
-          </splashStyles.CenteredFocusParagraph>
-        </div>
-      </div>
 
-    {sortedMembers.map((member) =>
-      <div className="row" key={member.username}>
-        <div className="col-6">
-          <splashStyles.CenteredFocusParagraph>
-            {member.username}
-          </splashStyles.CenteredFocusParagraph>
-        </div>
-        <div className="col-6">
-          <splashStyles.CenteredFocusParagraph>
-            {mostPrivilegedRole(member.roles)}
-          </splashStyles.CenteredFocusParagraph>
-        </div>
-      </div>
-      )}
+        {sortedMembers.map((member) =>
+          <div className="row no-gutters" key={member.username}>
+            <div className="col">
+              <splashStyles.CenteredFocusParagraph>
+                {member.username}
+              </splashStyles.CenteredFocusParagraph>
+            </div>
+            <div className="col">
+              <splashStyles.CenteredFocusParagraph>
+                {mostPrivilegedRole(member.roles)}
+              </splashStyles.CenteredFocusParagraph>
+            </div>
+          </div>
+        )}
+      </MembersTableContainer>
     </CenteredContainer>
   )
 };

--- a/static-site/src/sections/group-members-page.tsx
+++ b/static-site/src/sections/group-members-page.tsx
@@ -46,7 +46,7 @@ const GroupMembersPage = ({ groupName }: {groupName: string}) => {
         }
       }
       return {roles, members};
-    };
+    }
 
     let ignore = false;
     getGroupMembership(groupName).then(result => {
@@ -86,7 +86,7 @@ const MembersTable = ({ roles, members }: { roles: string[], members: GroupMembe
   function mostPrivilegedRole(memberRoles: string[]) {
     // Assumes that the provided roles are listed in order of least to most privileged
     return memberRoles.reduce((a, b) => roles.indexOf(a) > roles.indexOf(b) ? a : b);
-  };
+  }
 
   return (
     <CenteredContainer>
@@ -134,6 +134,6 @@ export async function canViewGroupMembers(groupName: string) {
     console.error("Cannot check user permissions to view group members", errorMessage);
   }
   return false
-};
+}
 
 export default GroupMembersPage;

--- a/static-site/src/sections/group-members-page.tsx
+++ b/static-site/src/sections/group-members-page.tsx
@@ -77,7 +77,7 @@ const GroupMembersPage = ({ groupName }: {groupName: string}) => {
       <BigSpacer/>
 
       {roles && members
-        ? <MembersTable roles={roles as string[]} members={members as GroupMember[]} />
+        ? <MembersTable members={members as GroupMember[]} />
         : <splashStyles.H4>Fetching group members...</splashStyles.H4>}
     </GenericPage>
   )
@@ -99,13 +99,11 @@ const MembersTableContainer = styled.div`
   }
 `;
 
-const MembersTable = ({ roles, members }: { roles: string[], members: GroupMember[]}) => {
+const MembersTable = ({ members }: { members: GroupMember[]}) => {
   const sortedMembers = members.toSorted((a, b) => a.username.localeCompare(b.username));
-  function mostPrivilegedRole(memberRoles: string[]) {
-    // Assumes that the provided roles are listed in order of least to most privileged
-    const roleName = memberRoles.reduce((a, b) => roles.indexOf(a) > roles.indexOf(b) ? a : b);
-    // Prettify the role name by making it singular and capitalized
-    return startCase(roleName.replace(/s$/, ''));
+  function prettifyRoles(memberRoles: string[]) {
+    // Prettify the role names by making them singular and capitalized
+    return memberRoles.map((roleName) => startCase(roleName.replace(/s$/, ''))).join(", ");
   }
 
   return (
@@ -119,7 +117,7 @@ const MembersTable = ({ roles, members }: { roles: string[], members: GroupMembe
           </div>
           <div className="col">
             <splashStyles.CenteredFocusParagraph>
-              <strong>Role</strong>
+              <strong>Roles</strong>
             </splashStyles.CenteredFocusParagraph>
           </div>
         </div>
@@ -133,7 +131,7 @@ const MembersTable = ({ roles, members }: { roles: string[], members: GroupMembe
             </div>
             <div className="col">
               <splashStyles.CenteredFocusParagraph>
-                {mostPrivilegedRole(member.roles)}
+                {prettifyRoles(member.roles)}
               </splashStyles.CenteredFocusParagraph>
             </div>
           </div>

--- a/static-site/src/sections/group-members-page.tsx
+++ b/static-site/src/sections/group-members-page.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from "react";
+import { uri } from "../../../src/templateLiterals.js";
+import GenericPage from "../layouts/generic-page.jsx";
+import { BigSpacer, CenteredContainer, FlexGridRight, MediumSpacer } from "../layouts/generalComponents.jsx";
+import * as splashStyles from "../components/splash/styles";
+import { ErrorBanner } from "../components/errorMessages.jsx";
+
+interface GroupMember {
+  username: string,
+  roles: string[]
+}
+
+interface ErrorMessage {
+  title: string,
+  contents: string
+}
+
+const GroupMembersPage = ({ groupName }: {groupName: string}) => {
+  const [ errorMessage, setErrorMessage ] = useState<ErrorMessage>({title: "", contents: ""});
+  const [ roles, setRoles ] = useState<string[]>([]);
+  const [ members, setMembers ] = useState<GroupMember[]>([]);
+
+  useEffect(() => {
+    async function getGroupMembership(groupName: string) {
+      const headers = { headers: {"Accept": "application/json"}};
+      let roles, members = [];
+      try {
+        const [ rolesResponse, membersResponse ] = await Promise.all([
+          fetch(uri`/groups/${groupName}/settings/roles`, headers),
+          fetch(uri`/groups/${groupName}/settings/members`, headers)
+        ]);
+        if (!rolesResponse.ok) {
+          throw new Error(`Fetching group roles failed: ${rolesResponse.status} ${rolesResponse.statusText}`)
+        }
+        if (!membersResponse.ok) {
+          throw new Error(`Fetching group members failed: ${membersResponse.status} ${membersResponse.statusText}`)
+        }
+        roles = await rolesResponse.json();
+        members = await membersResponse.json();
+      } catch (err) {
+        const errorMessage = (err as Error).message
+        if(!ignore) {
+          setErrorMessage({
+            title: "An error occurred when trying to fetch group membership data",
+            contents: errorMessage})
+        }
+      }
+      return {roles, members};
+    };
+
+    let ignore = false;
+    getGroupMembership(groupName).then(result => {
+      if (!ignore) {
+        setRoles(result.roles);
+        setMembers(result.members);
+      }
+    })
+    return () => {
+      ignore = true;
+    };
+  }, [groupName]);
+
+  return (
+    <GenericPage banner={errorMessage.title ? <ErrorBanner {...errorMessage} /> : undefined}>
+      <FlexGridRight>
+        <splashStyles.Button to={uri`/groups/${groupName}`}>
+          Return to {`"${groupName}"`} Page
+        </splashStyles.Button>
+      </FlexGridRight>
+      <MediumSpacer/>
+
+      <splashStyles.H2>
+        {`"${groupName}"`} Group Members
+      </splashStyles.H2>
+      <BigSpacer/>
+
+      {roles && members
+        ? <MembersTable roles={roles as string[]} members={members as GroupMember[]} />
+        : <splashStyles.H4>Fetching group members...</splashStyles.H4>}
+    </GenericPage>
+  )
+};
+
+const MembersTable = ({ roles, members }: { roles: string[], members: GroupMember[]}) => {
+  const sortedMembers = members.toSorted((a, b) => a.username.localeCompare(b.username));
+  function mostPrivilegedRole(memberRoles: string[]) {
+    // Assumes that the provided roles are listed in order of least to most privileged
+    return memberRoles.reduce((a, b) => roles.indexOf(a) > roles.indexOf(b) ? a : b);
+  };
+
+  return (
+    <CenteredContainer>
+      <div className="row">
+        <div className="col-6">
+          <splashStyles.CenteredFocusParagraph>
+            <strong>Username</strong>
+          </splashStyles.CenteredFocusParagraph>
+        </div>
+        <div className="col-6">
+          <splashStyles.CenteredFocusParagraph>
+            <strong>Roles</strong>
+          </splashStyles.CenteredFocusParagraph>
+        </div>
+      </div>
+
+    {sortedMembers.map((member) =>
+      <div className="row" key={member.username}>
+        <div className="col-6">
+          <splashStyles.CenteredFocusParagraph>
+            {member.username}
+          </splashStyles.CenteredFocusParagraph>
+        </div>
+        <div className="col-6">
+          <splashStyles.CenteredFocusParagraph>
+            {mostPrivilegedRole(member.roles)}
+          </splashStyles.CenteredFocusParagraph>
+        </div>
+      </div>
+      )}
+    </CenteredContainer>
+  )
+};
+
+export async function canViewGroupMembers(groupName: string) {
+  try {
+    const groupMemberOptions = await fetch(uri`/groups/${groupName}/settings/members`, { method: "OPTIONS"});
+      if ([401, 403].includes(groupMemberOptions.status)) {
+        console.log("You can ignore the console error above; it is used to determine whether the members can be shown.");
+      }
+      const allowedMethods = new Set(groupMemberOptions.headers.get("Allow")?.split(/\s*,\s*/));
+      return allowedMethods.has("GET");
+  } catch (err) {
+    const errorMessage = (err as Error).message
+    console.error("Cannot check user permissions to view group members", errorMessage);
+  }
+  return false
+};
+
+export default GroupMembersPage;

--- a/static-site/src/sections/group-members-page.tsx
+++ b/static-site/src/sections/group-members-page.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { startCase } from "lodash"
 import { uri } from "../../../src/templateLiterals.js";
 import GenericPage from "../layouts/generic-page.jsx";
 import { BigSpacer, CenteredContainer, FlexGridRight, MediumSpacer } from "../layouts/generalComponents.jsx";
@@ -85,7 +86,9 @@ const MembersTable = ({ roles, members }: { roles: string[], members: GroupMembe
   const sortedMembers = members.toSorted((a, b) => a.username.localeCompare(b.username));
   function mostPrivilegedRole(memberRoles: string[]) {
     // Assumes that the provided roles are listed in order of least to most privileged
-    return memberRoles.reduce((a, b) => roles.indexOf(a) > roles.indexOf(b) ? a : b);
+    const roleName = memberRoles.reduce((a, b) => roles.indexOf(a) > roles.indexOf(b) ? a : b);
+    // Prettify the role name by making it singular and capitalized
+    return startCase(roleName.replace(/s$/, ''));
   }
 
   return (
@@ -98,7 +101,7 @@ const MembersTable = ({ roles, members }: { roles: string[], members: GroupMembe
         </div>
         <div className="col-6">
           <splashStyles.CenteredFocusParagraph>
-            <strong>Roles</strong>
+            <strong>Role</strong>
           </splashStyles.CenteredFocusParagraph>
         </div>
       </div>

--- a/static-site/src/sections/group-settings-page.jsx
+++ b/static-site/src/sections/group-settings-page.jsx
@@ -12,7 +12,7 @@ const UNAUTHORIZED_MESSAGE = <>
   If your permissions have changed recently, try <a href="/logout">logging out</a> and logging back in.<br/>
 </>;
 
-const EditGroupSettingsPage = ({ location, groupName }) => {
+const EditGroupSettingsPage = ({ groupName }) => {
   const [ userAuthorized, setUserAuthorized ] = useState(null);
   const [ errorMessage, setErrorMessage ] = useState();
 
@@ -39,7 +39,7 @@ const EditGroupSettingsPage = ({ location, groupName }) => {
   };
 
   return (
-    <GenericPage location={location}>
+    <GenericPage>
       <FlexGridRight>
         <splashStyles.Button to={uri`/groups/${groupName}`}>
           Return to {`"${groupName}"`} Page

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -88,22 +88,21 @@ class Index extends React.Component {
   }
 
   render() {
-    const location = this.props.location;
     const banner = this.banner();
     if (this.state.groupNotFound) {
       return (
-        <GenericPage location={location} banner={banner} />
+        <GenericPage banner={banner} />
       );
     }
     if (!this.state.sourceInfo) {
       return (
-        <GenericPage location={location} banner={banner}>
+        <GenericPage banner={banner}>
           <splashStyles.H2>Data loading...</splashStyles.H2>
         </GenericPage>
       );
     }
     return (
-      <GenericPage location={location} banner={banner}>
+      <GenericPage banner={banner}>
         {this.state.editGroupSettingsAllowed && (
           <FlexGridRight>
             <splashStyles.Button to={`/groups/${this.state.groupName}/settings`}>

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -9,6 +9,7 @@ import { fetchAndParseJSON } from "../util/datasetsHelpers";
 import SourceInfoHeading from "../components/sourceInfoHeading";
 import { ErrorBanner } from "../components/errorMessages";
 import { canUserEditGroupSettings } from "./group-settings-page";
+import { canViewGroupMembers } from "./group-members-page";
 
 class Index extends React.Component {
   constructor(props) {
@@ -17,7 +18,8 @@ class Index extends React.Component {
     this.state = {
       groupNotFound: false,
       nonExistentPath: this.props.resourcePath,
-      editGroupSettingsAllowed: false
+      editGroupSettingsAllowed: false,
+      viewGroupMembersAllowed: false,
     };
   }
 
@@ -44,6 +46,7 @@ class Index extends React.Component {
         sourceInfo,
         groupName,
         editGroupSettingsAllowed: await canUserEditGroupSettings(groupName),
+        viewGroupMembersAllowed: await canViewGroupMembers(groupName),
         datasets: this.createDatasetListing(availableData.datasets, groupName),
         narratives: this.createDatasetListing(availableData.narratives, groupName),
       });
@@ -103,13 +106,23 @@ class Index extends React.Component {
     }
     return (
       <GenericPage banner={banner}>
-        {this.state.editGroupSettingsAllowed && (
-          <FlexGridRight>
-            <splashStyles.Button to={`/groups/${this.state.groupName}/settings`}>
-              Edit Group Settings
-            </splashStyles.Button>
-          </FlexGridRight>
-        )}
+        <FlexGridRight>
+          {this.state.viewGroupMembersAllowed && (
+            <div style={{ margin: "10px" }}>
+              <splashStyles.Button to={`/groups/${this.state.groupName}/settings/members`}>
+                Group Members
+              </splashStyles.Button>
+            </div>
+          )}
+          {this.state.editGroupSettingsAllowed && (
+            <div style={{ margin: "10px" }}>
+              <splashStyles.Button to={`/groups/${this.state.groupName}/settings`}>
+                Edit Group Settings
+              </splashStyles.Button>
+            </div>
+          )}
+        </FlexGridRight>
+
         <SourceInfoHeading sourceInfo={this.state.sourceInfo}/>
         <HugeSpacer />
         {this.state.sourceInfo.showDatasets && (

--- a/static-site/src/sections/individual-group-page.jsx
+++ b/static-site/src/sections/individual-group-page.jsx
@@ -16,7 +16,7 @@ class Index extends React.Component {
     configureAnchors({ offset: -10 });
     this.state = {
       groupNotFound: false,
-      nonExistentPath: this.props.resourcePath?.join("/"),
+      nonExistentPath: this.props.resourcePath,
       editGroupSettingsAllowed: false
     };
   }

--- a/static-site/src/sections/pathogens.jsx
+++ b/static-site/src/sections/pathogens.jsx
@@ -36,7 +36,7 @@ const resourceListingCallback = async () => {
 class Index extends React.Component {
   render() {
     return (
-      <GenericPage location={this.props.location}>
+      <GenericPage>
         <splashStyles.H1>{title}</splashStyles.H1>
         <SmallSpacer />
 

--- a/static-site/src/sections/sars-cov-2-forecasts-page.jsx
+++ b/static-site/src/sections/sars-cov-2-forecasts-page.jsx
@@ -48,7 +48,7 @@ const acknowledgement = (
 
 function Index(props) {
   return (
-    <GenericPage location={props.location}>
+    <GenericPage>
       <splashStyles.H1>{title}</splashStyles.H1>
       <SmallSpacer />
 

--- a/static-site/src/sections/sars-cov-2-forecasts-page.jsx
+++ b/static-site/src/sections/sars-cov-2-forecasts-page.jsx
@@ -46,7 +46,7 @@ const acknowledgement = (
   </>
 )
 
-function Index(props) {
+function Index() {
   return (
     <GenericPage>
       <splashStyles.H1>{title}</splashStyles.H1>

--- a/static-site/src/sections/sars-cov-2-page.jsx
+++ b/static-site/src/sections/sars-cov-2-page.jsx
@@ -188,7 +188,7 @@ class Index extends React.Component {
   render() {
     const banner = this.banner();
     return (
-      <GenericPage location={this.props.location} banner={banner}>
+      <GenericPage banner={banner}>
         <splashStyles.H1>{title}</splashStyles.H1>
         <SmallSpacer />
 

--- a/static-site/src/sections/staging-page.jsx
+++ b/static-site/src/sections/staging-page.jsx
@@ -63,7 +63,7 @@ class Index extends React.Component {
   render() {
     const banner = this.banner();
     return (
-      <GenericPage location={this.props.location} banner={banner}>
+      <GenericPage banner={banner}>
         <splashStyles.H1>{title}</splashStyles.H1>
         <SmallSpacer />
 

--- a/static-site/src/templates/displayMarkdown.jsx
+++ b/static-site/src/templates/displayMarkdown.jsx
@@ -72,7 +72,7 @@ export default class GenericTemplate extends React.Component {
         <SidebarBodyFlexContainer>
           <SidebarContainer $sidebarOpen={this.state.sidebarOpen}>
             <UserDataWrapper>
-              <NavBar minified location={this.props.location} />
+              <NavBar minified/>
             </UserDataWrapper>
             <Sidebar
               title="BLOG"


### PR DESCRIPTION
## Description of proposed changes

The new page is available at `groups/<groupName>/settings/members`. I chose to use the same URL as the API so that we don't have to take up another namespace (e.g. `groups/<groupName>/members`). The main Group page will only link out to the members page if the current user is authorized to list Group members.

The members list only displays the most privileged role for each member to keep the display simple. It assumes the group roles API returns the roles in the order from least to most privileged.

The plan is to make future changes to this page to allow Group owners to edit members here as well. I'm making that a separate change to keep this PR simple. 

## Related issue(s)

Related to #804 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
