### PR TITLE
group-members-page: Replace `toSorted()` with shallow copy + `sort()`

### DIFF
--- a/static-site/src/sections/group-members-page.tsx
+++ b/static-site/src/sections/group-members-page.tsx
@@ -100,7 +100,7 @@ const MembersTableContainer = styled.div`
 `;
 
 const MembersTable = ({ members }: { members: GroupMember[]}) => {
-  const sortedMembers = members.toSorted((a, b) => a.username.localeCompare(b.username));
+  const sortedMembers = [...members].sort((a, b) => a.username.localeCompare(b.username));
   function prettifyRoles(memberRoles: string[]) {
     // Prettify the role names by making them singular and capitalized
     return memberRoles.map((roleName) => startCase(roleName.replace(/s$/, ''))).join(", ");


### PR DESCRIPTION
## Description of proposed changes

I didn't realize that `toSorted` is a relatively new method that is not supported in older browser versions.¹

Thanks to @tsibley for using an old version of FireFox and catching this.

¹ <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted#browser_compatibility>

## Related issue(s)

Follow up to https://github.com/nextstrain/nextstrain.org/pull/973

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
