### PR TITLE
Fix link to Emma's personal site

### DIFF
--- a/static-site/components/people/teamMembers.ts
+++ b/static-site/components/people/teamMembers.ts
@@ -66,7 +66,7 @@ export const teamMembers: {
     {
       name: "Emma Hodcroft",
       image: "emma-hodcroft.jpg",
-      link: "https://emmahodcroft.com/",
+      link: "http://emmahodcroft.com/",
       blurb:
         "Emma joined Nextstrain in 2017 and has worked on the pipeline and visualization, including extending Nextstrain to use VCF files, but now mostly focuses on Enteroviruses and SARS-CoV-2.",
     },

--- a/static-site/src/components/People/teamMembers.js
+++ b/static-site/src/components/People/teamMembers.js
@@ -48,7 +48,7 @@ export const teamMembers = {
     {
       name: "Emma Hodcroft",
       image: "emma-hodcroft.jpg",
-      link: "https://emmahodcroft.com/",
+      link: "http://emmahodcroft.com/",
       blurb: "Emma joined Nextstrain in 2017 and has worked on the pipeline and visualization, including extending Nextstrain to use VCF files, but now mostly focuses on Enteroviruses and SARS-CoV-2."
     },
     {


### PR DESCRIPTION
## Description of proposed changes

I noticed the footer link to Emma's site wasn't working; turns out that's because we're linking `https` and it only talks `http`. This corrects the protocol in the link.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
