### PR TITLE
Remediate already ported bits [#1133]

### DIFF
--- a/static-site/app/blog/[id]/page.tsx
+++ b/static-site/app/blog/[id]/page.tsx
@@ -16,11 +16,14 @@ import styles from "./styles.module.css";
 
 // just to avoid having to repeat this in a couple method sigs...
 interface BlogPostParams {
+  /** a string representing the base name of the post */
   id: string;
 }
 
-// return a list of params that will get handed to this page at build
-// time, to statically build out all the blog posts
+/**
+ * return a list of params that will get handed to this page at build
+ * time, to statically build out all the blog posts
+ */
 export function generateStaticParams(): BlogPostParams[] {
   return getBlogPosts().map((post) => {
     return { id: post.blogUrlName };
@@ -28,18 +31,32 @@ export function generateStaticParams(): BlogPostParams[] {
 }
 
 type PopulatedMetadata = Metadata & {
+  /** the base URL to use for metadata attributes */
   metadataBase: URL
+
+  /** data to generate OpenGraph headers in the <head> of the page */
   openGraph: {
+    /** a brief description of the post */
     description: string
+
+    /** an array of image URLs associated with the post */
     images: { url: string}[]
+
+    /** the name of our site */
     siteName: string
+
+    /** the title of the blog post */
     title: string
+
+    /** we have a website! */
     type: "website"
+
+    /** the URL for the post */
     url: URL | string
   }
 }
 
-// generate opengraph and other metadata tags
+/** generate opengraph and other metadata tags */
 export async function generateMetadata({
   params,
 }: {
@@ -81,6 +98,9 @@ export async function generateMetadata({
   return metadata;
 }
 
+/**
+ * A React Server Component for rendering a single blog post
+ */
 export default async function BlogPost({
   params,
 }: {

--- a/static-site/app/blog/page.tsx
+++ b/static-site/app/blog/page.tsx
@@ -2,6 +2,10 @@ import { notFound, redirect } from "next/navigation";
 
 import { getBlogPosts } from "./utils";
 
+/**
+ * A React Server component that handles redirecting requests for
+ * /blog to the most recent blog post
+ */
 export default function Index(): void {
   const mostRecentPost = getBlogPosts()[0];
 

--- a/static-site/app/blog/parseMarkdown.ts
+++ b/static-site/app/blog/parseMarkdown.ts
@@ -3,11 +3,15 @@ import sanitizeHtml, { Attributes, IOptions, Tag } from "sanitize-html";
 
 import { siteUrl } from "../../data/BaseConfig";
 
+/**
+ * Render a string of text formatted with Markdown into HTML
+ */
 export default async function parseMarkdown({
   mdString,
   addHeadingAnchors = false,
   headingAnchorClass = undefined,
 }: {
+  /** the Markdown-formatted text to render */
   mdString: string
 
   /** Should `<a>` tags be added to headings? */
@@ -55,7 +59,17 @@ export default async function parseMarkdown({
   return cleanDescription;
 }
 
-function transformA(tagName: string, attribs: Attributes): Tag {
+/**
+ * A function to add `target=_blank` and `rel="noreferrer nofollow"`
+ * attributes to <a> tags that link to external destinations
+ */
+function transformA(
+  /** the name of the tag being transformed (will always be `a`) */
+  tagName: string,
+
+  /** attributes of the tag being transformed */
+  attribs: Attributes
+): Tag {
   // small helper to keep things dry
   const _setAttribs: (attribs: Attributes) => void = (attribs) => {
     attribs.target = "_blank";

--- a/static-site/app/blog/utils.ts
+++ b/static-site/app/blog/utils.ts
@@ -6,17 +6,33 @@ import { fileURLToPath } from "url";
 import parseMarkdown from "./parseMarkdown";
 
 export interface BlogPost {
+  /** author(s) name(s) */
   author: string;
+
+  /**
+   * the "slug" for this post, i.e., the string after `/blog` in the
+   * post's URL
+   */
   blogUrlName: string;
+
+  /** publication date of the post */
   date: string;
+
+  /** the Markdown-formatted content of the post */
   mdstring: string;
+
+  /** the string to use in the blog sidebar for this post */
   sidebarTitle: string;
+
+  /** the post title */
   title: string;
 }
 
-// Scans the ./static-site/content/blog directory for .md files and
-// returns a chronologically-sorted array of posts, each with some
-// basic metadata and the raw (unsanitized) markdown contents.
+/**
+ * Scans the ./static-site/content/blog directory for .md files and
+ * returns a chronologically-sorted array of posts, each with some
+ * basic metadata and the raw (unsanitized) markdown contents.
+ */
 export function getBlogPosts(): BlogPost[] {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -82,12 +98,18 @@ export function getBlogPosts(): BlogPost[] {
   return blogPosts;
 }
 
+/**
+ * A function to transform a Markdown-formatted string into HTML.
+ */
 export async function markdownToHtml({
   mdString,
   headingAnchorClass,
 }: {
-  mdString: string
-  headingAnchorClass?: string
+  /** the Markdown-formatted string to transform */
+  mdString: string;
+
+  /** the name to use for the CSS class on heading anchors */
+  headingAnchorClass?: string;
 }): Promise<string> {
   try {
     return await parseMarkdown({

--- a/static-site/app/contact/page.tsx
+++ b/static-site/app/contact/page.tsx
@@ -9,6 +9,9 @@ export const metadata: Metadata = {
   title: "Contact",
 };
 
+/**
+ * A React Server Component that renders the /contact page
+ */
 export default function ContactPage(): React.ReactElement {
   return (
     <>

--- a/static-site/app/layout.tsx
+++ b/static-site/app/layout.tsx
@@ -19,8 +19,10 @@ import "./styles/browserCompatability.css";
 import "./styles/bootstrap.css";
 import "./styles/globals.css";
 
-// Custom fonts bundled (i.e. no external requests), see
-// <https://nextjs.org/docs/pages/building-your-application/optimizing/fonts>
+/**
+ *  Custom fonts bundled (i.e. no external requests), see
+ * <https://nextjs.org/docs/pages/building-your-application/optimizing/fonts>
+ */
 const lato = Lato({
   style: ["normal", "italic"],
   subsets: ["latin"],
@@ -28,6 +30,9 @@ const lato = Lato({
   weight: ["300", "400", "700"],
 });
 
+/**
+ * data used to generate the metadata tags in the <head>
+ */
 export const metadata: Metadata = {
   title: {
     absolute: siteTitle,
@@ -36,6 +41,10 @@ export const metadata: Metadata = {
   description: siteTitleAlt,
 };
 
+/**
+ * A React Component that provides the overall page layout used by
+ * every page on the site.
+ */
 export default function RootLayout({
   children,
 }: {

--- a/static-site/app/not-found.tsx
+++ b/static-site/app/not-found.tsx
@@ -1,5 +1,9 @@
 import React from "react";
 
+/**
+ * A React Server Component that renders the 404 page, shown when a
+ * non-existent URL is requested.
+ */
 export default function FourOhFour(): React.ReactElement {
   return (
     <>

--- a/static-site/app/pathogens/page.tsx
+++ b/static-site/app/pathogens/page.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Metadata } from "next";
 
 import FlexCenter from "../../components/flex-center";
 import { FocusParagraphCentered } from "../../components/focus-paragraph";
@@ -7,6 +8,12 @@ import { SmallSpacer, HugeSpacer } from "../../components/spacers";
 import * as coreResources from "../../content/resource-listing.yaml";
 
 import { pathogenResourceListingCallback } from "./callback";
+
+const title = "Nextstrain-maintained pathogen analyses";
+
+export const metadata: Metadata = {
+  title,
+};
 
 /**
  * React Server Component that generates and presents a list of
@@ -18,7 +25,7 @@ export default function Pathogens(): React.ReactElement {
       <HugeSpacer />
       <HugeSpacer />
 
-      <h1>Nextstrain-maintained pathogen analyses</h1>
+      <h1>{title}</h1>
 
       <SmallSpacer />
 

--- a/static-site/app/team/page.tsx
+++ b/static-site/app/team/page.tsx
@@ -12,6 +12,9 @@ export const metadata: Metadata = {
   title: "Team",
 };
 
+/**
+ * A React Server Component that renders the /team page
+ */
 export default function TeamPage(): React.ReactElement {
   return (
     <div className={styles.teamPage}>

--- a/static-site/app/whoami/page.tsx
+++ b/static-site/app/whoami/page.tsx
@@ -10,6 +10,9 @@ import styles from "./styles.module.css";
 // components aren't allowed to do that, and we need to be a client
 // component to get access to the user context
 
+/**
+ * A React Client Component that renders the /whoami page
+ */
 export default function WhoAmI(): React.ReactElement {
   const { user, groupMemberships } = useContext(UserContext);
 

--- a/static-site/components/error-message/index.tsx
+++ b/static-site/components/error-message/index.tsx
@@ -10,7 +10,10 @@ export default function ErrorMessage({
   title,
   contents,
 }: {
+  /** the title of the error; displayed on top in bold */
   title: string;
+
+  /** the more specific contents of the error message */
   contents: string;
 }): React.ReactElement {
   return (

--- a/static-site/components/expandable-tiles/index.tsx
+++ b/static-site/components/expandable-tiles/index.tsx
@@ -15,11 +15,6 @@ const expandPreviewHeight = 60;
 
 /**
  * React Client Component to display an expandable div with a list of tiles.
- *
- * @param tiles - the list of tiles to display
- * @param tileWidth - width of an individual tile in pixels
- * @param tileHeight - height of an individual tile in pixels
- * @param TileComponent - React Functional Component to render an individual tile
  */
 export default function ExpandableTiles<Tile extends GenericTileBase>({
   tiles,
@@ -27,9 +22,16 @@ export default function ExpandableTiles<Tile extends GenericTileBase>({
   tileHeight,
   TileComponent,
 }: {
+  /** the list of tiles to display */
   tiles: Tile[];
+
+  /** width of an individual tile in pixels */
   tileWidth: number;
+
+  /** height of an individual tile in pixels */
   tileHeight: number;
+
+  /** React Functional Component to render an individual tile */
   TileComponent: React.FunctionComponent<{ tile: Tile }>;
 }): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);

--- a/static-site/components/expandable-tiles/types.ts
+++ b/static-site/components/expandable-tiles/types.ts
@@ -1,4 +1,7 @@
 export interface GenericTileBase {
+  /** the image on the tile */
   img: string;
+
+  /** the name on the tile */
   name: string;
 }

--- a/static-site/components/flex-center/index.tsx
+++ b/static-site/components/flex-center/index.tsx
@@ -2,9 +2,11 @@ import React from "react";
 
 import styles from "./styles.module.css";
 
+/** A React Server Component that formats its child nodes as a centered flex-div */
 export default function FlexCenter({
   children,
 }: {
+  /** the child nodes to render in the flex-div */
   children: React.ReactNode;
 }): React.ReactElement {
   return <div className={styles.flexCenter}>{children}</div>;

--- a/static-site/components/focus-paragraph/index.tsx
+++ b/static-site/components/focus-paragraph/index.tsx
@@ -2,17 +2,24 @@ import React from "react";
 
 import styles from "./styles.module.css";
 
+/** A React Server Component that renders its children inside a centered paragraph */
 export function FocusParagraphCentered({
   children,
 }: {
+  /** the child nodes to render in the paragraph */
   children: React.ReactNode;
 }): React.ReactElement {
   return <p className={`${styles.focus} ${styles.centered}`}>{children}</p>;
 }
 
+/**
+ * A React Server Component that renders its children inside a
+ * paragraph that is slightly narrower than the default
+ */
 export function FocusParagraphNarrow({
   children,
 }: {
+  /** the child nodes to render in the paragraph */
   children: React.ReactNode;
 }): React.ReactElement {
   return <p className={`${styles.focus} ${styles.narrow}`}>{children}</p>;

--- a/static-site/components/footer/index.tsx
+++ b/static-site/components/footer/index.tsx
@@ -6,6 +6,10 @@ import { BigSpacer, SmallSpacer } from "../spacers";
 import SiteMap from "./site-map";
 import TeamList from "./team-list";
 
+/**
+ * A React Server Component that renders the site footer, used at the
+ * bottom of all our pages.
+ */
 export default function Footer(): React.ReactElement {
   return (
     <div>

--- a/static-site/components/footer/site-map.tsx
+++ b/static-site/components/footer/site-map.tsx
@@ -2,11 +2,12 @@ import { FaExternalLinkAlt } from "react-icons/fa";
 
 import React from "react";
 
-import{ BigSpacer} from "../spacers";
+import { BigSpacer } from "../spacers";
 
 import styles from "./site-map.module.css";
-import {sections, Entry, Section} from "./sitemap";
+import { sections, Entry, Section } from "./sitemap";
 
+/** A React Server Component that renders the site map in the page footer */
 export default function SiteMap(): React.ReactElement {
   return (
     <div className={`${styles.siteMap} row`}>
@@ -26,7 +27,8 @@ export default function SiteMap(): React.ReactElement {
   );
 }
 
-function SectionList({ entries }:{entries: Entry[]}): React.ReactElement {
+/** A helper component that renders one section of the site map */
+function SectionList({ entries }: { entries: Entry[] }): React.ReactElement {
   return (
     <ul className={styles.unstyled}>
       {entries.map((entry) => (

--- a/static-site/components/footer/team-list.tsx
+++ b/static-site/components/footer/team-list.tsx
@@ -1,16 +1,20 @@
 "use client";
 
-// Because we don't want to show the footer version of the team list
-// on the team page, this component needs access to the pathname, so
-// it can decide whether or not to show the list in the footer --
-// which means it needs to be a client component.
-
 import { usePathname } from "next/navigation";
 import React from "react";
 
 import { MediumSpacer } from "../../src/layouts/generalComponents";
 import { FooterTeamList } from "../people/avatars";
 
+/**
+ * A React Client component that displays the core Nextstrain team in
+ * the footer on every page except the /team page
+ *
+ * Because we don't want to show the footer version of the team list
+ * on the team page, this component needs access to the pathname, so
+ * it can decide whether or not to show the list in the footer --
+ * which means it needs to be a client component.
+ */
 export default function TeamList() {
   const pathname = usePathname();
 

--- a/static-site/components/line/index.tsx
+++ b/static-site/components/line/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import styles from "./styles.module.css";
 
+/** A React Server Component that renders a div styled to provide a horizontal rule */
 export default function Line (): React.ReactElement {
   return <div className={styles.line}></div>
 }

--- a/static-site/components/list-resources/group-and-resource-links.tsx
+++ b/static-site/components/list-resources/group-and-resource-links.tsx
@@ -14,15 +14,15 @@ import styles from "./group-and-resource-links.module.css";
  * A React Client Component that displays a link to a group resource,
  * with proper styling, with attributes to force the link open in a
  * new window/tab and without sending referrer information.
- *
- * @param displayName - the text to use for the link
- * @param href - the `href` property for the <a> element
  */
 export function GroupLink({
   displayName,
   href,
 }: {
+  /** the text to use for the link */
   displayName: string;
+
+  /** the `href` property for the <a> element */
   href: string;
 }): React.ReactElement {
   return (
@@ -43,18 +43,19 @@ export function GroupLink({
  * new window/tab and without sending referrer information. Adds an
  * `onClick` handler to the `<div>` wrapping the link, so that a shift
  * click opens a modal with a timeline display of the resource.
- *
- * @param displayName - the text to use for the link
- * @param href - the `href` property for the <a> element
- * @param resource - the resource to display in a modal on a shift-click
  */
 export function IndividualQuickLink({
   displayName,
   href,
   resource,
 }: {
+  /** the text to use for the link */
   displayName: string;
+
+  /** the `href` property for the <a> element */
   href: string;
+
+  /** the resource to display in a modal on a shift-click */
   resource: Resource | undefined;
 }): React.ReactElement | null {
   const setModalResource = useContext(SetModalResourceContext);
@@ -66,6 +67,7 @@ export function IndividualQuickLink({
     return null;
   }
 
+  /** Helper function for handling shift-click events */
   function onClick(e: React.MouseEvent): void {
     if (e.shiftKey) {
       setModalResource && setModalResource(resource);
@@ -96,17 +98,19 @@ export function IndividualQuickLink({
  * a shift click opens a modal with a timeline display of the
  * resource. Further, adds hover state handling that changes the
  * display of the resource name on mouse-over/mouse-out.
- *
- * @param resource - the resource to display in a modal on a shift-click
- * @param topOfColumn - whether the resource is at the top of a column
- * when displayed; items at the top of a column act like they're being
- * hovered all the time
  */
 export function IndividualResourceLink({
   resource,
   topOfColumn,
 }: {
+  /** the resource to display in a modal on a shift-click */
   resource: Resource;
+
+  /**
+   * whether the resource is at the top of a column when displayed;
+   * items at the top of a column act like they're being hovered all
+   * the time
+   */
   topOfColumn: boolean;
 }): React.ReactElement | null {
   const setModalResource = useContext(SetModalResourceContext);

--- a/static-site/components/list-resources/icon-container.tsx
+++ b/static-site/components/list-resources/icon-container.tsx
@@ -16,13 +16,6 @@ import styles from "./icon-container.module.css";
  * Currently supports `"history"` and `"bullet-list"` as `iconName`
  * values; if provided with something else, will throw an
  * `InternalError`
- *
- * @param color - (optional) string value for CSS `color`
- * @param handleClick - (optional) callback for `onClick` handler
- * @param hoverColor - (optional) string value for CSS `color` when
- * element is hovered over
- * @param iconName - name of icon to display
- * @param text to display below icon
  */
 export default function IconContainer({
   color,
@@ -31,10 +24,19 @@ export default function IconContainer({
   iconName,
   text,
 }: {
+  /** string value for CSS `color` */
   color?: string;
+
+  /** callback for `onClick` handler */
   handleClick?: () => void;
+
+  /** string value for CSS `color` when element is hovered over */
   hoverColor?: string;
+
+  /** name of icon to display */
   iconName: string;
+
+  /** text to display below icon */
   text: string;
 }): React.ReactElement {
   const [hovered, setHovered] = useState(false);

--- a/static-site/components/list-resources/index.tsx
+++ b/static-site/components/list-resources/index.tsx
@@ -42,7 +42,10 @@ import {
 import styles from "./styles.module.css";
 
 interface ListResourcesProps {
+  /** Is the resource versioned? */
   versioned: boolean;
+
+  /** Set of quick links associated with the resource */
   quickLinks: QuickLink[];
 
   /**
@@ -54,12 +57,13 @@ interface ListResourcesProps {
   /** Mapping from group name -> display name */
   groupDisplayNames: Record<string, string>;
 
+  /** Metadata about the tile */
   tileData: FilterTile[];
 
-  /** callback to use to get data */
+  /** Callback to use to get data */
   resourceListingCallback: () => Promise<ResourceListingInfo>;
 
-  /** this is currently unused */
+  /** This is currently unused */
   resourceType: string;
 }
 
@@ -83,10 +87,9 @@ const SetSelectedFilterOptions = createContext<React.Dispatch<
  * the resizes happen frequently and debouncing would be better. From
  * limited testing it's not too slow and these resizes should be
  * infrequent.
- *
- * @param props - see the `ListResourceProps` interface for details
  */
 export default function ListResources(
+  /** see the `ListResourceProps` interface for details */
   props: ListResourcesProps,
 ): React.ReactElement {
   const ref = useRef(null);
@@ -129,13 +132,6 @@ export default function ListResources(
  * future this will be expanded. Similarly, we define versioned:
  * boolean here in the UI whereas this may be better expressed as a
  * property of the API response.
- *
- * @param versioned - boolean for whether the resources are versioned
- * @param elWidth - width of the element
- * @param quickLinks - list of `QuickLink` objects for the resources
- * @param defaultGroupLinks - boolean for if the group name is a url
- * @param groupDisplayNames - apping from group name -> display name
- * @param tileData - the tiles for the resources
  */
 function ListResourcesContent({
   versioned = true,
@@ -146,6 +142,7 @@ function ListResourcesContent({
   tileData,
   resourceListingCallback,
 }: ListResourcesProps & {
+  /** width of the element */
   elWidth: number;
 }): React.ReactElement {
   const { groups, dataFetchError } = useDataFetch(
@@ -260,20 +257,19 @@ function ListResourcesContent({
 /**
  * A React Client component that provides a way to filter the
  * displayed resources.
- *
- * @param options - list of available `FilterOption` objects
- * @param selectedFilterOptions - readonly list of active
- * `FilterOption` objects
- * @param setSelectedFilterOptions - React State setter for the active
- * `FilterOption` objects
  */
 function Filter({
   options,
   selectedFilterOptions,
   setSelectedFilterOptions,
 }: {
+  /** list of available `FilterOption` objects */
   options: FilterOption[];
+
+  /** readonly list of active `FilterOption` objects*/
   selectedFilterOptions: readonly FilterOption[];
+
+  /** React State setter for the active `FilterOption` objects*/
   setSelectedFilterOptions: React.Dispatch<
     React.SetStateAction<readonly FilterOption[]>
   >;
@@ -311,17 +307,18 @@ function Filter({
 /**
  * A React Client Component with controls for how the displayed
  * resources are sorted.
- *
- * @param sortMethod - the `SortMethod` to use
- * @param changeSortMethod - React State setter for the `SortMethod`
  */
 function SortOptions({
   sortMethod,
   changeSortMethod,
 }: {
+  /** the `SortMethod` to use */
   sortMethod: SortMethod;
+
+  /** React State setter for the `SortMethod` */
   changeSortMethod: React.Dispatch<React.SetStateAction<SortMethod>>;
 }): React.ReactElement {
+  /** helper function for managing changes to the sort method */
   function onChangeValue(event: FormEvent<HTMLInputElement>): void {
     const sortMethod = event.currentTarget.value;
     if (sortMethod !== "alphabetical" && sortMethod !== "lastUpdated") {
@@ -389,10 +386,13 @@ function SortOptions({
 
 /**
  * A React Client Component for displaying a single `Tile` object
- *
- * @param tile - the `FilterTile` object to display
  */
-function Tile({ tile }: { tile: FilterTile }): React.ReactElement {
+function Tile({
+  tile,
+}: {
+  /** the `FilterTile` object to display */
+  tile: FilterTile;
+}): React.ReactElement {
   const setSelectedFilterOptions = useContext(SetSelectedFilterOptions);
   if (!setSelectedFilterOptions) {
     throw new Error(
@@ -425,15 +425,14 @@ function Tile({ tile }: { tile: FilterTile }): React.ReactElement {
   );
 }
 
-/**
- * React Client Component for the image displayed on a `Tile`
- *
- * @param filename - the file name of the image file to display
- * expected to be within the `pathogen_images` directory
- */
+/** React Client Component for the image displayed on a `Tile` */
 function TileImgWrapper({
   filename,
 }: {
+  /**
+   * the file name of the image file to display expected to be within
+   * the `pathogen_images` directory
+   */
   filename: string;
 }): React.ReactElement {
   let src: string;
@@ -446,9 +445,11 @@ function TileImgWrapper({
   return <img className={styles.tileImg} src={src} alt={""} />;
 }
 
-// Given a set of user-defined tiles, restrict them to the set of
-// tiles for which the filters are valid given the resources known to
-// the resource listing UI
+/**
+ * Given a set of user-defined tiles, restrict them to the set of
+ * tiles for which the filters are valid given the resources known to
+ * the resource listing UI
+ */
 function useTiles(tiles?: FilterTile[], groups?: Group[]): FilterTile[] {
   const [restrictedTiles, setRestrictedTiles] = useState<FilterTile[]>([]);
 

--- a/static-site/components/list-resources/individual-resource.tsx
+++ b/static-site/components/list-resources/individual-resource.tsx
@@ -16,19 +16,19 @@ import styles from "./individual-resource.module.css";
 /**
  * React Client Component to display an individual resource as part of
  * a resource listing.
- *
- * @param gapWidth - the value for the CSS `gap` property in the
- * `<div>` containing the resource
- * @param isMobile - boolean for whether the display is a mobile one
- * @param resource - the resource to display
  */
 export function IndividualResource({
   gapWidth,
   isMobile,
   resource,
 }: {
+  /** the value for the CSS `gap` property in the `<div>` containing the resource */
   gapWidth: number;
+
+  /** boolean for whether the display is a mobile one */
   isMobile: boolean;
+
+  /** the resource to display */
   resource: Resource;
 }): React.ReactElement | null {
   const setModalResource = useContext(SetModalResourceContext);

--- a/static-site/components/list-resources/modal.tsx
+++ b/static-site/components/list-resources/modal.tsx
@@ -37,12 +37,11 @@ export const SetModalResourceContext = createContext<React.Dispatch<
 /**
  * A React Client Component that displays a provided `resource` in
  * a modal popover window.
- *
- * @param resource - the VersionedResource object to display
  */
 export function ResourceModal({
   resource,
 }: {
+  /** the VersionedResource object to display */
   resource: VersionedResource;
 }): React.ReactElement {
   const [ref, setRef] = useState(null);
@@ -153,11 +152,13 @@ export function ResourceModal({
 /**
  * A React Client Component that displays a close icon in the
  * <ResourceModal> component.
- *
- * @param onClick - the callback to run when the icon is clicked;
- * ideally should close the modal
  */
-function CloseIcon({ onClick }: { onClick: () => void }): React.ReactElement {
+function CloseIcon({
+  onClick,
+}: {
+  /** the callback to run when the icon is clicked; ideally should close the modal */
+  onClick: () => void;
+}): React.ReactElement {
   const [hovered, setHovered] = useState(false);
 
   return (
@@ -179,7 +180,10 @@ function CloseIcon({ onClick }: { onClick: () => void }): React.ReactElement {
  * chronologically first date in the list, and the chronologically
  * last date in the list.
  */
-function _snapshotSummary(dates: string[]): {
+function _snapshotSummary(
+  /** list of dates to snapshot */
+  dates: string[],
+): {
   duration: string;
   first: string;
   last: string;

--- a/static-site/components/list-resources/resource-group.tsx
+++ b/static-site/components/list-resources/resource-group.tsx
@@ -16,16 +16,7 @@ import { DisplayNamedResource, Group, QuickLink, Resource } from "./types";
 
 import styles from "./resource-group.module.css";
 
-/**
- * React Client Component for displaying a group of related Resource
- * objects.
- *
- * @param group - `Group` object representing the resources to display
- * @param elWidth - the width of the element displaying the resources
- * @param numGroups - overall count of `Group` objects being displayed
- * @param sortMethod - React State holding the active sorting method
- * @param quickLinks - a list of `QuickLink` objects for the group
- */
+/** React Client Component for displaying a group of related Resource objects. */
 export default function ResourceGroup({
   group,
   elWidth,
@@ -33,10 +24,19 @@ export default function ResourceGroup({
   sortMethod,
   quickLinks,
 }: {
+  /** `Group` object representing the resources to display */
   group: Group;
+
+  /** the width of the element displaying the resources */
   elWidth: number;
+
+  /** overall count of `Group` objects being displayed */
   numGroups: number;
+
+  /** React State holding the active sorting method */
   sortMethod: string;
+
+  /** a list of `QuickLink` objects for the group */
   quickLinks: QuickLink[];
 }): React.ReactElement {
   const { collapseThreshold, resourcesToShowWhenCollapsed } =
@@ -98,18 +98,7 @@ function NextstrainLogo(): React.ReactElement {
   return <img alt="nextstrain logo" height="35px" src={nextstrainLogoPath} />;
 }
 
-/**
- * A React Client Component for the header above a <ResourceGroup>
- *
- * @param group - the `ResourceGroup` being displayed
- * @param isMobile - boolean for whether we're on a mobile sized screen
- * @param setCollapsed - a React State setter for the collapsed state
- * @param collapsible - boolean for whether the header is collapsible
- * @param isCollapsed - boolean for whether the header is _collapsed_
- * @param resourcesToShowWhenCollapsed - count of resources to show in
- * the collapsed state,
- * @param quickLinks - list of `QuickLink` objects to display
- */
+/** A React Client Component for the header above a <ResourceGroup> */
 function ResourceGroupHeader({
   group,
   isMobile,
@@ -119,12 +108,25 @@ function ResourceGroupHeader({
   resourcesToShowWhenCollapsed,
   quickLinks,
 }: {
+  /** the `ResourceGroup` being displayed */
   group: Group;
+
+  /** boolean for whether we're on a mobile sized screen */
   isMobile: boolean;
+
+  /** a React State setter for the collapsed state */
   setCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /** boolean for whether the header is collapsible */
   collapsible: boolean;
+
+  /** boolean for whether the header is _collapsed_ */
   isCollapsed: boolean;
+
+  /** count of resources to show in the collapsed state, */
   resourcesToShowWhenCollapsed: number;
+
+  /** list of `QuickLink` objects to display */
   quickLinks: QuickLink[];
 }): React.ReactElement {
   const setModalResource = useContext(SetModalResourceContext);
@@ -266,13 +268,11 @@ function ResourceGroupHeader({
  *
  *     "seasonal-flu | h1n1pdm"
  *     "             | h3n2"
- *
- * @param resources - the list of `Resource` objects to operate on
- *
- * @returns a list of `DisplayNamedResource` objects corresponding to
- * the inputs with `displayName` added
  */
-function _addDisplayName(resources: Resource[]): DisplayNamedResource[] {
+function _addDisplayName(
+  /** the list of `Resource` objects to operate on */
+  resources: Resource[],
+): DisplayNamedResource[] {
   const sep = "│"; // ASCII 179
 
   return resources.map((r, i) => {
@@ -313,13 +313,11 @@ function _addDisplayName(resources: Resource[]): DisplayNamedResource[] {
  * A helper function to calculate the collapse threshold and number of
  * groups to display when collapsed, based on the number of total
  * groups.
- *
- * @param numGroups - the total number of `Group` objects in play
- *
- * @returns An object with two numberic properties,
- * `collapseThreshold` and `resourcesToShowWhenCollapsed`
  */
-function _collapseThresholds(numGroups: number): {
+function _collapseThresholds(
+  /** the total number of `Group` objects in play */
+  numGroups: number,
+): {
   collapseThreshold: number;
   resourcesToShowWhenCollapsed: number;
 } {
@@ -348,14 +346,11 @@ function _collapseThresholds(numGroups: number): {
  * Helper function to calculate the width between resources and the
  * max width of a single resource, based on the provided list of
  * `DisplayNamedResource` objects.
- *
- * @param displayResources - the list of `DisplayNamedResource`
- * objects in play
- *
- * @returns An object with numeric properties, `gapWidth` and
- * `maxResourceWidth`
  */
-function _getMaxResourceWidth(displayResources: DisplayNamedResource[]): {
+function _getMaxResourceWidth(
+  /** the list of `DisplayNamedResource` objects in play */
+  displayResources: DisplayNamedResource[],
+): {
   gapWidth: number;
   maxResourceWidth: number;
 } {

--- a/static-site/components/list-resources/tooltip-wrapper.tsx
+++ b/static-site/components/list-resources/tooltip-wrapper.tsx
@@ -8,15 +8,15 @@ import React from "react";
  * Note that the <Tooltip> component must be included somewhere in the
  * rendered React output in order for this wrapper element to cause a
  * tooltip to appear.
- *
- * @param description - a string containing HTML, to display as the tooltip
- * @param children - the content that the tooltip applies to
  */
 export default function TooltipWrapper({
   description,
   children,
 }: {
+  /** a string containing HTML, to display as the tooltip */
   description: string;
+
+  /** the content that the tooltip applies to */
   children: React.ReactNode;
 }): React.ReactElement {
   return (

--- a/static-site/components/list-resources/types.ts
+++ b/static-site/components/list-resources/types.ts
@@ -83,10 +83,11 @@ export interface QuickLink {
  *
  * If applied to a Group object that does not have version
  * information, will throw an `InternalError`
- *
- * @param group - the Group object to convert to a VersionedGroup
  */
-export function convertVersionedGroup(group: Group): VersionedGroup {
+export function convertVersionedGroup(
+  /** the Group object to convert to a VersionedGroup */
+  group: Group,
+): VersionedGroup {
   if (group.nVersions !== undefined && group.lastUpdated !== undefined) {
     return {
       ...group,
@@ -104,10 +105,9 @@ export function convertVersionedGroup(group: Group): VersionedGroup {
  *
  * If applied to a Resource object that does not have version
  * information, will throw an `InternalError`
- *
- * @param resource - the Resource object to convert to a VersionedResource
  */
 export function convertVersionedResource(
+  /** the Resource object to convert to a VersionedResource */
   resource: Resource,
 ): VersionedResource {
   if (

--- a/static-site/components/list-resources/use-data-fetch.ts
+++ b/static-site/components/list-resources/use-data-fetch.ts
@@ -24,16 +24,18 @@ import { Group, Resource, ResourceListingInfo } from "./types";
  * to the entire API response. In the future, we may shift this
  * `versioned` status into the API response proper, to allow it to
  * vary across the returned resources.
- *
- * @param versioned - indicates whether the fetched resources are versioned
- * @param defaultGroupLinks - whether to modify the group URL to include a group
- * @param groupDisplayNames - a map used to optionally rename some resources
- * @param resourceListingCallback - the callback to fetch resource data
  */
 export default function useDataFetch(
+  /** indicates whether the fetched resources are versioned */
   versioned: boolean,
+
+  /** whether to modify the group URL to include a group */
   defaultGroupLinks: boolean,
+
+  /** a map used to optionally rename some resources */
   groupDisplayNames: Record<string, string>,
+
+  /** the callback to fetch resource data */
   resourceListingCallback: () => Promise<ResourceListingInfo>,
 ): { groups: Group[] | undefined; dataFetchError: boolean } {
   const [groups, setGroups] = useState<Group[]>();
@@ -83,16 +85,18 @@ export default function useDataFetch(
  * Helper function to convert the provided `partitions` (an object
  * mapping group names to lists of resources) into a list of `Group`
  * objects
- *
- * @param partitions - object map of names to resources
- * @param pathPrefix - prefix to add when defaultGroupLinks param is true
- * @param defaultGroupLinks - boolean controlling conversion of groupUrl values
- * @param groupDisplayNames - map controlling rename of resource names
  */
 function _groupsFrom(
+  /** object map of names to resources */
   partitions: Record<string, Resource[]>,
+
+  /** prefix to add when defaultGroupLinks param is true */
   pathPrefix: string,
+
+  /** boolean controlling conversion of groupUrl values */
   defaultGroupLinks: boolean,
+
+  /** map controlling rename of resource names */
   groupDisplayNames: Record<string, string>,
 ): Group[] {
   return Object.entries(partitions).map(([groupName, resources]) => {
@@ -127,14 +131,15 @@ function _groupsFrom(
  * Helper function to group the provided `pathVersions` object
  * mapping between path and dates into an object with pathogen/group
  * names as the keys and arrays of Resource objects as the values.
- *
- * @param pathVersions - object mapping path to lists of dates
- * @param pathPrefix - prefix added to resource name to build URL
- * @param versioned - boolean controlling addition of version-specific fields
  */
 function _partitionByPathogen(
+  /** object mapping path to lists of dates */
   pathVersions: Record<string, string[]>,
+
+  /** prefix added to resource name to build URL */
   pathPrefix: string,
+
+  /** boolean controlling addition of version-specific fields */
   versioned: boolean,
 ): Record<string, Resource[]> {
   return Object.entries(pathVersions).reduce(
@@ -182,10 +187,11 @@ function _partitionByPathogen(
  * Helper function for sorting datasets in a way that is nicer than
  * pure lexicographic sorting when dealing with temporal datasets
  * names (e.g., "12y", "2y", "6m", etc.)
- *
- * @param words - list of strings to sort
  */
-function _sortableName(words: string[]): string {
+function _sortableName(
+  /** list of strings to sort*/
+  words: string[],
+): string {
   const w = words.map((word) => {
     const m = word.match(/^(\d+)([ym])$/);
     if (m && m[1]) {
@@ -211,10 +217,11 @@ const msInADay = 1000 * 60 * 60 * 24;
  * between updates. Also considers consistency (essentially, the
  * variance) of the updates, and whether the resource/dataset
  * continues to be updated
- *
- * @param dateObjects - a list of Date objects corresponding to update dates
  */
-function _updateCadence(dateObjects: Date[]): {
+function _updateCadence(
+  /** a list of Date objects corresponding to update dates */
+  dateObjects: Date[],
+): {
   summary: string;
   description: string;
 } {

--- a/static-site/components/list-resources/use-filter-options.ts
+++ b/static-site/components/list-resources/use-filter-options.ts
@@ -6,10 +6,11 @@ import { FilterOption, Group } from "./types";
 /**
  * Utility function that takes a provided `word` and returns a
  *  `FilterOption` object based on the provided string.
- *
- * @param word - the string to make into a `FiterOption`
  */
-export function createFilterOption(word: string): FilterOption {
+export function createFilterOption(
+  /** the string to make into a `FilterOption` */
+  word: string,
+): FilterOption {
   return { label: word, value: word };
 }
 
@@ -26,10 +27,11 @@ export function createFilterOption(word: string): FilterOption {
  * apply a filter) but we don't include the count in the label because
  * the React select component doesn't update already-set options and
  * thus we get out-of-sync.
- *
- * @param resourceGroups - the list of groups to create filter options from
  */
-export function useFilterOptions(resourceGroups: Group[]): FilterOption[] {
+export function useFilterOptions(
+  /** the list of groups to create filter options from */
+  resourceGroups: Group[],
+): FilterOption[] {
   const [state, setState] = useState<FilterOption[]>([]);
 
   useMemo((): void => {

--- a/static-site/components/list-resources/use-sort-and-filter.ts
+++ b/static-site/components/list-resources/use-sort-and-filter.ts
@@ -21,16 +21,18 @@ import {
  *
  * N.b., this code runs in a React Client Component context (i.e., not
  * server side, but during the client-side hydration phase)
- *
- * @param sortMethod - either "lastUpdated" or "alphabetical""
- * @param selectedFilterOptions - a list of `FilterOption` values
- * @param setState - a setter for a React State
- * @param originalData - a list of Group objects
  */
 export default function useSortAndFilter(
+  /** either "lastUpdated" or "alphabetical" */
   sortMethod: SortMethod,
+
+  /** a list of `FilterOption` values */
   selectedFilterOptions: readonly FilterOption[],
+
+  /** a setter for a React State */
   setState: React.Dispatch<React.SetStateAction<Group[]>>,
+
+  /** a list of Group objects */
   originalData?: Group[],
 ): void {
   useMemo(() => {

--- a/static-site/components/logos/index.tsx
+++ b/static-site/components/logos/index.tsx
@@ -11,14 +11,20 @@ import bzLogo from "../../static/logos/bz_logo.png";
 
 import styles from "./styles.module.css";
 
-type Logo = {
+type LogoType = {
+  /** `src` property of the logo image */
   imgSrc: string;
+
+  /** URL that the image should link to */
   href: string;
+
+  /** width of the image, in pixels */
   width: number;
 };
 
+/** React Server Component to return a set of logos, used in the site footer. */
 export default function Logos(): React.ReactElement {
-  const logos: Logo[] = [
+  const logos: LogoType[] = [
     {
       imgSrc: fredHutchLogo.src,
       href: "http://www.fredhutch.org/",
@@ -67,7 +73,7 @@ export default function Logos(): React.ReactElement {
         <p className="footerParagraph">Nextstrain is supported by</p>
 
         <div className={styles.allLogosContainer}>
-          {logos.map((logo: Logo) => (
+          {logos.map((logo: LogoType) => (
             <Logo key={logo.href} href={logo.href} imgSrc={logo.imgSrc} width={logo.width} />
           ))}
         </div>
@@ -76,13 +82,19 @@ export default function Logos(): React.ReactElement {
   );
 }
 
+/** React Server Component to render a single logo */
 function Logo({
   href,
   imgSrc,
   width,
 }: {
+  /** URL that the image should link to */
   href: string;
+
+  /** `src` property of the logo image */
   imgSrc: string;
+
+  /** width of the image, in pixels */
   width: number;
 }): React.ReactElement {
   return (

--- a/static-site/components/nav/index.tsx
+++ b/static-site/components/nav/index.tsx
@@ -7,6 +7,7 @@ import UserOrLoginLink from "./user-or-login-link";
 
 import styles from "./styles.module.css";
 
+/** React Server Component to render the site nav bar */
 export default function Nav(): React.ReactElement {
   return (
     <nav className={styles.nav}>

--- a/static-site/components/nav/nav-logo.tsx
+++ b/static-site/components/nav/nav-logo.tsx
@@ -9,6 +9,12 @@ import logo from "../../static/logos/nextstrain-logo-small.png";
 
 import styles from "./styles.module.css";
 
+/**
+ * React Client Component to render the nav bar logo on everything
+ * except the home page.
+ *
+ * Needs to be a client component because of the use of `usePathname()`
+ */
 export default function NavLogo(): React.ReactElement | null {
   const pathname = usePathname();
 
@@ -20,21 +26,23 @@ export default function NavLogo(): React.ReactElement | null {
   ) : null;
 }
 
-const Logo = (): React.ReactElement => (
-  <a href="/" className={styles.logo}>
-    <Image src={logo} alt="Nextstrain (logo)" width="40" height="40" />
-  </a>
-);
-
-const LogoType = (): React.ReactElement => {
-  const rainbowTitle = siteTitle
-    .split("")
-    .map((letter, i) => (
-      <span key={i} style={{ color: `var(--titleColor${i})` }}>{letter}</span>
-    ));
-  const SubTitle = (): React.ReactElement => (
-    <div>Groups Server</div>
+/** React Client Component that renders the Nextstrain logo */
+function Logo(): React.ReactElement {
+  return (
+    <a href="/" className={styles.logo}>
+      <Image src={logo} alt="Nextstrain (logo)" width="40" height="40" />
+    </a>
   );
+}
+
+/** React Client Component that renders the logotype alongside the logo */
+function LogoType(): React.ReactElement {
+  const rainbowTitle = siteTitle.split("").map((letter, i) => (
+    <span key={i} style={{ color: `var(--titleColor${i})` }}>
+      {letter}
+    </span>
+  ));
+  const SubTitle = (): React.ReactElement => <div>Groups Server</div>;
 
   return (
     <div className={styles.responsiveTitle}>
@@ -44,4 +52,4 @@ const LogoType = (): React.ReactElement => {
       </a>
     </div>
   );
-};
+}

--- a/static-site/components/nav/user-or-login-link.tsx
+++ b/static-site/components/nav/user-or-login-link.tsx
@@ -4,6 +4,13 @@ import React, { useContext } from "react";
 
 import { UserContext } from "../user-data-wrapper";
 
+/*
+ * React Client Component that renders the LOGIN button or the name of
+ * the actively logged in user, when there is an actively logged in
+ * user
+ *
+ * Needs to be a client component because of the use of `useContext`
+ */
 export default function UserOrLoginLink(): React.ReactElement {
   const { user } = useContext(UserContext);
   return user ? (

--- a/static-site/components/people/avatars.tsx
+++ b/static-site/components/people/avatars.tsx
@@ -3,6 +3,10 @@ import React from "react";
 import styles from "./avatars.module.css";
 import { TeamMember, teamMembers } from "./teamMembers";
 
+/**
+ * React Server Component to render the list of small avatars of team
+ * members in the footer.
+ */
 export function FooterTeamList(): React.ReactElement {
   const people = [...teamMembers["founders"], ...teamMembers["core"]];
 
@@ -26,9 +30,11 @@ export function FooterTeamList(): React.ReactElement {
   );
 }
 
+/** React Server Component to render the team listing on the /team page */
 export function TeamPageList({
   membersKey,
 }: {
+  /** which set of team members we want to render */
   membersKey: string;
 }): React.ReactElement {
   const people: TeamMember[] = teamMembers[membersKey];
@@ -63,15 +69,23 @@ export function TeamPageList({
   );
 }
 
+/** React Server Component to render a particularly styled comma */
 function Comma(): React.ReactElement {
   return <span style={{ marginLeft: "2px", marginRight: "2px" }}>,</span>;
 }
 
+/**
+ * React Server Component to conditionally put an <a href> around a
+ * set of children, if one is provided.
+ */
 function MaybeLinked({
   link,
   children,
 }: {
+  /** the link to use, or undefined to not add a link */
   link: string | undefined;
+
+  /** the children to display, with or without associated link */
   children: React.ReactNode;
 }) {
   return link ? <a href={link}>{children}</a> : children;

--- a/static-site/components/plausible-analytics/index.tsx
+++ b/static-site/components/plausible-analytics/index.tsx
@@ -1,6 +1,7 @@
 import Script from "next/script";
 import React from "react";
 
+/** React Server Component to add analytics javascript */
 export default function PlausibleAnalytics(): React.ReactElement {
   /* See <https://plausible.io/docs/plausible-script>. Analytics are disabled on
      localhost, but use `script.local.js` if you want to track localhost for

--- a/static-site/components/spacers/index.tsx
+++ b/static-site/components/spacers/index.tsx
@@ -7,11 +7,20 @@ const DEFAULT_HEIGHTS = {
   huge: 40,
 };
 
+/**
+ * React Server Component that renders a spacer div with a particular height
+ *
+ * Note that this is an internal, non-exported helper to keep the
+ * actually exported components DRY
+ */
 function Spacer({
   count,
   height,
 }: {
+  /** how many spacers? (optional, defaults to 1) */
   count?: number;
+
+  /** height of an individual spacer */
   height: number;
 }): React.ReactElement {
   if (!count) {
@@ -21,17 +30,41 @@ function Spacer({
   return <div style={{ height: count * height }}></div>;
 }
 
-export function SmallSpacer({ count }: { count?: number }): React.ReactElement {
+/** React Server Component for a small spacer */
+export function SmallSpacer({
+  count,
+}: {
+  /** (optional) number of spacers to return, default 1 */
+  count?: number;
+}): React.ReactElement {
   return <Spacer count={count} height={DEFAULT_HEIGHTS["small"]} />;
 }
 
-export function MediumSpacer({ count }: { count?: number }): React.ReactElement {
+/** React Server Component for a medium spacer */
+export function MediumSpacer({
+  count,
+}: {
+  /** (optional) number of spacers to return, default 1 */
+  count?: number;
+}): React.ReactElement {
   return <Spacer count={count} height={DEFAULT_HEIGHTS["medium"]} />;
 }
 
-export function BigSpacer({ count }: { count?: number }): React.ReactElement {
+/** React Server Component for a big spacer */
+export function BigSpacer({
+  count,
+}: {
+  /** (optional) number of spacers to return, default 1 */ count?: number;
+}): React.ReactElement {
   return <Spacer count={count} height={DEFAULT_HEIGHTS["big"]} />;
 }
-export function HugeSpacer({ count }: { count?: number }): React.ReactElement {
+
+/** React Server Component for a HUGE spacer */
+export function HugeSpacer({
+  count,
+}: {
+  /** (optional) number of spacers to return, default 1 */
+  count?: number;
+}): React.ReactElement {
   return <Spacer count={count} height={DEFAULT_HEIGHTS["huge"]} />;
 }

--- a/static-site/components/user-data-wrapper/index.tsx
+++ b/static-site/components/user-data-wrapper/index.tsx
@@ -23,6 +23,7 @@ const initialState: UserState = {
 
 export const UserContext = createContext(initialState);
 
+/** React Client Component that wraps up tracking of logged-in user state */
 export default class UserDataWrapper extends React.Component<
   { children: React.ReactNode },
   UserState


### PR DESCRIPTION
Updates all the pages and components that had previously been ported to the App Router to use the standard JSDoc function documentation style. 

Also adjusts some whitespace, and adds usage of the `Metadata` object to the /pathogens page, aligning it with other, similar pages. 

## Related issue(s)

#1133 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
