### PR TITLE
Remove missing community dataset [#1193]

### DIFF
--- a/static-site/content/community-datasets.yaml
+++ b/static-site/content/community-datasets.yaml
@@ -142,10 +142,6 @@ data:
     maintainers: Bryan Tegomoh (CDCF/NDHHS)
     date: '2021-12-27'
     title: 'Genomic Surveillance of SARS-CoV-2 in Nebraska: Nebraska-focused subsampling, Last 4 EpiWeeks'
-  - url: https://nextstrain.org/community/arodzh-sudo/ncov-puertorico/Puerto-Rico
-    maintainers: Arnold Rodriguez-Hilario
-    date: '2022-02-11'
-    title: Phylogenetic Analysis of SARS-CoV-2 in Puerto Rico
   - url: https://nextstrain.org/community/andersen-lab/HCoV-19-Genomics-Nextstrain/hCoV-19/usa/california
     maintainers: the SEARCH Alliance
     date: '2021-02-18'


### PR DESCRIPTION
While porting `/community` to App Router, I looked at every community dataset/repo to verify they were all working, which lead to the discovery that the repo backing this one is gone (or no longer public).

Cleaning it up; closes #1193 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
