### PR TITLE
Add support for `sidebarTitle` value in blog post frontmatter; fix existing blog sidebar titles [#1005]

### DIFF
--- a/static-site/content/blog/2018-05-14-new-nextstrain-website.md
+++ b/static-site/content/blog/2018-05-14-new-nextstrain-website.md
@@ -2,6 +2,7 @@
 author: "James Hadfield"
 date: "2018-05-14"
 title: "New nextstrain.org website"
+sidebarTitle: "New Nextstrain Website"
 ---
 
 The data visualisation aspect of nextstrain.org has been under a lot of development over the last year, with new features and new datasets, but we've fallen behind with documentation and explanations of everything that's going on.

--- a/static-site/content/blog/2019-10-21-auspice-v2.md
+++ b/static-site/content/blog/2019-10-21-auspice-v2.md
@@ -2,7 +2,7 @@
 author: "James Hadfield"
 date: "2019-10-21"
 title: "Auspice v2 released"
-anchorText: "Auspice v2"
+sidebarTitle: "Auspice v2"
 ---
 
 ## What's New

--- a/static-site/content/blog/2019-10-21-auspice-v2.md
+++ b/static-site/content/blog/2019-10-21-auspice-v2.md
@@ -181,7 +181,7 @@ See [requests made from the client](https://nextstrain.github.io/auspice/customi
 ## Improvements in the entropy panel
 
 We improved the usability of the entropy (genomic diversity) panel, as well as fixing a few hidden bugs -- see [PR #771](https://github.com/nextstrain/auspice/pull/771).
-For instance, you can now see which codon a nucleotide codes for (and vice-versa). 
+For instance, you can now see which codon a nucleotide codes for (and vice-versa).
 
 ![entropy](img/v2-entropy.gif)
 

--- a/static-site/content/blog/2019-10-31-using-narratives-to-explain-west-nile-virus-spread.md
+++ b/static-site/content/blog/2019-10-31-using-narratives-to-explain-west-nile-virus-spread.md
@@ -1,5 +1,6 @@
 ---
 title: Using Nextstrain narratives to explain WNV spread and evolution
+sidebarTitle: Using Narratives To Explain West Nile Virus Spread
 date: "2019-10-31"
 author: James Hadfield
 ---

--- a/static-site/content/blog/2020-06-02-SARSCoV2-clade-naming.md
+++ b/static-site/content/blog/2020-06-02-SARSCoV2-clade-naming.md
@@ -2,6 +2,7 @@
 author: "Emma B Hodcroft, James Hadfield, Richard A Neher, Trevor Bedford"
 date: "2020-06-02"
 title: "Year-letter Genetic Clade Naming for SARS-CoV-2 on Nextstrain.org"
+sidebarTitle: "SARS-CoV-2 Clade Naming"
 ---
 
 Nextstrain provides clade or lineage information for a number of pathogens it already tracks, including influenza and enterovirus D68. Nextstrain also introduced informal clade designations for SARS-CoV-2 on 4 March 2020, largely to aid internal discussions and to create URL links allowing ‘automatic zoom’ to an area of the tree that was of interest. These clades names were ad-hoc letter-number combinations (e.g. A2a) and were never intended to be a permanent naming system (and never visible by default). Nevertheless, these clades have been used by some to discuss different aspects of the phylogeny on Nextstrain, underscoring the need for a more long-term, formal proposal to designate SARS-CoV-2 clades.

--- a/static-site/content/blog/2021-01-06-updated-SARS-CoV-2-clade-naming.md
+++ b/static-site/content/blog/2021-01-06-updated-SARS-CoV-2-clade-naming.md
@@ -2,6 +2,7 @@
 author: "Trevor Bedford, Emma B Hodcroft, Richard A Neher"
 date: "2021-01-06"
 title: "Updated Nextstrain SARS-CoV-2 clade naming strategy"
+sidebarTitle: "Updated SARS-CoV-2 Clade Naming"
 ---
 
 The emerging 501Y.V1 and 501Y.V2 variants have pushed the Nextstrain team to revise our strategy for Nextstrain clade labels. Here, we propose a backwards-compatible update to make clades more adaptable to the continuing pandemic situation, and more useful to people working on the pandemic today.

--- a/static-site/content/blog/2021-07-08-ncov-open-announcement.md
+++ b/static-site/content/blog/2021-07-08-ncov-open-announcement.md
@@ -2,6 +2,7 @@
 author: "Trevor Bedford, James Hadfield, Emma Hodcroft, John Huddleston, Richard Neher, Thomas Sibley"
 date: "2021-07-08"
 title: "Extension of SARS-CoV-2 data processing to incorporate Open Data through GenBank"
+sidebarTitle: "Ncov Open Announcement"
 ---
 
 Progress towards large-scale real-time genomic surveillance of SARS-CoV-2 has been remarkable with over 2 million viral genomes shared to [GISAID](https://www.gisaid.org/) from all over the world since Jan 2020. This has allowed detailed tracking of the [emergence and spread of variants of concern](https://www.who.int/en/activities/tracking-SARS-CoV-2-variants/) and is an essential pandemic response activity. In an unprecedented collective effort, these data were shared by hundreds of laboratories from all over the world, often within days or weeks of sample collection, and curated by GISAID. Such early sharing of unpublished data requires certain guarantees that submitters get credit for their contributions and a chance to publish on their data. Sequences submitted to the GISAID EpiCoV database are shared under [Terms of Use](https://www.gisaid.org/registration/terms-of-use/) that restrict resharing of sequence data or metadata.

--- a/static-site/content/blog/2022-04-29-SARS-CoV-2-clade-naming-2022.md
+++ b/static-site/content/blog/2022-04-29-SARS-CoV-2-clade-naming-2022.md
@@ -18,7 +18,7 @@ Our revised set of guidelines will therefore now be to designate a clade when an
   2. A clade reaches >20% global frequency for 2 or more months
   3. A clade reaches >30% regional frequency for 2 or more months
   4. A clade shows consistent >0.05 per day growth in frequency where it's circulating and has reached >5% regional frequency
-  
+
 Additionally, for points 2, 3, and 4, we require the clade to show multiple mutations in S1 or particular mutations of known biological relevance.
 
 As a result of this, we are designating 3 new Nextstrain clades:

--- a/static-site/content/blog/2022-04-29-SARS-CoV-2-clade-naming-2022.md
+++ b/static-site/content/blog/2022-04-29-SARS-CoV-2-clade-naming-2022.md
@@ -2,6 +2,7 @@
 author: "Cornelius Roemer, Emma B Hodcroft, Richard A Neher, Trevor Bedford"
 date: "2022-04-29"
 title: "SARS-CoV-2 clade naming strategy for 2022"
+sidebarTitle: "SARS-CoV-2 clade naming 2022"
 ---
 
 The rapid dominance and increased diversity of the Omicron variant and its constituent sub-lineages has triggered another update of the Nextstrain clade naming guidelines and labels. Once again, we propose a backwards-compatible update, this time to allow more flexible and faster designation of clades as new variants appear and spread.

--- a/static-site/content/blog/2024-03-27-annual-update-march-2024.md
+++ b/static-site/content/blog/2024-03-27-annual-update-march-2024.md
@@ -2,6 +2,7 @@
 author: "Nextstrain team"
 date: "2024-03-27"
 title: "Nextstrain Annual Update March 2024"
+sidebarTitle: "Annual Update March 2024"
 ---
 
 _The nextstrain.org blog has not seen a lot of use lately. Here we're piloting an effort to post annual updates._

--- a/static-site/content/blog/2024-06-12-new-resources-for-measles.md
+++ b/static-site/content/blog/2024-06-12-new-resources-for-measles.md
@@ -2,6 +2,7 @@
 author: "Kim Andrews, Jover Lee, James Hadfield, Jennifer Chang, Trevor Bedford"
 date: "2024-06-12"
 title: "New Resources for Measles Virus"
+sidebarTitle: "New Resources for Measles"
 ---
 
 We now provide regularly updated phylogenetic monitoring of measles virus at [nextstrain.org/measles](https://nextstrain.org/measles). This site displays phylogenies generated using genomic data from NCBI GenBank, and is updated daily when new sequences are uploaded to NCBI. You can choose to display one of two different phylogenies based on the following data types:

--- a/static-site/content/blog/2024-06-18-h5n1-cattle-outbreak-analysis-and-resources.md
+++ b/static-site/content/blog/2024-06-18-h5n1-cattle-outbreak-analysis-and-resources.md
@@ -2,6 +2,7 @@
 author: "Trevor Bedford, Jover Lee, James Hadfield, John Huddleston, Louise Moncla"
 date: "2024-06-18"
 title: "Phylogenetic analysis of H5N1 cattle outbreak and curated genomic data"
+sidebarTitle: "H5N1 Cattle Outbreak Analysis and Resources"
 ---
 
 # Phylogenetic analysis

--- a/static-site/content/blog/2024-09-03-augur-v25-features.md
+++ b/static-site/content/blog/2024-09-03-augur-v25-features.md
@@ -2,6 +2,7 @@
 author: "The Nextstrain team"
 date: "2024-09-03"
 title: "Notable changes in Augur v25"
+sidebarTitle: "Augur v25 features"
 ---
 
 The Nextstrain team has released several new versions of Augur – our

--- a/static-site/pages/blog.jsx
+++ b/static-site/pages/blog.jsx
@@ -19,7 +19,7 @@ export default function Index({redirectTo}) {
 
 /**
  * Return the URL for the latest blog post
- * 
+ *
  * Note that we cannot return a redirect property here as that's not
  * useable for statically generated sites. See
  * <https://nextjs.org/docs/pages/api-reference/functions/get-static-props#redirect>

--- a/static-site/pages/blog/[id].jsx
+++ b/static-site/pages/blog/[id].jsx
@@ -23,11 +23,11 @@ export const getStaticPaths = (async () => {
     fallback: false // any paths not defined will result in a 404 page
   }
 })
- 
+
 /**
  * For a given id (matching the route /blog/id via the dynamic routing filename `blog/[id].jsx`)
  * return the params to be parsed to the rendering component.
- * 
+ *
  * Note: The context.params.id is set to one of the entries in the array returned from
  * `getStaticPaths`. See <https://nextjs.org/docs/pages/api-reference/functions/get-static-props>
  */

--- a/static-site/pages/blog/[id].jsx
+++ b/static-site/pages/blog/[id].jsx
@@ -35,7 +35,7 @@ export const getStaticProps = (async (context) => {
   const posts = getBlogPosts();
   const thisPost = posts.find((post) => post.blogUrlName===context.params.id);
   const sidebarData = posts.map((post) => {
-    return {date: post.date, blogUrlName: post.blogUrlName, sidebarName: post.sidebarName, selected: post===thisPost};
+    return {date: post.date, blogUrlName: post.blogUrlName, sidebarTitle: post.sidebarTitle, selected: post===thisPost};
   })
   return {
     props: {...thisPost, sidebarData}

--- a/static-site/src/components/Sidebar/index.jsx
+++ b/static-site/src/components/Sidebar/index.jsx
@@ -7,7 +7,7 @@ const Sidebar = ({title, posts}) => {
       <SectionTitle>{title.toUpperCase()}</SectionTitle>
       <ul>
         {posts.map((post) => (
-          <IndividualPost {...post} key={post.sidebarName}/>
+          <IndividualPost {...post} key={post.sidebarTitle}/>
         ))}
       </ul>
       <div style={{paddingBottom: "30px"}}/>
@@ -15,14 +15,14 @@ const Sidebar = ({title, posts}) => {
   );
 }
 
-const IndividualPost = ({blogUrlName, sidebarName, selected}) => {
+const IndividualPost = ({blogUrlName, sidebarTitle, selected}) => {
   return (
-    <ItemContainer key={sidebarName}>
+    <ItemContainer key={sidebarTitle}>
       <a href={`/blog/${blogUrlName}`}>
         <li>
           {selected ?
-            (<SelectedPostTitle>{sidebarName}</SelectedPostTitle>) :
-            (<UnselectedPostTitle>{sidebarName}</UnselectedPostTitle>)
+            (<SelectedPostTitle>{sidebarTitle}</SelectedPostTitle>) :
+            (<UnselectedPostTitle>{sidebarTitle}</UnselectedPostTitle>)
           }
         </li>
       </a>

--- a/static-site/src/util/blogPosts.js
+++ b/static-site/src/util/blogPosts.js
@@ -13,7 +13,7 @@ export function getBlogPosts() {
   const postsDirectory = path.join(__dirname, "..", "..", "content", "blog")
   const markdownFiles = fs.readdirSync(postsDirectory)
     .filter((fileName) => fileName.endsWith(".md"));
-  
+
   const blogPosts = markdownFiles.map((fileName) => {
     const {data: frontmatter, content: mdstring, isEmpty} = matter(
       fs.readFileSync(path.join(postsDirectory, fileName), 'utf8')
@@ -37,4 +37,3 @@ export function getBlogPosts() {
 
   return blogPosts;
 }
-


### PR DESCRIPTION
## Description of proposed changes

[Preview](https://nextstrain-s-sidebar-ti-iwuz4n.herokuapp.com/blog/)

Add support for explicit, optional `sidebarTitle` key in blog post frontmatter 

* Removes previous calculated `sidebarName` post object key in favor of optional `sidebarTitle` in post frontmatter
* If frontmatter does not contain `sidebarTitle`, `post.sidebarTitle` is set tot the frontmatter `title` value
* Update blog JSX files to use `post.sidebarTitle` instead of `post.sidebarName`
* Delete now unused `formatFileName()` method
* Add `sidebarTitle` frontmatter values as needed to (mostly) replicate the current sidebar titles (formerly based on the post file name)
* Correct some trailing whitespace

## Related issue(s)

Closes #1005 
<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
