### PR TITLE
Add yellow-fever to manifest

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -746,6 +746,13 @@
           "default": "NA"
         }
       },
+      "yellow-fever": {
+        "resolution":{
+          "genome": "",
+          "prM-E": "",
+          "default": "genome"
+        }
+      },
       "zika": "",
       "default": "zika"
     }

--- a/env/production/config.json
+++ b/env/production/config.json
@@ -110,5 +110,5 @@
   "OIDC_GROUPS_CLAIM": "cognito:groups",
   "SESSION_COOKIE_DOMAIN": "nextstrain.org",
   "GROUPS_DATA_FILE": "groups.json",
-  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v3.json.gz"
+  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v4.json.gz"
 }

--- a/env/testing/config.json
+++ b/env/testing/config.json
@@ -108,5 +108,5 @@
   "OIDC_USERNAME_CLAIM": "cognito:username",
   "OIDC_GROUPS_CLAIM": "cognito:groups",
   "GROUPS_DATA_FILE": "groups.json",
-  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v3.json.gz"
+  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v4.json.gz"
 }

--- a/src/routing/core.js
+++ b/src/routing/core.js
@@ -27,8 +27,8 @@ const coreBuildPaths = [
    * The data here is a superset of the pathogen keys in `manifest_guest.json`
    * and we could (should) reduce the duplication.
    *
-   * As of 2024-03 this list includes 3 paths not in the manifest: 'monkeypox',
-   * 'yellow-fever' and 'mers'
+   * As of 2024-12 this list includes 2 paths not in the manifest: 'monkeypox',
+   * and 'mers'
    */
   "/avian-flu",
   "/dengue",


### PR DESCRIPTION
Also bumps resource index revision number in testing and production configs.

Note: needs to merge semi-concurrently with the work for nextstrain/yellow-fever#25.