### PR TITLE
Rename "wnv/global" to "wnv/all-lineages"

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -778,12 +778,12 @@
       },
       "WNV": {
         "resolution": {
-          "global": "",
+          "all-lineages": "",
           "wa": "",
           "lineage-1A": "",
           "lineage-2": "",
           "NA": "",
-          "default": "global"
+          "default": "all-lineages"
         }
       },
       "yellow-fever": {

--- a/test/date_descriptor.test.js
+++ b/test/date_descriptor.test.js
@@ -1,10 +1,10 @@
 /**
- * 
+ *
  * Testing of requests made using URLs with date descriptors (i.e. @YYYY-MM-DD).
  * It would be better if we also ran the server from the test process and could
  * spy on the requests being made to check the correct versionId is being used
  * in the requests to AWS.
- * 
+ *
  */
 
 /**
@@ -114,7 +114,7 @@ const narratives = [
 describe("Request valid main datasets", () => {
 
   for (const d of datasets.filter((el) => !el.hasOwnProperty('sidecar') && el.valid===true)) {
-    
+
     if (d.charon!==false) {
       it(`Charon API using ${d.prefix}`, async () => {
         const url = `${BASE_URL}/charon/getDataset?prefix=${d.prefix}`;
@@ -302,14 +302,14 @@ describe("Valid narratives", () => {
 })
 
 const redirects = [
-  ["WNV", "WNV/global"],
+  ["WNV", "WNV/all-lineages"],
   /* Note that WNV is not in the index, so this versioned test ensures we are
   not checking the existence/validity of any version descriptor against the WNV
   resource, rather we are redirecting and deferring those checks */
-  ["WNV@2025-03-12", "WNV/global@2025-03-12"],
+  ["WNV@2025-03-17", "WNV/all-lineages@2025-03-17"],
   /* URL queries should be preserved across the redirect, but only for the RESTful API */
-  ["WNV@2025-03-12?c=region", "WNV/global@2025-03-12?c=region", {charon: false}],
-  ["staging/WNV@2025-03-13?c=region", "staging/WNV/global@2025-03-13?c=region", {charon: false}],
+  ["WNV@2025-03-17?c=region", "WNV/all-lineages@2025-03-17?c=region", {charon: false}],
+  ["staging/WNV@2025-03-17?c=region", "staging/WNV/all-lineages@2025-03-17?c=region", {charon: false}],
 ]
 
 describe("Paths redirect with version descriptors", () => {

--- a/test/inventory_parsing.test.js
+++ b/test/inventory_parsing.test.js
@@ -61,7 +61,7 @@ test('back-to-back delete markers', async () => {
 test('core URL redirects (via our manifest) are correctly obtained', async () => {
   const expected_url_redirects = {
     'dengue/denv1': 'dengue/denv1/genome',
-    WNV: 'WNV/global',
+    WNV: 'WNV/all-lineages',
     'seasonal-flu': 'seasonal-flu/h3n2/ha/2y',
     'seasonal-flu/h3n2': 'seasonal-flu/h3n2/ha/2y',
     'seasonal-flu/h3n2/ha': 'seasonal-flu/h3n2/ha/2y',


### PR DESCRIPTION
## Description of proposed changes

Renamed the default "wnv/global" to "wnv/all-lineages" and updated the tests accordingly.

This PR should come after related WNV PR:

* https://github.com/nextstrain/WNV/pull/88

## Related issue(s)

## Checklist

- [x] Checks pass
- [ ] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
