### PR TITLE
Temporarily bypass broken resource indexer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,12 +115,14 @@ jobs:
     uses: ./.github/workflows/index-resources.yml
     secrets: inherit
 
+  # TODO: remove resource-indexer failure bypass once it is fixed:
+  # <https://github.com/nextstrain/nextstrain.org/issues/975>
   deploy:
     if: |2
          !cancelled()
       && needs.build.result == 'success'
       && needs.test.result == 'success'
-      && contains(fromJSON('["success", "skipped"]'), needs.index-resources.result)
+      && contains(fromJSON('["success", "skipped", "failure"]'), needs.index-resources.result)
       && github.repository == 'nextstrain/nextstrain.org'
       && (   (github.event_name == 'push' && github.ref == 'refs/heads/master')
           || (github.event_name == 'workflow_dispatch' && inputs.heroku-app) )


### PR DESCRIPTION
## Description of proposed changes

Reasoning in added comment.

## Related issue(s)

Workaround for #975

## Checklist

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
- [ ] Post-merge: deploy is successful

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
