### PR TITLE
Use portable version of logo in README

### DIFF
--- a/logo/README.md
+++ b/logo/README.md
@@ -1,6 +1,6 @@
 # Nextstrain logos
 
-![Nextstrain](logo.svg)
+![Nextstrain](logo-portable.svg)
 
 These vector logos were made in Inkscape from existing assets in use by Auspice and nextstrain.org.
 


### PR DESCRIPTION
The non-portable version can render differently on various browsers. For me, the font appears much thinner than the portable version.

Before and after:

![image](https://github.com/user-attachments/assets/c2a234ad-b4ea-408a-92bc-585c72a35e08)