### PR TITLE
Make use of Plausible Analytics configurable [#1162]

### DIFF
--- a/static-site/components/plausible-analytics/index.tsx
+++ b/static-site/components/plausible-analytics/index.tsx
@@ -1,17 +1,31 @@
 import Script from "next/script";
 import React from "react";
 
+// import from BaseConfig to avoid a conflict with SiteConfig, due to
+// it importing an older component that's still using styled.
+//
+// TODO convert over to SiteConfig once this is no longer true.
+import {
+  plausibleAnalyticsDataDomain,
+  plausibleAnalyticsScript,
+} from "../../data/BaseConfig";
+
 /** React Server Component to add analytics javascript */
 export default function PlausibleAnalytics(): React.ReactElement {
-  /* See <https://plausible.io/docs/plausible-script>. Analytics are disabled on
-     localhost, but use `script.local.js` if you want to track localhost for
-     testing purposes */
-  return (
-    <Script
-      src="https://plausible.io/js/script.js"
-      data-domain="nextstrain.org"
-      async
-      defer
-    />
-  );
+  /* See <https://plausible.io/docs/plausible-script>. Analytics are
+     disabled on localhost; see comments in BaseConfig if you want to
+     change configuration, enable analytics for localhost, or disable
+     them completely. */
+  if (plausibleAnalyticsDataDomain && plausibleAnalyticsScript) {
+    return (
+      <Script
+        src={plausibleAnalyticsScript}
+        data-domain={plausibleAnalyticsDataDomain}
+        async
+        defer
+      />
+    );
+  } else {
+    return <></>;
+  }
 }

--- a/static-site/data/BaseConfig.js
+++ b/static-site/data/BaseConfig.js
@@ -30,3 +30,13 @@ export const blogFeeds = {
   rss2: `rss2.xml`,
 }
 export const blogFeedUrls = Object.fromEntries( Object.entries(blogFeeds).map(([k,v]) => [k, `${blogUrl}/${v}`]));
+
+/*
+  See <https://plausible.io/docs/plausible-script>. Analytics are
+  disabled on localhost, but use `script.local.js` if you want to
+  track localhost for testing purposes. If you want to disable all
+  analytics, set both of these constants to `undefined`.
+*/
+export const plausibleAnalyticsScript = "https://plausible.io/js/script.js";
+export const plausibleAnalyticsDataDomain = "nextstrain.org";
+

--- a/static-site/pages/_app.tsx
+++ b/static-site/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { AppProps } from "next/app";
 import { Lato } from 'next/font/google'
 import Script from 'next/script'
 
+import { plausibleAnalyticsDataDomain, plausibleAnalyticsScript } from "../data/SiteConfig";
 import "../src/styles/browserCompatability.css";
 import "../src/styles/bootstrap.css";
 import "../src/styles/globals.css";
@@ -23,15 +24,20 @@ export default function App({ Component, pageProps }: AppProps) {
 }
 
 function PlausibleAnalytics() {
-  /* See <https://plausible.io/docs/plausible-script>. Analytics are disabled on
-     localhost, but use `script.local.js` if you want to track localhost for
-     testing purposes */
-  return (
-    <Script
-      src="https://plausible.io/js/script.js" 
-      data-domain="nextstrain.org"
-      async
-      defer
-    />
-  )
+  /* See <https://plausible.io/docs/plausible-script>. Analytics are
+     disabled on localhost; see comments in BaseConfig if you want to
+     change configuration, enable analytics for localhost, or disable
+     them completely. */
+  if (plausibleAnalyticsDataDomain && plausibleAnalyticsScript) {
+    return (
+      <Script
+        src={plausibleAnalyticsScript}
+        data-domain={plausibleAnalyticsDataDomain}
+        async
+        defer
+      />
+    );
+  } else {
+    return <></>;
+  }
 }


### PR DESCRIPTION
## Description of proposed changes

Adds config values to BaseConfig for script URL and `data-domain` prop. Setting the config values to `undefined` will disable inclusion of the analytics script completely.

## Related issue(s)

Closes #1162 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
