### PR TITLE
endpoints/cli: Provide the latest CLI version as JSON on the /cli endpoint

### DIFF
--- a/src/routing/cli.js
+++ b/src/routing/cli.js
@@ -14,6 +14,6 @@ export function setup(app) {
   app.routeAsync("/cli/installer/:os")
     .getAsync(endpoints.cli.installer);
 
-  app.route("/cli")
-    .get((req, res) => res.redirect("https://docs.nextstrain.org/projects/cli/"));
+  app.routeAsync("/cli")
+    .getAsync(endpoints.cli.info);
 }


### PR DESCRIPTION
Nextstrain CLI will soon start querying this endpoint for its own update check instead of querying PyPI directly.  This gives us insights into usage and also more flexibility to shift how we're releasing and distributing it.

Related-to: <https://github.com/nextstrain/cli/pull/434>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
