### PR TITLE
Remove extension on ESM imports

### DIFF
--- a/auspice-client/customisations/languageSelector.js
+++ b/auspice-client/customisations/languageSelector.js
@@ -1,5 +1,5 @@
 import React from "react";
-import ISO6391 from "iso-639-1/build/index.js";
+import ISO6391 from "iso-639-1/build/index";
 
 /* This and some of the following functions are reused
 in the static site (specifically ../../static-site/src/pages/ncov-sit-reps.jsx)

--- a/auspice-client/customisations/navbar.js
+++ b/auspice-client/customisations/navbar.js
@@ -1,5 +1,5 @@
 import React from "react";
-import LanguageSelector from "./languageSelector.js";
+import LanguageSelector from "./languageSelector";
 
 import logoPNG from "./nextstrain-logo-small.png";
 

--- a/auspice-client/customisations/splash.js
+++ b/auspice-client/customisations/splash.js
@@ -1,7 +1,7 @@
 import React, {useState, useEffect} from "react";
 import styled from 'styled-components';
-import MarkdownDisplay from "auspice/src/components/markdownDisplay/index.js";
-import NavBar from "./navbar.js";
+import MarkdownDisplay from "auspice/src/components/markdownDisplay";
+import NavBar from "./navbar";
 
 
 /**


### PR DESCRIPTION
## Description of proposed changes

This reverts commit "auspice-client: Append extension on ESM imports" (7cde8399).

The reasoning in that commit was that extensions are necessary for Webpack 5. However, this is not entirely accurate - they are only [required](https://webpack.js.org/configuration/module/#resolvefullyspecified) when using the default for resolve.fullySpecified *and* using "type": "module" package.json. The latter is not true in our case.

Notably, removing the exact path for `auspice/src/components/markdownDisplay` allows the usage to be tolerant of filename changes such as TypeScript conversion.

## Related issue(s)

Unblocks changes such as https://github.com/nextstrain/auspice/commit/ff91cfd17a16063a6890b65d8a23c929297c3fc8

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
- [x] https://nextstrain-s-victorlin--ptzfgd.herokuapp.com/narratives/ncov/sit-rep/2020-08-14 works
    - This confirms navbar and languageSelector changes
- [x] https://nextstrain-s-victorlin--ptzfgd.herokuapp.com/community/inrb-drc/ebola-nord-kivu works with the `/charon/getDataset` request blocked to render the custom Auspice splash component
    - This confirms splash changes

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
