### PR TITLE
Bump GH Action workflows to `ubuntu-24.04`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ defaults:
 jobs:
   # Lint regardless of build or test status and lint early.
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -42,7 +42,7 @@ jobs:
       - run: node ./scripts/check-resource-index-match.js
 
   type-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -53,7 +53,7 @@ jobs:
 
   # Build into Heroku slug so we can deploy the same build that we test.
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -72,7 +72,7 @@ jobs:
   test:
     if: github.repository == 'nextstrain/nextstrain.org'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: heroku/heroku:22
     env:
@@ -155,7 +155,7 @@ jobs:
       url: ${{ inputs.heroku-app && format('https://{0}.herokuapp.com', inputs.heroku-app) || 'https://next.nextstrain.org' }}
 
     # Deploy steps
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       HEROKU_APP: ${{ inputs.heroku-app || 'nextstrain-canary' }}
     steps:

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   merge-auspice-bump:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: metadata
         uses: dependabot/fetch-metadata@v2

--- a/.github/workflows/index-resources.yml
+++ b/.github/workflows/index-resources.yml
@@ -31,7 +31,7 @@ defaults:
 
 jobs:
   build-ref-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       ref-matrix: ${{ steps.ref-matrix.outputs.ref-matrix }}
     steps:
@@ -61,7 +61,7 @@ jobs:
       group: ${{ github.workflow }}-${{ matrix.resource_index }}
     env:
         RESOURCE_INDEX: ${{ matrix.resource_index }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint
       contents: read

--- a/.github/workflows/remind-to-promote.yml
+++ b/.github/workflows/remind-to-promote.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version-file: 'package.json'
       - run: npm ci
 
         # Use the GitHub Actions cache to store the minimal persistent state we

--- a/.github/workflows/remind-to-promote.yml
+++ b/.github/workflows/remind-to-promote.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   remind-to-promote:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 jobs:
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: scripts/terraform-fmt -check
@@ -28,7 +28,7 @@ jobs:
         env:
           - env/production
           - env/testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -6,6 +6,7 @@ on:
     tags-ignore:
       - '**'
     paths:
+      - '.github/workflows/terraform-lint.yml'
       - '**.tf'
       - '**.tfvars'
       - '**.tf.json'

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -18,6 +18,12 @@ jobs:
   fmt:
     runs-on: ubuntu-24.04
     steps:
+      - name: Install Terraform
+        run: |
+          wget -O terraform.zip https://releases.hashicorp.com/terraform/1.10.2/terraform_1.10.2_linux_amd64.zip
+          unzip terraform.zip -d "$HOME/terraform"
+          echo "$HOME/terraform" >> "$GITHUB_PATH"
+
       - uses: actions/checkout@v4
       - run: scripts/terraform-fmt -check
 
@@ -30,6 +36,12 @@ jobs:
           - env/testing
     runs-on: ubuntu-24.04
     steps:
+      - name: Install Terraform
+        run: |
+          wget -O terraform.zip https://releases.hashicorp.com/terraform/1.10.2/terraform_1.10.2_linux_amd64.zip
+          unzip terraform.zip -d "$HOME/terraform"
+          echo "$HOME/terraform" >> "$GITHUB_PATH"
+
       - uses: actions/checkout@v4
 
       - run: terraform init -backend=false


### PR DESCRIPTION
## Description of proposed changes

Bump all GH Action workflows to `ubuntu-24.04` and address breakages.
1. Added installation steps for Terraform
2. We interact with Heroku via the Platform API so we are not affected by the removal of the Heroku CLI.

## Related issue(s)

Related to https://github.com/nextstrain/.github/issues/113

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
- [x] Test runs on [gh-action-ubuntu-24.04 branch](https://github.com/nextstrain/nextstrain.org/actions?query=branch%3Agh-action-ubuntu-24.04)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
