### PR TITLE
auspice-client: Speed up build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ build-static() {
 build-auspice() {
     echo "Building a customised version of auspice"
     cd auspice-client
-    npm ci
+    npm ci --ignore-scripts
     ./node_modules/.bin/auspice build --verbose --extend ./customisations/config.json
     cd ..
 }


### PR DESCRIPTION
## Description of proposed changes

Auspice's prepare script builds Auspice and by default will run during installation. It is not necessary here since there is a custom build call right after installation.

Notably, this avoids [installation of devDependencies for git installs](https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts). One of the devDependencies, puppeteer, has recently been timing out on Heroku in attempts to download Chrome.

## Related issue(s)

- https://github.com/nextstrain/auspice/issues/1709

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Heroku build is successful (took ~3 minutes which seems to be an improvement)
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
- [x] Applied change to [#1039](https://github.com/nextstrain/nextstrain.org/pull/1039) to confirm that it resolves the issue with Heroku builds timing out (build completed in ~5 minutes): 
![image](https://github.com/user-attachments/assets/72d7536a-3e40-4b3d-8c92-e0a772a35878)


<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
