### PR TITLE
Fix _localInventoryPath JSDoc

### DIFF
--- a/resourceIndexer/inventory.js
+++ b/resourceIndexer/inventory.js
@@ -303,8 +303,9 @@ function _localManifestPath(name) {
 
 /**
  * Returns the local filepath for the inventory associated with this collection
- * @param {string} name Collection name
- * @param {string} key Inventory key from the manifest
+ * @param {Object} param
+ * @param {string} param.name Collection name
+ * @param {string} param.key Inventory key from the manifest
  * @returns {string} inventory path name
  */
 function _localInventoryPath({ name, key }) {


### PR DESCRIPTION
## Description of proposed changes

Follow-up to "Derive inventory path from key in manifest" (4b2257cb).

Caught by @jameshadfield in review: https://github.com/nextstrain/nextstrain.org/pull/979#discussion_r1713066094

## Checklist

- [ ] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
    - There is a change in `resourceIndexer/*` however it is a non-functional change which shouldn't require version bump.