### PR TITLE
Add avian-flu/h5n1-d1.1/genome core build

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -17,6 +17,12 @@
                   "default": "genome"
               }
           },
+          "h5n1-d1.1": {
+              "segment": {
+                  "genome": "",
+                  "default": "genome"
+              }
+          },
           "h5n1": {
             "segment": {
               "ha": {


### PR DESCRIPTION
Build PR: https://github.com/nextstrain/avian-flu/pull/126

Preview URL: https://nextstrain-s-james-avia-qlfqbu.herokuapp.com/avian-flu/h5n1-d1.1/genome

I didn't add this to the featured datasets list at this stage, but we can if people think it's warranted 