### PR TITLE
Support multiple inventory files

### DIFF
--- a/env/production/config.json
+++ b/env/production/config.json
@@ -110,5 +110,5 @@
   "OIDC_GROUPS_CLAIM": "cognito:groups",
   "SESSION_COOKIE_DOMAIN": "nextstrain.org",
   "GROUPS_DATA_FILE": "groups.json",
-  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v2.json.gz"
+  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v3.json.gz"
 }

--- a/env/testing/config.json
+++ b/env/testing/config.json
@@ -108,5 +108,5 @@
   "OIDC_USERNAME_CLAIM": "cognito:username",
   "OIDC_GROUPS_CLAIM": "cognito:groups",
   "GROUPS_DATA_FILE": "groups.json",
-  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v2.json.gz"
+  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v3.json.gz"
 }


### PR DESCRIPTION
## Description of proposed changes

This is necessary for the core collection inventory which is now split into 2 files.

## Related issue(s)

- #975

## Checklist

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
- [x] Local runs are successful ([ref](https://github.com/nextstrain/nextstrain.org/pull/979#issuecomment-2278879109))
- [x] Rebuild index job is successful ([ref](https://github.com/nextstrain/nextstrain.org/actions/runs/10327086205/job/28591692144))

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
