### PR TITLE
Update blog post date

### DIFF
--- a/static-site/content/blog/2025-01-09-human-metapneumovirus-analysis-and-resources.md
+++ b/static-site/content/blog/2025-01-09-human-metapneumovirus-analysis-and-resources.md
@@ -1,6 +1,6 @@
 ---
 author: "Isabel Joia, Richard Neher"
-date: "2025-01-07"
+date: "2025-01-09"
 title: "Phylogenetic analysis of Human Metapneumovirus"
 sidebarTitle: "HMPV Phylogenetic Analysis and Resources"
 ---


### PR DESCRIPTION
The date in the file name and front matter was last updated on 2024-01-07, however it is now 2024-01-09 and the post hasn't been published to nextstrain.org yet. Updated the date to today, and will promote to nextstrain.org after merge.

Follow-up to #1101 