### PR TITLE
(nit) Use double quotes in the same line

### DIFF
--- a/static-site/src/components/ListResources/index.tsx
+++ b/static-site/src/components/ListResources/index.tsx
@@ -58,7 +58,7 @@ function ListResources({
       <ErrorContainer>
         {"Whoops - listing resources isn't working!"}
         <br/>
-        {'Please '}<a href="/contact" style={{fontWeight: 300}}>get in touch</a>{" if this keeps happening"}
+        {"Please "}<a href="/contact" style={{fontWeight: 300}}>get in touch</a>{" if this keeps happening"}
       </ErrorContainer>
     )
   }


### PR DESCRIPTION
## Description of proposed changes

For consistency. If there was an ESLint rule for consistency within the same line, I would consider turning it on. But I don't think such a rule exists. The closest is [jsx-quotes](https://eslint.org/docs/latest/rules/jsx-quotes) which is too opinionated and would change lots of code that is working just fine.

## Related issue(s)

Prompted by https://github.com/nextstrain/nextstrain.org/pull/1073#discussion_r1842669224

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
