### PR TITLE
Add height property to Next.js Image

### DIFF
--- a/static-site/components/nav/nav-logo.tsx
+++ b/static-site/components/nav/nav-logo.tsx
@@ -22,7 +22,7 @@ export default function NavLogo(): React.ReactElement | null {
 
 const Logo = (): React.ReactElement => (
   <a href="/" className={styles.logo}>
-    <Image src={logo} alt="Nextstrain (logo)" width="40" />
+    <Image src={logo} alt="Nextstrain (logo)" width="40" height="40" />
   </a>
 );
 


### PR DESCRIPTION
## Description of proposed changes

This is not reflected in the type definition for Next.js's Image element, but width and height [must be set together](https://nextjs.org/docs/app/building-your-application/optimizing/images#image-sizing).

## Related issue(s)

Follow-up to https://github.com/nextstrain/nextstrain.org/issues/1072#issuecomment-2489442505

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
