### PR TITLE
Auto-prepend `/` to tile URLs

### DIFF
--- a/static-site/content/featured-analyses.yaml
+++ b/static-site/content/featured-analyses.yaml
@@ -3,7 +3,6 @@
 #   rendered on the splash page.
 # - When adding or modifying descriptions, ensure it takes up at most two lines
 #   when rendered on the splash page.
-# - Ensure URLs start with `/`.
 
 - name: Mpox in the DRC
   description: INRB analysis of ongoing mpox clade I outbreak in the DRC

--- a/static-site/src/components/splash/index.tsx
+++ b/static-site/src/components/splash/index.tsx
@@ -255,6 +255,10 @@ function TileSourceIcon({ url, isNarrative }: {
 
   let maintainers: string, image: React.JSX.Element;
 
+  if (!url.startsWith('/')) {
+    url = '/' + url;
+  }
+
   if (url.startsWith('/community')) {
     const owner = isNarrative ? url.split('/')[3] : url.split('/')[2];
     maintainers = `${owner} on GitHub`;


### PR DESCRIPTION
## Description of proposed changes

Previously, the code assumed that all URLs started with `/` and was noted in featured-analyses.yaml. However, there was nothing to check this. A `/` is perfectly valid for everything except for the source check, which silently assumes everything that doesn't start with `/` is maintained by Nextstrain. This is a bad assumption.

The source check could either (1) be updated to work with the error or (2) throw a runtime error. I chose to go with (1) to make things easier when updating featured analyses.

## Related issue(s)

Follow-up to https://github.com/nextstrain/nextstrain.org/pull/993#discussion_r1729422975

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
- [x] Manually reverting 7a93cbd1c8bb1f71c86824f70572f7e42fcf9e3e still shows the correct source icon

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
