### PR TITLE
Update mumps resolution names and default view

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -362,9 +362,9 @@
       },
       "mumps": {
         "resolution": {
-          "na": "",
+          "north-america": "",
           "global": "",
-          "default": "na"
+          "default": "global"
         }
       },
       "ncov": {


### PR DESCRIPTION
## Description of proposed changes

Update mumps resolution names and default view after https://github.com/nextstrain/mumps/pull/22 is merged

* Change mump resolution name from "na" to "north-america"
* Do not redirect from "mumps/na" to "mumps/north-america" since "mumps/na" is still being used by the narrative tutorial and is related to a recent paper
  * https://github.com/nextstrain/mumps/issues/19#issuecomment-2831224800
* Change default view of mumps from "north-america" to "global"

## Related issue(s)


## Checklist

- [ ] Checks pass
- [ ] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
