### PR TITLE
Remove PreviewOverlay when expanded

### DIFF
--- a/static-site/src/components/ExpandableTiles/index.tsx
+++ b/static-site/src/components/ExpandableTiles/index.tsx
@@ -46,7 +46,7 @@ export const ExpandableTiles = <AnyTile extends Tile>({tiles, tileWidth, tileHei
             return <TileComponent tile={el} key={el.name} />
           })}
         </TilesContainer>
-        <PreviewOverlay onClick={toggleExpand} className={!isExpandable || isExpanded ? "hidden" : "visible"} />
+        {isExpandable && !isExpanded && <PreviewOverlay onClick={toggleExpand} />}
       </ExpandableContainer>
       {isExpandable && <>
         <ArrowButton onClick={toggleExpand}>
@@ -97,16 +97,6 @@ const PreviewOverlay = styled.div`
   width: 100%;
   height: ${expandPreviewHeight}px;
   cursor: pointer;
-
-  &.visible {
-    opacity: 1;
-  }
-
-  &.hidden {
-    opacity: 0;
-  }
-
-  transition: opacity ${transitionDuration} ${transitionTimingFunction};
 `;
 
 const TilesContainer = styled.div<{$tileWidth: number}>`


### PR DESCRIPTION
In all current usages of ExpandableTiles, it is possible for and sometimes even expected for users to interact with tiles by clicking. Having an invisible overlay on top of the last row of tiles with a separate onClick behavior can be confusing for users expecting another onClick behavior.

When the tiles are expanded, the only benefit to having PreviewOverlay available is for the onClick behavior of hiding the tiles. This can already be accomplished by the ArrowButton which also covers full width and has a height of 1em.

This removes the opacity transition, which in my eyes does not make a noticeable difference. The visually distinct part of the transition action is on the height change to show more rows of tiles, not the opacity here.

## Related issues

Closes #1010

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Bug cannot be reproduced in review app
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
