### PR TITLE
Always use production config.json in index-resources GH Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       - run: npm ci
       - run: npm run lint:server
       - run: npm run lint:static-site
+      - run: node ./scripts/check-resource-index-match.js
 
   # Build into Heroku slug so we can deploy the same build that we test.
   build:

--- a/.github/workflows/index-resources.yml
+++ b/.github/workflows/index-resources.yml
@@ -44,6 +44,8 @@ jobs:
         env:
           HEROKU_TOKEN: ${{ secrets.HEROKU_TOKEN_READ_PROTECTED }}
           IS_WORKFLOW_CALL: ${{ inputs.is-workflow-call || false }}
+          # Ensure that we are using the production configs to match Heroku apps
+          CONFIG_FILE: ./env/production/config.json
         run: |
           # Assign to variable before output to ensure error exit code propagates to GH Action job
           ref_matrix=$(./scripts/get-resource-index-ref-matrix)

--- a/docs/resource-collection.rst
+++ b/docs/resource-collection.rst
@@ -22,7 +22,8 @@ The nextstrain.org testing & production configs currently set this to
 ``s3://nextstrain-inventories/resources/v<revision_number>.json.gz``.
 
 If you make any updates that changes the structure or the contents of the resource
-index JSON, then bump the ``<revision_number>`` within the configs (``env/production/config.json``)
+index JSON, then bump the ``<revision_number>`` within the configs
+(``env/testing/config.json`` and ``env/production/config.json``)
 so that any uploads to S3 does not disrupt the production server.
 
 These updates include changes to:

--- a/scripts/check-resource-index-match.js
+++ b/scripts/check-resource-index-match.js
@@ -1,0 +1,16 @@
+import { readFileSync } from "fs";
+
+const PRODUCTION_CONFIG = "env/production/config.json";
+const TESTING_CONFIG = "env/testing/config.json";
+const RESOURCE_INDEX = "RESOURCE_INDEX";
+
+const production_index = JSON.parse(readFileSync(PRODUCTION_CONFIG, 'utf8'))[RESOURCE_INDEX]
+const testing_index = JSON.parse(readFileSync(TESTING_CONFIG, 'utf8'))[RESOURCE_INDEX]
+
+if (production_index !== testing_index) {
+    console.error(`ERROR: Please make sure ${PRODUCTION_CONFIG} and ${TESTING_CONFIG} have the same ${RESOURCE_INDEX}!"`)
+    process.exit(1);
+} else {
+    console.log(`Confirmed ${PRODUCTION_CONFIG} and ${TESTING_CONFIG} have the same ${RESOURCE_INDEX}`);
+    process.exit(0);
+}


### PR DESCRIPTION
## Description of proposed changes

Ensures that the index-resource workflow always uses the production config as our Heroku apps default to NODE_ENV=production.¹

¹ <https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/infrastructure.html#environment-or-config-variables>

## Related issue(s)

Resolves https://github.com/nextstrain/nextstrain.org/issues/980

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
