### PR TITLE
Remove font-size scaling

### DIFF
--- a/static-site/src/components/sourceInfoHeading.jsx
+++ b/static-site/src/components/sourceInfoHeading.jsx
@@ -24,9 +24,6 @@ const OverviewContainer = styled.div`
     width: 200px;
     padding: 0;
   }
-  a, p {
-    font-size: 94%;
-  }
 `;
 
 export const AvatarImg = styled.img`


### PR DESCRIPTION
## Description of proposed changes

The purpose of the scaling is unclear. It was added in "parse /groups/:groupName markdown;" (347ee033) which is the commit that added the markdown rendering of group descriptions, so maybe it was a stylistic adjustment relative to whatever else was on the page at that time.

A similar 94% font-size scaling is used in the custom Auspice splash page (auspice-client/customisations/splash.js) as well as other parts of the Auspice code base. The purposes of those are also unclear.

The main motivation for removing it here is that there was an [internal bug report](https://bedfordlab.slack.com/archives/C0K3GS3J8/p1731343211138099) of a group's description rendering with what looks like partially scaled fonts. The issue self-resolved without any code changes and we were unable to understand what caused it. My suspicion is that this font-size scaling is a contributing factor. It can't be the only factor because it has been around for many years now and this is the first report of such an issue. Maybe a recent browser update handles scaled fonts poorly.

Another motivation is that, after seeing the unscaled version, the scaled version has noticeably smaller text for what seems to be no apparent reason. I think removing the scaling improves readability on this page, but of course that is subjective.

## Related issues

- Maybe fixes [text rendering issue](https://bedfordlab.slack.com/archives/C0K3GS3J8/p1731343211138099)?

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
