### PR TITLE
Use Heroku-22 stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     container:
-      image: heroku/heroku:20
+      image: heroku/heroku:22
     env:
       # Override NODE_ENV=production default in production build (slug)
       NODE_ENV: development

--- a/scripts/heroku-build
+++ b/scripts/heroku-build
@@ -64,11 +64,11 @@ docker run \
   --volume "$(realpath build/cache)":/build/cache:rw \
   --volume "$(realpath build/env)":/build/env:ro \
   --env HOME=/tmp \
-  --env STACK=heroku-20 \
+  --env STACK=heroku-22 \
   --env SOURCE_VERSION \
   --env SOURCE_DESCRIPTION \
   --env NODE_MODULES_CACHE=false \
-  heroku/heroku:20-build bash -c '
+  heroku/heroku:22-build bash -c '
        /build/pack/bin/detect  /build/app \
     && /build/pack/bin/compile /build/app /build/cache /build/env
   '
@@ -115,7 +115,7 @@ jq \
   --argjson procfile "$(<build/app/Procfile.json)" \
   --arg checksum "$(awk '{print "SHA256:" $1}' build/slug.tar.gz.sha256sum)" \
   '{
-    "stack": "heroku-20",
+    "stack": "heroku-22",
     "commit": $ENV.SOURCE_VERSION,
     "commit_description": $ENV.SOURCE_DESCRIPTION,
     "process_types": $procfile,

--- a/scripts/heroku-exec
+++ b/scripts/heroku-exec
@@ -47,5 +47,5 @@ docker run \
   --env HOME=/app \
   --env BASH_ENV=/app/.heroku/BASH_ENV \
   "${docker_args[@]:0}" \
-  heroku/heroku:20 \
+  heroku/heroku:22 \
     bash -c -- 'exec "$@"' "$1" "$@"


### PR DESCRIPTION
## Description of proposed changes

The Heroku-20 stack is deprecated and we have been bombarded with warnings and messages from Heroku telling us to upgrade.

<https://help.heroku.com/NPN275RK/heroku-20-end-of-life-faq>

## Related issue(s)

- #974

## Checklist

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
- [ ] Post-merge: deploy succeeds and site looks ok

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
