### PR TITLE
Add /workshop redirect link

### DIFF
--- a/src/redirects.js
+++ b/src/redirects.js
@@ -122,7 +122,8 @@ const setup = (app) => {
     "/help/coronavirus/FAQ": `${mainReadTheDocs}/learn/pathogens/coronavirus/FAQ.html`,
     "/help/coronavirus/SARS-CoV-2": `${mainReadTheDocs}/learn/pathogens/coronavirus/SARS-CoV-2.html`,
     "/help/coronavirus/Technical-FAQ": `${mainReadTheDocs}/learn/pathogens/coronavirus/Technical-FAQ.html`,
-    "/help/coronavirus/human-CoV": `${mainReadTheDocs}/learn/pathogens/coronavirus/human-CoV.html`
+    "/help/coronavirus/human-CoV": `${mainReadTheDocs}/learn/pathogens/coronavirus/human-CoV.html`,
+    "/workshop": "https://github.com/nextstrain/nextstrain-walkthrough"
   };
 
   for (const [from, to] of Object.entries(docsRedirects)) {


### PR DESCRIPTION
## Description of proposed changes

Workshop attendees will be typing a URL into their browser as the first step. 'https://nextstrain.org/workshop' is easier to type than 'https://github.com/nextstrain/nextstrain-walkthrough', plus it looks nicer.

## Checklist

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
- [x] Redirect works on review app: https://nextstrain-s-victorlin--73x4gz.herokuapp.com/workshop

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
