### PR TITLE
Update @aws-sdk/client-cognito-identity-provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -309,19 +309,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
-    "node_modules/@aws-crypto/ie11-detection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@aws-crypto/kms-keyring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring/-/kms-keyring-4.0.1.tgz",
@@ -491,437 +478,1018 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "tslib": "^1.11.1"
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@aws-crypto/util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
-      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.127.0.tgz",
-      "integrity": "sha512-G77FLYcl9egUoD3ZmR6TX94NMqBMeT53hBGrEE3uVUJV1CwfGKfaF007mPpRZnIB3avnJBQGEK6MrwlCfv2qAw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/abort-controller/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/abort-controller/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.143.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.143.0.tgz",
-      "integrity": "sha512-7e0hTa809QHCNANgvRU1xxf5jJMvVV6SSstdnIGfDKAoCdhyMkgkagFhSBWA1bnRnxsYWoNGNztanAyuDJNxhg==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.914.0.tgz",
+      "integrity": "sha512-HKBGYOPOeraZphXvwQFw5SDMpJvaSgG5EB3e6irAOg2UIkTaAuyjkPQVQNzxNmOT7oQCRNaeSDKCFugPuav7fw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.142.0",
-        "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.142.0",
-        "@aws-sdk/fetch-http-handler": "3.131.0",
-        "@aws-sdk/hash-node": "3.127.0",
-        "@aws-sdk/invalid-dependency": "3.127.0",
-        "@aws-sdk/middleware-content-length": "3.127.0",
-        "@aws-sdk/middleware-host-header": "3.127.0",
-        "@aws-sdk/middleware-logger": "3.127.0",
-        "@aws-sdk/middleware-recursion-detection": "3.127.0",
-        "@aws-sdk/middleware-retry": "3.127.0",
-        "@aws-sdk/middleware-serde": "3.127.0",
-        "@aws-sdk/middleware-signing": "3.130.0",
-        "@aws-sdk/middleware-stack": "3.127.0",
-        "@aws-sdk/middleware-user-agent": "3.127.0",
-        "@aws-sdk/node-config-provider": "3.127.0",
-        "@aws-sdk/node-http-handler": "3.127.0",
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/smithy-client": "3.142.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/url-parser": "3.127.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.142.0",
-        "@aws-sdk/util-defaults-mode-node": "3.142.0",
-        "@aws-sdk/util-user-agent-browser": "3.127.0",
-        "@aws-sdk/util-user-agent-node": "3.127.0",
-        "@aws-sdk/util-utf8-browser": "3.109.0",
-        "@aws-sdk/util-utf8-node": "3.109.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/credential-provider-node": "3.914.0",
+        "@aws-sdk/middleware-host-header": "3.914.0",
+        "@aws-sdk/middleware-logger": "3.914.0",
+        "@aws-sdk/middleware-recursion-detection": "3.914.0",
+        "@aws-sdk/middleware-user-agent": "3.914.0",
+        "@aws-sdk/region-config-resolver": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/util-endpoints": "3.914.0",
+        "@aws-sdk/util-user-agent-browser": "3.914.0",
+        "@aws-sdk/util-user-agent-node": "3.914.0",
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/hash-node": "^4.2.3",
+        "@smithy/invalid-dependency": "^4.2.3",
+        "@smithy/middleware-content-length": "^4.2.3",
+        "@smithy/middleware-endpoint": "^4.3.4",
+        "@smithy/middleware-retry": "^4.4.4",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.3",
+        "@smithy/util-defaults-mode-node": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-retry": "^4.2.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/client-sso": {
-      "version": "3.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.142.0.tgz",
-      "integrity": "sha512-Pewcpxq+wqcbB3t3s6KImBUUf+qqBNqMfd2wgQ3PdpYBjlNzrWYLHAnIT1vhIFjOGJXDi/qwF8FX7qbWNUB7Lg==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.914.0.tgz",
+      "integrity": "sha512-83Xp8Wl7RDWg/iIYL8dmrN9DN7qu7fcUzDC9LyMhDN8cAEACykN/i4Fk45UHRCejL9Sjxu4wsQzxRYp1smQ95g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/fetch-http-handler": "3.131.0",
-        "@aws-sdk/hash-node": "3.127.0",
-        "@aws-sdk/invalid-dependency": "3.127.0",
-        "@aws-sdk/middleware-content-length": "3.127.0",
-        "@aws-sdk/middleware-host-header": "3.127.0",
-        "@aws-sdk/middleware-logger": "3.127.0",
-        "@aws-sdk/middleware-recursion-detection": "3.127.0",
-        "@aws-sdk/middleware-retry": "3.127.0",
-        "@aws-sdk/middleware-serde": "3.127.0",
-        "@aws-sdk/middleware-stack": "3.127.0",
-        "@aws-sdk/middleware-user-agent": "3.127.0",
-        "@aws-sdk/node-config-provider": "3.127.0",
-        "@aws-sdk/node-http-handler": "3.127.0",
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/smithy-client": "3.142.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/url-parser": "3.127.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.142.0",
-        "@aws-sdk/util-defaults-mode-node": "3.142.0",
-        "@aws-sdk/util-user-agent-browser": "3.127.0",
-        "@aws-sdk/util-user-agent-node": "3.127.0",
-        "@aws-sdk/util-utf8-browser": "3.109.0",
-        "@aws-sdk/util-utf8-node": "3.109.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/middleware-host-header": "3.914.0",
+        "@aws-sdk/middleware-logger": "3.914.0",
+        "@aws-sdk/middleware-recursion-detection": "3.914.0",
+        "@aws-sdk/middleware-user-agent": "3.914.0",
+        "@aws-sdk/region-config-resolver": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/util-endpoints": "3.914.0",
+        "@aws-sdk/util-user-agent-browser": "3.914.0",
+        "@aws-sdk/util-user-agent-node": "3.914.0",
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/hash-node": "^4.2.3",
+        "@smithy/invalid-dependency": "^4.2.3",
+        "@smithy/middleware-content-length": "^4.2.3",
+        "@smithy/middleware-endpoint": "^4.3.4",
+        "@smithy/middleware-retry": "^4.4.4",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.3",
+        "@smithy/util-defaults-mode-node": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-retry": "^4.2.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/client-sts": {
-      "version": "3.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.142.0.tgz",
-      "integrity": "sha512-rOa1MTI1h3kTjlHkItAlXGHefM5sjsfw3muhNEhzrZBuhpOrLU8apbiG2rcJqB8m0prMoY39PuG+WquxN4ap6g==",
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/core": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.914.0.tgz",
+      "integrity": "sha512-QMnWdW7PwxVfi5WBV2a6apM1fIizgBf1UHYbqd3e1sXk8B0d3tpysmLZdIx30OY066zhEo6FyAKLAeTSsGrALg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.142.0",
-        "@aws-sdk/fetch-http-handler": "3.131.0",
-        "@aws-sdk/hash-node": "3.127.0",
-        "@aws-sdk/invalid-dependency": "3.127.0",
-        "@aws-sdk/middleware-content-length": "3.127.0",
-        "@aws-sdk/middleware-host-header": "3.127.0",
-        "@aws-sdk/middleware-logger": "3.127.0",
-        "@aws-sdk/middleware-recursion-detection": "3.127.0",
-        "@aws-sdk/middleware-retry": "3.127.0",
-        "@aws-sdk/middleware-sdk-sts": "3.130.0",
-        "@aws-sdk/middleware-serde": "3.127.0",
-        "@aws-sdk/middleware-signing": "3.130.0",
-        "@aws-sdk/middleware-stack": "3.127.0",
-        "@aws-sdk/middleware-user-agent": "3.127.0",
-        "@aws-sdk/node-config-provider": "3.127.0",
-        "@aws-sdk/node-http-handler": "3.127.0",
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/smithy-client": "3.142.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/url-parser": "3.127.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.142.0",
-        "@aws-sdk/util-defaults-mode-node": "3.142.0",
-        "@aws-sdk/util-user-agent-browser": "3.127.0",
-        "@aws-sdk/util-user-agent-node": "3.127.0",
-        "@aws-sdk/util-utf8-browser": "3.109.0",
-        "@aws-sdk/util-utf8-node": "3.109.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/xml-builder": "3.914.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/signature-v4": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.127.0.tgz",
-      "integrity": "sha512-Ig7XhUikRBlnRTYT5JBGzWfYZp68X5vkFVIFCmsHHt/qVy0Nz9raZpmDHicdS1u67yxDkWgCPn/bNevWnM0GFg==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.914.0.tgz",
+      "integrity": "sha512-v7zeMsLkTB0/ZK6DGbM6QUNIeeEtNBd+4DHihXjsHKBKxBESKIJlWF5Bcj+pgCSWcFGClxmqL6NfWCFQ0WdtjQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.914.0.tgz",
+      "integrity": "sha512-NXS5nBD0Tbk5ltjOAucdcx8EQQcFdVpCGrly56AIbznl0yhuG5Sxq4q2tUSJj9006eEXBK5rt52CdDixCcv3xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-stream": "^4.5.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.142.0.tgz",
-      "integrity": "sha512-joMJTxUTNmxURnVmmd7XhtwOwijMjh7z09V8o2EHQMk+ak+rhaRgqb2kTA2nO0J3SRxdO5z5SKkyQgW0d1fY9g==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.914.0.tgz",
+      "integrity": "sha512-RcL02V3EE8DRuu8qb5zoV+aVWbUIKZRA3NeHsWKWCD25nxQUYF4CrbQizWQ91vda5+e6PysGGLYROOzapX3Xmw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.127.0",
-        "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.142.0",
-        "@aws-sdk/credential-provider-web-identity": "3.127.0",
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/shared-ini-file-loader": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/credential-provider-env": "3.914.0",
+        "@aws-sdk/credential-provider-http": "3.914.0",
+        "@aws-sdk/credential-provider-process": "3.914.0",
+        "@aws-sdk/credential-provider-sso": "3.914.0",
+        "@aws-sdk/credential-provider-web-identity": "3.914.0",
+        "@aws-sdk/nested-clients": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/credential-provider-imds": "^4.2.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.142.0.tgz",
-      "integrity": "sha512-JkhCKNkEhCS2vgD/qg5hJPatupNLObqts9FXiDia5CF6w8YcHLH+mWSvhUMCUGkunAOvFHDkQL1uPXfoQuJvPg==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.914.0.tgz",
+      "integrity": "sha512-SDUvDKqsJ5UPDkem0rq7/bdZtXKKTnoBeWvRlI20Zuv4CLdYkyIGXU9sSA2mrhsZ/7bt1cduTHpGd1n/UdBQEg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.127.0",
-        "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-ini": "3.142.0",
-        "@aws-sdk/credential-provider-process": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.142.0",
-        "@aws-sdk/credential-provider-web-identity": "3.127.0",
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/shared-ini-file-loader": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.914.0",
+        "@aws-sdk/credential-provider-http": "3.914.0",
+        "@aws-sdk/credential-provider-ini": "3.914.0",
+        "@aws-sdk/credential-provider-process": "3.914.0",
+        "@aws-sdk/credential-provider-sso": "3.914.0",
+        "@aws-sdk/credential-provider-web-identity": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/credential-provider-imds": "^4.2.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.127.0.tgz",
-      "integrity": "sha512-6v0m2lqkO9J5fNlTl+HjriQNIdfg8mjVST544+5y9EnC/FVmTnIz64vfHveWdNkP/fehFx7wTimNENtoSqCn3A==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.914.0.tgz",
+      "integrity": "sha512-34C3CYM3iAVcSg3cX4UfOwabWeTeowjZkqJbWgDZ+I/HNZ8+9YbVuJcOZL5fVhw242UclxlVlddNPNprluZKGg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/shared-ini-file-loader": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.142.0.tgz",
-      "integrity": "sha512-jJvp/A5xrikaeL0DhjhQTvUc0+eF0hN5Nbo+nxpnUOiOOkyqs329g65NI1TmLp/OzDcqQ/8p5vj2+7ufTGEOXQ==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.914.0.tgz",
+      "integrity": "sha512-LfuSyhwvb1qOWN+oN3zyq5D899RZVA0nUrx6czKpDJYarYG0FCTZPO5aPcyoNGAjUu8l+CYUvXcd9ZdZiwv3/A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.142.0",
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/shared-ini-file-loader": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.914.0",
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/token-providers": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.127.0.tgz",
-      "integrity": "sha512-85ahDZnLYB3dqkW+cQ0bWt+NVqOoxomTrJoq3IC2q6muebeFrJ0pyf0JEW/RNRzBiUvvsZujzGdWifzWyQKfVg==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.914.0.tgz",
+      "integrity": "sha512-49zJm5x48eG4kiu7/lUGYicwpOPA3lzkuxZ8tdegKKB9Imya6yxdATx4V5UcapFfX79xgpZr750zYHHqSX53Sw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/nested-clients": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
-      "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.914.0.tgz",
+      "integrity": "sha512-KlmHhRbn1qdwXUdsdrJ7S/MAkkC1jLpQ11n+XvxUUUCGAJd1gjC7AjxPZUM7ieQ2zcb8bfEzIU7al+Q3ZT0u7Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/property-provider": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-      "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/token-providers": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.914.0.tgz",
+      "integrity": "sha512-wX8lL5OnCk/54eUPP1L/dCH+Gp/f3MjnHR6rNp+dbGs7+omUAub4dEbM/JMBE4Jsn5coiVgmgqx97Q5cRxh/EA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/nested-clients": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.109.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.109.0.tgz",
-      "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
-      "deprecated": "The package @aws-sdk/util-base64-browser has been renamed to @aws-sdk/util-base64. Please install the renamed package.",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+      "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-base64-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.55.0.tgz",
-      "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
-      "deprecated": "The package @aws-sdk/util-base64-node has been renamed to @aws-sdk/util-base64. Please install the renamed package.",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.55.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
-      "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.914.0.tgz",
+      "integrity": "sha512-POUBUTjD7WQ/BVoUGluukCIkIDO12IPdwRAvUgFshfbaUdyXFuBllM/6DmdyeR3rJhXnBqe3Uy5e2eXbz/MBTw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.55.0.tgz",
-      "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
-      "dependencies": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-endpoints": "^3.2.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
-      "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.914.0.tgz",
+      "integrity": "sha512-k75evsBD5TcIjedycYS7QXQ98AmOtbnxRJOPtCo0IwYRmy7UvqgS/gBL5SmrIqeV6FDSYRQMgdBxSMp6MLmdew==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^4.8.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.109.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
-      "integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/abort-controller": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.3.tgz",
+      "integrity": "sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.109.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.109.0.tgz",
-      "integrity": "sha512-Ti/ZBdvz2eSTElsucjzNmzpyg2MwfD1rXmxD0hZuIF8bPON/0+sZYnWd5CbDw9kgmhy28dmKue086tbZ1G0iLQ==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.55.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/config-resolver": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.0.tgz",
+      "integrity": "sha512-Kkmz3Mup2PGp/HNJxhCWkLNdlajJORLSjwkcfrj0E7nu6STAEdcMR1ir5P9/xOmncx8xXfru0fbUYLlZog/cFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/core": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.17.0.tgz",
+      "integrity": "sha512-Tir3DbfoTO97fEGUZjzGeoXgcQAUBRDTmuH9A8lxuP8ATrgezrAJ6cLuRvwdKN4ZbYNlHgKlBX69Hyu3THYhtg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-stream": "^4.5.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.3.tgz",
+      "integrity": "sha512-hA1MQ/WAHly4SYltJKitEsIDVsNmXcQfYBRv2e+q04fnqtAX5qXaybxy/fhUeAMCnQIdAjaGDb04fMHQefWRhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.4.tgz",
+      "integrity": "sha512-bwigPylvivpRLCm+YK9I5wRIYjFESSVwl8JQ1vVx/XhCw0PtCi558NwTnT2DaVCl5pYlImGuQTSwMsZ+pIavRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/querystring-builder": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/hash-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.3.tgz",
+      "integrity": "sha512-6+NOdZDbfuU6s1ISp3UOk5Rg953RJ2aBLNLLBEcamLjHAg1Po9Ha7QIB5ZWhdRUVuOUrT8BVFR+O2KIPmw027g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.3.tgz",
+      "integrity": "sha512-Cc9W5DwDuebXEDMpOpl4iERo8I0KFjTnomK2RMdhhR87GwrSmUmwMxS4P5JdRf+LsjOdIqumcerwRgYMr/tZ9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.3.tgz",
+      "integrity": "sha512-/atXLsT88GwKtfp5Jr0Ks1CSa4+lB+IgRnkNrrYP0h1wL4swHNb0YONEvTceNKNdZGJsye+W2HH8W7olbcPUeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/middleware-endpoint": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.4.tgz",
+      "integrity": "sha512-/RJhpYkMOaUZoJEkddamGPPIYeKICKXOu/ojhn85dKDM0n5iDIhjvYAQLP3K5FPhgB203O3GpWzoK2OehEoIUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.17.0",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/middleware-retry": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.4.tgz",
+      "integrity": "sha512-vSgABQAkuUHRO03AhR2rWxVQ1un284lkBn+NFawzdahmzksAoOeVMnXXsuPViL4GlhRHXqFaMlc8Mj04OfQk1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/service-error-classification": "^4.2.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-retry": "^4.2.3",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/middleware-serde": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.3.tgz",
+      "integrity": "sha512-8g4NuUINpYccxiCXM5s1/V+uLtts8NcX4+sPEbvYQDZk4XoJfDpq5y2FQxfmUL89syoldpzNzA0R9nhzdtdKnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/middleware-stack": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.3.tgz",
+      "integrity": "sha512-iGuOJkH71faPNgOj/gWuEGS6xvQashpLwWB1HjHq1lNNiVfbiJLpZVbhddPuDbx9l4Cgl0vPLq5ltRfSaHfspA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/node-config-provider": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz",
+      "integrity": "sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/node-http-handler": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.2.tgz",
+      "integrity": "sha512-MHFvTjts24cjGo1byXqhXrbqm7uznFD/ESFx8npHMWTFQVdBZjrT1hKottmp69LBTRm/JQzP/sn1vPt0/r6AYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/querystring-builder": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/property-provider": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz",
+      "integrity": "sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/protocol-http": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+      "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/querystring-builder": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.3.tgz",
+      "integrity": "sha512-LOVCGCmwMahYUM/P0YnU/AlDQFjcu+gWbFJooC417QRB/lDJlWSn8qmPSDp+s4YVAHOgtgbNG4sR+SxF/VOcJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/querystring-parser": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.3.tgz",
+      "integrity": "sha512-cYlSNHcTAX/wc1rpblli3aUlLMGgKZ/Oqn8hhjFASXMCXjIqeuQBei0cnq2JR8t4RtU9FpG6uyl6PxyArTiwKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/service-error-classification": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.3.tgz",
+      "integrity": "sha512-NkxsAxFWwsPsQiwFG2MzJ/T7uIR6AQNh1SzcxSUnmmIqIQMlLRQDKhc17M7IYjiuBXhrQRjQTo3CxX+DobS93g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz",
+      "integrity": "sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/signature-v4": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.3.tgz",
+      "integrity": "sha512-CmSlUy+eEYbIEYN5N3vvQTRfqt0lJlQkaQUIf+oizu7BbDut0pozfDjBGecfcfWf7c62Yis4JIEgqQ/TCfodaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/smithy-client": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.0.tgz",
+      "integrity": "sha512-qz7RTd15GGdwJ3ZCeBKLDQuUQ88m+skh2hJwcpPm1VqLeKzgZvXf6SrNbxvx7uOqvvkjCMXqx3YB5PDJyk00ww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.17.0",
+        "@smithy/middleware-endpoint": "^4.3.4",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-stream": "^4.5.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/types": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+      "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/url-parser": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.3.tgz",
+      "integrity": "sha512-I066AigYvY3d9VlU3zG9XzZg1yT10aNqvCaBTw9EPgu5GrsEl1aUkcMvhkIXascYH1A8W0LQo3B1Kr1cJNcQEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-base64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-config-provider": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.3.tgz",
+      "integrity": "sha512-vqHoybAuZXbFXZqgzquiUXtdY+UT/aU33sxa4GBPkiYklmR20LlCn+d3Wc3yA5ZM13gQ92SZe/D8xh6hkjx+IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.5.tgz",
+      "integrity": "sha512-YQ9GQEC3knSa8oGSNdl5U6TlLynoOlLMIszrehgJxNh80v+ZCBnlXLtjyz0ffOxuM7j9cgviJuvuNkAzUseq6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/credential-provider-imds": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-endpoints": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.3.tgz",
+      "integrity": "sha512-aCfxUOVv0CzBIkU10TubdgKSx5uRvzH064kaiPEWfNIvKOtNpu642P4FP1hgOFkjQIkDObrfIDnKMKkeyrejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-middleware": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.3.tgz",
+      "integrity": "sha512-v5ObKlSe8PWUHCqEiX2fy1gNv6goiw6E5I/PN2aXg3Fb/hse0xeaAnSpXDiWl7x6LamVKq7senB+m5LOYHUAHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-retry": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.3.tgz",
+      "integrity": "sha512-lLPWnakjC0q9z+OtiXk+9RPQiYPNAovt2IXD3CP4LkOnd9NpUsxOjMx1SnoUVB7Orb7fZp67cQMtTBKMFDvOGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-stream": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.3.tgz",
+      "integrity": "sha512-oZvn8a5bwwQBNYHT2eNo0EU8Kkby3jeIg1P2Lu9EQtqDxki1LIjGRJM6dJ5CZUig8QmLxWxqOKWvg3mVoOBs5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/fast-xml-parser": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
-      "bin": {
-        "xml2js": "cli.js"
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
       },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/client-kms": {
       "version": "3.651.1",
@@ -972,75 +1540,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-kms/node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-kms/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-kms/node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-kms/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-kms/node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-kms/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-host-header": {
@@ -2249,75 +2748,6 @@
         "@aws-sdk/client-sts": "^3.651.1"
       }
     },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.649.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.649.0.tgz",
@@ -2963,75 +3393,6 @@
       ],
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-host-header": {
@@ -3731,75 +4092,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.649.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.649.0.tgz",
@@ -4446,45 +4738,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.130.0.tgz",
-      "integrity": "sha512-7dkCHHI9kRcHW6YNr9/2Ub6XkvU9Fu6H/BnlKbaKlDR8jq7QpaFhPhctOVi5D/NDpxJgALifexFne0dvo3piTw==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.130.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/util-config-provider": "3.109.0",
-        "@aws-sdk/util-middleware": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.109.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.109.0.tgz",
-      "integrity": "sha512-GrAZl/aBv0A28LkyNyq8SPJ5fmViCwz80fWLMeWx/6q5AbivuILogjlWwEZSvZ9zrlHOcFC0+AnCa5pQrjaslw==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/config-resolver/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/core": {
       "version": "3.651.1",
@@ -5224,46 +5477,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.127.0.tgz",
-      "integrity": "sha512-I6KlIBBzmJn/U1KikiC50PK3SspT9G5lkVLBaW5a6YfOcijqVTXfAN3kYzqhfeS0j4IgfJEwKVsjsZfmprJO5A==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.127.0",
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/url-parser": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds/node_modules/@aws-sdk/property-provider": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-      "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
     "node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.651.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.651.1.tgz",
@@ -5727,111 +5940,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
-      "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/querystring-builder": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.109.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.109.0.tgz",
-      "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
-      "deprecated": "The package @aws-sdk/util-base64-browser has been renamed to @aws-sdk/util-base64. Please install the renamed package.",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/@aws-sdk/hash-node": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.127.0.tgz",
-      "integrity": "sha512-wx7DKlXdKebH4JcMsOevdsm2oDNMVm36kuMm0XWRIrFWQ/oq7OquDpEMJzWvGqWF/IfFUpb7FhAWZZpALwlcwA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/util-buffer-from": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
-      "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
-      "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.127.0.tgz",
-      "integrity": "sha512-bxvmtmJ6gIRfOHvh1jAPZBH2mzppEblPjEOFo4mOzXz4U3qPIxeuukCjboMnGK9QEpV2wObWcYYld0vxoRrfiA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
       "version": "3.430.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.430.0.tgz",
@@ -5853,32 +5961,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.127.0.tgz",
-      "integrity": "sha512-AFmMaIEW3Rzg0TaKB9l/RENLowd7ZEEOpm0trYw1CgUUORWW/ydCsDT7pekPlC25CPbhUmWXCSA4xPFSYOVnDw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
       "version": "3.428.0",
@@ -5923,30 +6005,63 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.127.0.tgz",
-      "integrity": "sha512-e2gTLJb5lYP9lRV7hN3rKY2l4jv8OygOoHElZJ3Z8KPZskjHelYPcQ8XbdfhSXXxC3vc/0QqN0ResFt3W3Pplg==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.914.0.tgz",
+      "integrity": "sha512-7r9ToySQ15+iIgXMF/h616PcQStByylVkCshmQqcdeynD/lCn2l667ynckxW4+ql0Q+Bo/URljuhJRxVJzydNA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+      "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/@smithy/protocol-http": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+      "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/@smithy/types": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+      "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
       "version": "3.428.0",
@@ -5967,92 +6082,109 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.127.0.tgz",
-      "integrity": "sha512-jMNLcZB/ECA7OfkNBLNeAlrLRehyfnUeNQJHW3kcxs9h1+6VxaF6wY+WKozszLI7/3OBzQrFHBQCfRZV7ykSLg==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.914.0.tgz",
+      "integrity": "sha512-/gaW2VENS5vKvJbcE1umV4Ag3NuiVzpsANxtrqISxT3ovyro29o1RezW/Avz/6oJqjnmgz8soe9J1t65jJdiNg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+      "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger/node_modules/@smithy/types": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+      "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.127.0.tgz",
-      "integrity": "sha512-tB6WX+Z1kUKTnn5h38XFrTCzoqPKjUZLUjN4Wb27/cbeSiTSKGAZcCXHOJm36Ukorl5arlybQTqGe689EU00Hw==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.914.0.tgz",
+      "integrity": "sha512-yiAjQKs5S2JKYc+GrkvGMwkUvhepXDigEXpSJqUseR/IrqHhvGNuOxDxq+8LbDhM4ajEW81wkiBbU+Jl9G82yQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.914.0",
+        "@aws/lambda-invoke-store": "^0.0.1",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+      "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@smithy/protocol-http": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+      "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@smithy/types": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+      "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.127.0.tgz",
-      "integrity": "sha512-ZSvg/AyGUacWnf3i8ZbyImtiCH+NyafF8uV7bITP7JkwPrG+VdNocJZOr88GRM0c1A0jfkOf7+oq+fInPwwiNA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/service-error-classification": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/util-middleware": "3.127.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
       "version": "3.429.0",
@@ -6075,112 +6207,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
-    "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.130.0.tgz",
-      "integrity": "sha512-FDfs7+ohbhEK3eH3Dshr6JDiL8P72bp3ffeNpPBXuURFqwt4pCmjHuX3SqQR0JIJ2cl3aIdxc17rKaZJfOjtPw==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.130.0",
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/signature-v4": "3.130.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/property-provider": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-      "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.127.0.tgz",
-      "integrity": "sha512-xmWMYV/t9M+b9yHjqaD1noDNJJViI2QwOH7TQZ9VbbrvdVtDrFuS9Sf9He80TBCJqeHShwQN9783W1I3Pu/8kw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.130.0.tgz",
-      "integrity": "sha512-JePq5XLR9TfRN3RQ0d7Za/bEW5D3xgtD1FNAwHeenWALeozMuQgRPjM5RroCnL/5jY3wuvCZI7cSXeqhawWqmA==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/signature-v4": "3.130.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/property-provider": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-      "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
     "node_modules/@aws-sdk/middleware-ssec": {
       "version": "3.428.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.428.0.tgz",
@@ -6199,201 +6225,1251 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
-      "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.914.0.tgz",
+      "integrity": "sha512-+grKWKg+htCpkileNOqm7LO9OrE9nVPv49CYbF7dXefQIdIhfQ0pvm+hdSUnh8GFLx86FKoJs2DZSBCYqgjQFw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/util-endpoints": "3.914.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-stack/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.127.0.tgz",
-      "integrity": "sha512-CHxgswoOzdkOEoIq7Oyob3Sx/4FYUv6BhUesAX7MNshaDDsTQPbSWjw5bqZDiL/gO+X/34fvqCVVpVD2GvxW/g==",
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/core": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.914.0.tgz",
+      "integrity": "sha512-QMnWdW7PwxVfi5WBV2a6apM1fIizgBf1UHYbqd3e1sXk8B0d3tpysmLZdIx30OY066zhEo6FyAKLAeTSsGrALg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/xml-builder": "3.914.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/signature-v4": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+      "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.914.0.tgz",
+      "integrity": "sha512-POUBUTjD7WQ/BVoUGluukCIkIDO12IPdwRAvUgFshfbaUdyXFuBllM/6DmdyeR3rJhXnBqe3Uy5e2eXbz/MBTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-endpoints": "^3.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.914.0.tgz",
+      "integrity": "sha512-k75evsBD5TcIjedycYS7QXQ98AmOtbnxRJOPtCo0IwYRmy7UvqgS/gBL5SmrIqeV6FDSYRQMgdBxSMp6MLmdew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/abort-controller": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.3.tgz",
+      "integrity": "sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/core": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.17.0.tgz",
+      "integrity": "sha512-Tir3DbfoTO97fEGUZjzGeoXgcQAUBRDTmuH9A8lxuP8ATrgezrAJ6cLuRvwdKN4ZbYNlHgKlBX69Hyu3THYhtg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-stream": "^4.5.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.4.tgz",
+      "integrity": "sha512-bwigPylvivpRLCm+YK9I5wRIYjFESSVwl8JQ1vVx/XhCw0PtCi558NwTnT2DaVCl5pYlImGuQTSwMsZ+pIavRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/querystring-builder": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/middleware-endpoint": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.4.tgz",
+      "integrity": "sha512-/RJhpYkMOaUZoJEkddamGPPIYeKICKXOu/ojhn85dKDM0n5iDIhjvYAQLP3K5FPhgB203O3GpWzoK2OehEoIUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.17.0",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/middleware-serde": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.3.tgz",
+      "integrity": "sha512-8g4NuUINpYccxiCXM5s1/V+uLtts8NcX4+sPEbvYQDZk4XoJfDpq5y2FQxfmUL89syoldpzNzA0R9nhzdtdKnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/middleware-stack": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.3.tgz",
+      "integrity": "sha512-iGuOJkH71faPNgOj/gWuEGS6xvQashpLwWB1HjHq1lNNiVfbiJLpZVbhddPuDbx9l4Cgl0vPLq5ltRfSaHfspA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/node-config-provider": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz",
+      "integrity": "sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.2.tgz",
+      "integrity": "sha512-MHFvTjts24cjGo1byXqhXrbqm7uznFD/ESFx8npHMWTFQVdBZjrT1hKottmp69LBTRm/JQzP/sn1vPt0/r6AYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/querystring-builder": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/property-provider": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz",
+      "integrity": "sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/protocol-http": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+      "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/querystring-builder": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.3.tgz",
+      "integrity": "sha512-LOVCGCmwMahYUM/P0YnU/AlDQFjcu+gWbFJooC417QRB/lDJlWSn8qmPSDp+s4YVAHOgtgbNG4sR+SxF/VOcJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/querystring-parser": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.3.tgz",
+      "integrity": "sha512-cYlSNHcTAX/wc1rpblli3aUlLMGgKZ/Oqn8hhjFASXMCXjIqeuQBei0cnq2JR8t4RtU9FpG6uyl6PxyArTiwKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz",
+      "integrity": "sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.3.tgz",
+      "integrity": "sha512-CmSlUy+eEYbIEYN5N3vvQTRfqt0lJlQkaQUIf+oizu7BbDut0pozfDjBGecfcfWf7c62Yis4JIEgqQ/TCfodaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/smithy-client": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.0.tgz",
+      "integrity": "sha512-qz7RTd15GGdwJ3ZCeBKLDQuUQ88m+skh2hJwcpPm1VqLeKzgZvXf6SrNbxvx7uOqvvkjCMXqx3YB5PDJyk00ww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.17.0",
+        "@smithy/middleware-endpoint": "^4.3.4",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-stream": "^4.5.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/types": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+      "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/url-parser": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.3.tgz",
+      "integrity": "sha512-I066AigYvY3d9VlU3zG9XzZg1yT10aNqvCaBTw9EPgu5GrsEl1aUkcMvhkIXascYH1A8W0LQo3B1Kr1cJNcQEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/util-base64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/util-endpoints": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.3.tgz",
+      "integrity": "sha512-aCfxUOVv0CzBIkU10TubdgKSx5uRvzH064kaiPEWfNIvKOtNpu642P4FP1hgOFkjQIkDObrfIDnKMKkeyrejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/util-middleware": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.3.tgz",
+      "integrity": "sha512-v5ObKlSe8PWUHCqEiX2fy1gNv6goiw6E5I/PN2aXg3Fb/hse0xeaAnSpXDiWl7x6LamVKq7senB+m5LOYHUAHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/util-stream": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.3.tgz",
+      "integrity": "sha512-oZvn8a5bwwQBNYHT2eNo0EU8Kkby3jeIg1P2Lu9EQtqDxki1LIjGRJM6dJ5CZUig8QmLxWxqOKWvg3mVoOBs5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.127.0.tgz",
-      "integrity": "sha512-bAHkASMhLZHT1yv2TX6OJGFV9Lc3t1gKfTMEKdXM2O2YhGfSx9A/qLeJm79oDfnILWQtSS2NicxlRDI2lYGf4g==",
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.914.0.tgz",
+      "integrity": "sha512-cktvDU5qsvtv9HqJ0uoPgqQ87pttRMZe33fdZ3NQmnkaT6O6AI7x9wQNW5bDH3E6rou/jYle9CBSea1Xum69rQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/shared-ini-file-loader": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/middleware-host-header": "3.914.0",
+        "@aws-sdk/middleware-logger": "3.914.0",
+        "@aws-sdk/middleware-recursion-detection": "3.914.0",
+        "@aws-sdk/middleware-user-agent": "3.914.0",
+        "@aws-sdk/region-config-resolver": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/util-endpoints": "3.914.0",
+        "@aws-sdk/util-user-agent-browser": "3.914.0",
+        "@aws-sdk/util-user-agent-node": "3.914.0",
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/hash-node": "^4.2.3",
+        "@smithy/invalid-dependency": "^4.2.3",
+        "@smithy/middleware-content-length": "^4.2.3",
+        "@smithy/middleware-endpoint": "^4.3.4",
+        "@smithy/middleware-retry": "^4.4.4",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.3",
+        "@smithy/util-defaults-mode-node": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-retry": "^4.2.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/node-config-provider/node_modules/@aws-sdk/property-provider": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-      "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.914.0.tgz",
+      "integrity": "sha512-QMnWdW7PwxVfi5WBV2a6apM1fIizgBf1UHYbqd3e1sXk8B0d3tpysmLZdIx30OY066zhEo6FyAKLAeTSsGrALg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/xml-builder": "3.914.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/signature-v4": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/node-config-provider/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-config-provider/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.127.0.tgz",
-      "integrity": "sha512-pyMKvheK8eDwWLgYIRsWy8wiyhsbYYcqkZQs3Eh6upI4E8iCY7eMmhWvHYCibvsO+UjsOwa4cAMOfwnv/Z9s8A==",
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.914.0.tgz",
+      "integrity": "sha512-KlmHhRbn1qdwXUdsdrJ7S/MAkkC1jLpQ11n+XvxUUUCGAJd1gjC7AjxPZUM7ieQ2zcb8bfEzIU7al+Q3ZT0u7Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.127.0",
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/querystring-builder": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/node-http-handler/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
-      "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+      "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/protocol-http/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.127.0.tgz",
-      "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.914.0.tgz",
+      "integrity": "sha512-POUBUTjD7WQ/BVoUGluukCIkIDO12IPdwRAvUgFshfbaUdyXFuBllM/6DmdyeR3rJhXnBqe3Uy5e2eXbz/MBTw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-endpoints": "^3.2.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/querystring-builder/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
-      "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.914.0.tgz",
+      "integrity": "sha512-k75evsBD5TcIjedycYS7QXQ98AmOtbnxRJOPtCo0IwYRmy7UvqgS/gBL5SmrIqeV6FDSYRQMgdBxSMp6MLmdew==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "@smithy/types": "^4.8.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/querystring-builder/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.127.0.tgz",
-      "integrity": "sha512-Vn/Dv+PqUSepp/DzLqq0LJJD8HdPefJCnLbO5WcHCARHSGlyGlZUFEM45k/oEHpTvgMXj/ORaP3A+tLwLu0AmA==",
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/abort-controller": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.3.tgz",
+      "integrity": "sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/querystring-parser/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/config-resolver": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.0.tgz",
+      "integrity": "sha512-Kkmz3Mup2PGp/HNJxhCWkLNdlajJORLSjwkcfrj0E7nu6STAEdcMR1ir5P9/xOmncx8xXfru0fbUYLlZog/cFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/querystring-parser/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/core": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.17.0.tgz",
+      "integrity": "sha512-Tir3DbfoTO97fEGUZjzGeoXgcQAUBRDTmuH9A8lxuP8ATrgezrAJ6cLuRvwdKN4ZbYNlHgKlBX69Hyu3THYhtg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-stream": "^4.5.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.3.tgz",
+      "integrity": "sha512-hA1MQ/WAHly4SYltJKitEsIDVsNmXcQfYBRv2e+q04fnqtAX5qXaybxy/fhUeAMCnQIdAjaGDb04fMHQefWRhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.4.tgz",
+      "integrity": "sha512-bwigPylvivpRLCm+YK9I5wRIYjFESSVwl8JQ1vVx/XhCw0PtCi558NwTnT2DaVCl5pYlImGuQTSwMsZ+pIavRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/querystring-builder": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/hash-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.3.tgz",
+      "integrity": "sha512-6+NOdZDbfuU6s1ISp3UOk5Rg953RJ2aBLNLLBEcamLjHAg1Po9Ha7QIB5ZWhdRUVuOUrT8BVFR+O2KIPmw027g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.3.tgz",
+      "integrity": "sha512-Cc9W5DwDuebXEDMpOpl4iERo8I0KFjTnomK2RMdhhR87GwrSmUmwMxS4P5JdRf+LsjOdIqumcerwRgYMr/tZ9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.3.tgz",
+      "integrity": "sha512-/atXLsT88GwKtfp5Jr0Ks1CSa4+lB+IgRnkNrrYP0h1wL4swHNb0YONEvTceNKNdZGJsye+W2HH8W7olbcPUeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-endpoint": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.4.tgz",
+      "integrity": "sha512-/RJhpYkMOaUZoJEkddamGPPIYeKICKXOu/ojhn85dKDM0n5iDIhjvYAQLP3K5FPhgB203O3GpWzoK2OehEoIUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.17.0",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-retry": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.4.tgz",
+      "integrity": "sha512-vSgABQAkuUHRO03AhR2rWxVQ1un284lkBn+NFawzdahmzksAoOeVMnXXsuPViL4GlhRHXqFaMlc8Mj04OfQk1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/service-error-classification": "^4.2.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-retry": "^4.2.3",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-serde": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.3.tgz",
+      "integrity": "sha512-8g4NuUINpYccxiCXM5s1/V+uLtts8NcX4+sPEbvYQDZk4XoJfDpq5y2FQxfmUL89syoldpzNzA0R9nhzdtdKnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-stack": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.3.tgz",
+      "integrity": "sha512-iGuOJkH71faPNgOj/gWuEGS6xvQashpLwWB1HjHq1lNNiVfbiJLpZVbhddPuDbx9l4Cgl0vPLq5ltRfSaHfspA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-config-provider": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz",
+      "integrity": "sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.2.tgz",
+      "integrity": "sha512-MHFvTjts24cjGo1byXqhXrbqm7uznFD/ESFx8npHMWTFQVdBZjrT1hKottmp69LBTRm/JQzP/sn1vPt0/r6AYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/querystring-builder": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/property-provider": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz",
+      "integrity": "sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/protocol-http": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+      "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-builder": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.3.tgz",
+      "integrity": "sha512-LOVCGCmwMahYUM/P0YnU/AlDQFjcu+gWbFJooC417QRB/lDJlWSn8qmPSDp+s4YVAHOgtgbNG4sR+SxF/VOcJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-parser": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.3.tgz",
+      "integrity": "sha512-cYlSNHcTAX/wc1rpblli3aUlLMGgKZ/Oqn8hhjFASXMCXjIqeuQBei0cnq2JR8t4RtU9FpG6uyl6PxyArTiwKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/service-error-classification": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.3.tgz",
+      "integrity": "sha512-NkxsAxFWwsPsQiwFG2MzJ/T7uIR6AQNh1SzcxSUnmmIqIQMlLRQDKhc17M7IYjiuBXhrQRjQTo3CxX+DobS93g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz",
+      "integrity": "sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/signature-v4": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.3.tgz",
+      "integrity": "sha512-CmSlUy+eEYbIEYN5N3vvQTRfqt0lJlQkaQUIf+oizu7BbDut0pozfDjBGecfcfWf7c62Yis4JIEgqQ/TCfodaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/smithy-client": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.0.tgz",
+      "integrity": "sha512-qz7RTd15GGdwJ3ZCeBKLDQuUQ88m+skh2hJwcpPm1VqLeKzgZvXf6SrNbxvx7uOqvvkjCMXqx3YB5PDJyk00ww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.17.0",
+        "@smithy/middleware-endpoint": "^4.3.4",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-stream": "^4.5.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+      "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/url-parser": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.3.tgz",
+      "integrity": "sha512-I066AigYvY3d9VlU3zG9XzZg1yT10aNqvCaBTw9EPgu5GrsEl1aUkcMvhkIXascYH1A8W0LQo3B1Kr1cJNcQEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-base64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-config-provider": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.3.tgz",
+      "integrity": "sha512-vqHoybAuZXbFXZqgzquiUXtdY+UT/aU33sxa4GBPkiYklmR20LlCn+d3Wc3yA5ZM13gQ92SZe/D8xh6hkjx+IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.5.tgz",
+      "integrity": "sha512-YQ9GQEC3knSa8oGSNdl5U6TlLynoOlLMIszrehgJxNh80v+ZCBnlXLtjyz0ffOxuM7j9cgviJuvuNkAzUseq6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/credential-provider-imds": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-endpoints": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.3.tgz",
+      "integrity": "sha512-aCfxUOVv0CzBIkU10TubdgKSx5uRvzH064kaiPEWfNIvKOtNpu642P4FP1hgOFkjQIkDObrfIDnKMKkeyrejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-middleware": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.3.tgz",
+      "integrity": "sha512-v5ObKlSe8PWUHCqEiX2fy1gNv6goiw6E5I/PN2aXg3Fb/hse0xeaAnSpXDiWl7x6LamVKq7senB+m5LOYHUAHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-retry": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.3.tgz",
+      "integrity": "sha512-lLPWnakjC0q9z+OtiXk+9RPQiYPNAovt2IXD3CP4LkOnd9NpUsxOjMx1SnoUVB7Orb7fZp67cQMtTBKMFDvOGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-stream": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.3.tgz",
+      "integrity": "sha512-oZvn8a5bwwQBNYHT2eNo0EU8Kkby3jeIg1P2Lu9EQtqDxki1LIjGRJM6dJ5CZUig8QmLxWxqOKWvg3mVoOBs5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.430.0",
@@ -6438,46 +7514,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.127.0.tgz",
-      "integrity": "sha512-wjZY9rnlA8SPrICUumTYicEKtK4/yKB62iadUk66hxe8MrH8JhuHH2NqIad0Pt/bK/YtNVhd3yb4pRapOeY5qQ==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.127.0.tgz",
-      "integrity": "sha512-S3Nn4KRTqoJsB/TbRZSWBBUrkckNMR0Juqz7bOB+wupVvddKP6IcpspSC/GX9zgJjVMV8iGisZ6AUsYsC5r+cA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.130.0.tgz",
-      "integrity": "sha512-g5G1a1NHL2uOoFfC2zQdZcj+wbjgBQPkx6xGdtqNKf9v2kS0n6ap5JUGEaqWE02lUlmWHsoMsS73hXtzwXaBRQ==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/util-hex-encoding": "3.109.0",
-        "@aws-sdk/util-middleware": "3.127.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.428.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.428.0.tgz",
@@ -6497,78 +7533,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
-      "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.109.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
-      "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
-      "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.142.0.tgz",
-      "integrity": "sha512-G38YWTfSFZb5cOH6IwLct530Uy8pnmJvJFeC1pd1nkKD4PRZb+bI2w4xXSX+znYdLA71RYK620OtVKJlB44PtA==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/smithy-client/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/smithy-client/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/token-providers": {
       "version": "3.431.0",
@@ -6802,29 +7766,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.127.0.tgz",
-      "integrity": "sha512-njZ7zn41JHRpNfr3BCesVXCLZE0zcWSfEdtRV0ICw0cU1FgYcKELSuY9+gLUB4ci6uc7gq7mPE8+w30FcM4QeA==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
     "node_modules/@aws-sdk/util-arn-parser": {
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
@@ -6840,86 +7781,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.142.0.tgz",
-      "integrity": "sha512-vVB/CrodMmIfv4v54MyBlKO0sQSI/+Mvs4g5gMyVjmT4a+1gnktJQ9R6ZHQ2/ErGewcra6eH9MU5T0r1kYe0+w==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/@aws-sdk/property-provider": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-      "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.142.0.tgz",
-      "integrity": "sha512-13d5RZLO13EDwll3COUq3D4KVsqM63kdf+YjG5mzXR1eXo6GVjghfQfiy0MYM6YbAjTfJxZQkc0nFgWLU8jdyg==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/node-config-provider": "3.127.0",
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/property-provider": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-      "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/util-endpoints": {
       "version": "3.428.0",
@@ -6973,56 +7834,63 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
-    "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
-      "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-middleware/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.127.0.tgz",
-      "integrity": "sha512-uO2oHmJswuYKJS+GiMdYI8izhpC9M7/jFFvnAmLlTEVwpEi1VX9KePAOF+u5AaBC2kzITo/7dg141XfRHZloIQ==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.914.0.tgz",
+      "integrity": "sha512-rMQUrM1ECH4kmIwlGl9UB0BtbHy6ZuKdWFrIknu8yGTRI/saAucqNTh5EI1vWBxZ0ElhK5+g7zOnUuhSmVQYUA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/types": "^4.8.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+      "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@smithy/types": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+      "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.127.0.tgz",
-      "integrity": "sha512-3P/M4ZDD2qMeeoCk7TE/Mw7cG5IjB87F6BP8nI8/oHuaz7j6fsI7D49SNpyjl8JApRynZ122Ad6hwQwRj3isYw==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.914.0.tgz",
+      "integrity": "sha512-gTkLFUZiNPgJmeFCX8VJRmQWXKfF3Imm5IquFIR5c0sCBfhtMjTXZF0dHDW5BlceZ4tFPwfF9sCqWJ52wbFSBg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-user-agent": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -7034,17 +7902,76 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+      "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/node-config-provider": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz",
+      "integrity": "sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/property-provider": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz",
+      "integrity": "sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz",
+      "integrity": "sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/types": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+      "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.52.0",
@@ -7074,6 +8001,15 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.0.1.tgz",
+      "integrity": "sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -11402,6 +12338,24 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
@@ -15398,14 +16352,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -27045,21 +27991,6 @@
         }
       }
     },
-    "@aws-crypto/ie11-detection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
     "@aws-crypto/kms-keyring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring/-/kms-keyring-4.0.1.tgz",
@@ -27247,384 +28178,781 @@
       }
     },
     "@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
       "requires": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
       "requires": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "tslib": "^1.11.1"
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@aws-crypto/supports-web-crypto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
       "requires": {
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@aws-crypto/util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
-      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
       "requires": {
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/abort-controller": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.127.0.tgz",
-      "integrity": "sha512-G77FLYcl9egUoD3ZmR6TX94NMqBMeT53hBGrEE3uVUJV1CwfGKfaF007mPpRZnIB3avnJBQGEK6MrwlCfv2qAw==",
-      "requires": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.143.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.143.0.tgz",
-      "integrity": "sha512-7e0hTa809QHCNANgvRU1xxf5jJMvVV6SSstdnIGfDKAoCdhyMkgkagFhSBWA1bnRnxsYWoNGNztanAyuDJNxhg==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.914.0.tgz",
+      "integrity": "sha512-HKBGYOPOeraZphXvwQFw5SDMpJvaSgG5EB3e6irAOg2UIkTaAuyjkPQVQNzxNmOT7oQCRNaeSDKCFugPuav7fw==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.142.0",
-        "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.142.0",
-        "@aws-sdk/fetch-http-handler": "3.131.0",
-        "@aws-sdk/hash-node": "3.127.0",
-        "@aws-sdk/invalid-dependency": "3.127.0",
-        "@aws-sdk/middleware-content-length": "3.127.0",
-        "@aws-sdk/middleware-host-header": "3.127.0",
-        "@aws-sdk/middleware-logger": "3.127.0",
-        "@aws-sdk/middleware-recursion-detection": "3.127.0",
-        "@aws-sdk/middleware-retry": "3.127.0",
-        "@aws-sdk/middleware-serde": "3.127.0",
-        "@aws-sdk/middleware-signing": "3.130.0",
-        "@aws-sdk/middleware-stack": "3.127.0",
-        "@aws-sdk/middleware-user-agent": "3.127.0",
-        "@aws-sdk/node-config-provider": "3.127.0",
-        "@aws-sdk/node-http-handler": "3.127.0",
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/smithy-client": "3.142.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/url-parser": "3.127.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.142.0",
-        "@aws-sdk/util-defaults-mode-node": "3.142.0",
-        "@aws-sdk/util-user-agent-browser": "3.127.0",
-        "@aws-sdk/util-user-agent-node": "3.127.0",
-        "@aws-sdk/util-utf8-browser": "3.109.0",
-        "@aws-sdk/util-utf8-node": "3.109.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/credential-provider-node": "3.914.0",
+        "@aws-sdk/middleware-host-header": "3.914.0",
+        "@aws-sdk/middleware-logger": "3.914.0",
+        "@aws-sdk/middleware-recursion-detection": "3.914.0",
+        "@aws-sdk/middleware-user-agent": "3.914.0",
+        "@aws-sdk/region-config-resolver": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/util-endpoints": "3.914.0",
+        "@aws-sdk/util-user-agent-browser": "3.914.0",
+        "@aws-sdk/util-user-agent-node": "3.914.0",
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/hash-node": "^4.2.3",
+        "@smithy/invalid-dependency": "^4.2.3",
+        "@smithy/middleware-content-length": "^4.2.3",
+        "@smithy/middleware-endpoint": "^4.3.4",
+        "@smithy/middleware-retry": "^4.4.4",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.3",
+        "@smithy/util-defaults-mode-node": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-retry": "^4.2.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/client-sso": {
-          "version": "3.142.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.142.0.tgz",
-          "integrity": "sha512-Pewcpxq+wqcbB3t3s6KImBUUf+qqBNqMfd2wgQ3PdpYBjlNzrWYLHAnIT1vhIFjOGJXDi/qwF8FX7qbWNUB7Lg==",
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.914.0.tgz",
+          "integrity": "sha512-83Xp8Wl7RDWg/iIYL8dmrN9DN7qu7fcUzDC9LyMhDN8cAEACykN/i4Fk45UHRCejL9Sjxu4wsQzxRYp1smQ95g==",
           "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.130.0",
-            "@aws-sdk/fetch-http-handler": "3.131.0",
-            "@aws-sdk/hash-node": "3.127.0",
-            "@aws-sdk/invalid-dependency": "3.127.0",
-            "@aws-sdk/middleware-content-length": "3.127.0",
-            "@aws-sdk/middleware-host-header": "3.127.0",
-            "@aws-sdk/middleware-logger": "3.127.0",
-            "@aws-sdk/middleware-recursion-detection": "3.127.0",
-            "@aws-sdk/middleware-retry": "3.127.0",
-            "@aws-sdk/middleware-serde": "3.127.0",
-            "@aws-sdk/middleware-stack": "3.127.0",
-            "@aws-sdk/middleware-user-agent": "3.127.0",
-            "@aws-sdk/node-config-provider": "3.127.0",
-            "@aws-sdk/node-http-handler": "3.127.0",
-            "@aws-sdk/protocol-http": "3.127.0",
-            "@aws-sdk/smithy-client": "3.142.0",
-            "@aws-sdk/types": "3.127.0",
-            "@aws-sdk/url-parser": "3.127.0",
-            "@aws-sdk/util-base64-browser": "3.109.0",
-            "@aws-sdk/util-base64-node": "3.55.0",
-            "@aws-sdk/util-body-length-browser": "3.55.0",
-            "@aws-sdk/util-body-length-node": "3.55.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.142.0",
-            "@aws-sdk/util-defaults-mode-node": "3.142.0",
-            "@aws-sdk/util-user-agent-browser": "3.127.0",
-            "@aws-sdk/util-user-agent-node": "3.127.0",
-            "@aws-sdk/util-utf8-browser": "3.109.0",
-            "@aws-sdk/util-utf8-node": "3.109.0",
-            "tslib": "^2.3.1"
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.914.0",
+            "@aws-sdk/middleware-host-header": "3.914.0",
+            "@aws-sdk/middleware-logger": "3.914.0",
+            "@aws-sdk/middleware-recursion-detection": "3.914.0",
+            "@aws-sdk/middleware-user-agent": "3.914.0",
+            "@aws-sdk/region-config-resolver": "3.914.0",
+            "@aws-sdk/types": "3.914.0",
+            "@aws-sdk/util-endpoints": "3.914.0",
+            "@aws-sdk/util-user-agent-browser": "3.914.0",
+            "@aws-sdk/util-user-agent-node": "3.914.0",
+            "@smithy/config-resolver": "^4.4.0",
+            "@smithy/core": "^3.17.0",
+            "@smithy/fetch-http-handler": "^5.3.4",
+            "@smithy/hash-node": "^4.2.3",
+            "@smithy/invalid-dependency": "^4.2.3",
+            "@smithy/middleware-content-length": "^4.2.3",
+            "@smithy/middleware-endpoint": "^4.3.4",
+            "@smithy/middleware-retry": "^4.4.4",
+            "@smithy/middleware-serde": "^4.2.3",
+            "@smithy/middleware-stack": "^4.2.3",
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/node-http-handler": "^4.4.2",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/smithy-client": "^4.9.0",
+            "@smithy/types": "^4.8.0",
+            "@smithy/url-parser": "^4.2.3",
+            "@smithy/util-base64": "^4.3.0",
+            "@smithy/util-body-length-browser": "^4.2.0",
+            "@smithy/util-body-length-node": "^4.2.1",
+            "@smithy/util-defaults-mode-browser": "^4.3.3",
+            "@smithy/util-defaults-mode-node": "^4.2.5",
+            "@smithy/util-endpoints": "^3.2.3",
+            "@smithy/util-middleware": "^4.2.3",
+            "@smithy/util-retry": "^4.2.3",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-sdk/client-sts": {
-          "version": "3.142.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.142.0.tgz",
-          "integrity": "sha512-rOa1MTI1h3kTjlHkItAlXGHefM5sjsfw3muhNEhzrZBuhpOrLU8apbiG2rcJqB8m0prMoY39PuG+WquxN4ap6g==",
+        "@aws-sdk/core": {
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.914.0.tgz",
+          "integrity": "sha512-QMnWdW7PwxVfi5WBV2a6apM1fIizgBf1UHYbqd3e1sXk8B0d3tpysmLZdIx30OY066zhEo6FyAKLAeTSsGrALg==",
           "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.130.0",
-            "@aws-sdk/credential-provider-node": "3.142.0",
-            "@aws-sdk/fetch-http-handler": "3.131.0",
-            "@aws-sdk/hash-node": "3.127.0",
-            "@aws-sdk/invalid-dependency": "3.127.0",
-            "@aws-sdk/middleware-content-length": "3.127.0",
-            "@aws-sdk/middleware-host-header": "3.127.0",
-            "@aws-sdk/middleware-logger": "3.127.0",
-            "@aws-sdk/middleware-recursion-detection": "3.127.0",
-            "@aws-sdk/middleware-retry": "3.127.0",
-            "@aws-sdk/middleware-sdk-sts": "3.130.0",
-            "@aws-sdk/middleware-serde": "3.127.0",
-            "@aws-sdk/middleware-signing": "3.130.0",
-            "@aws-sdk/middleware-stack": "3.127.0",
-            "@aws-sdk/middleware-user-agent": "3.127.0",
-            "@aws-sdk/node-config-provider": "3.127.0",
-            "@aws-sdk/node-http-handler": "3.127.0",
-            "@aws-sdk/protocol-http": "3.127.0",
-            "@aws-sdk/smithy-client": "3.142.0",
-            "@aws-sdk/types": "3.127.0",
-            "@aws-sdk/url-parser": "3.127.0",
-            "@aws-sdk/util-base64-browser": "3.109.0",
-            "@aws-sdk/util-base64-node": "3.55.0",
-            "@aws-sdk/util-body-length-browser": "3.55.0",
-            "@aws-sdk/util-body-length-node": "3.55.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.142.0",
-            "@aws-sdk/util-defaults-mode-node": "3.142.0",
-            "@aws-sdk/util-user-agent-browser": "3.127.0",
-            "@aws-sdk/util-user-agent-node": "3.127.0",
-            "@aws-sdk/util-utf8-browser": "3.109.0",
-            "@aws-sdk/util-utf8-node": "3.109.0",
-            "entities": "2.2.0",
-            "fast-xml-parser": "3.19.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.914.0",
+            "@aws-sdk/xml-builder": "3.914.0",
+            "@smithy/core": "^3.17.0",
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/signature-v4": "^5.3.3",
+            "@smithy/smithy-client": "^4.9.0",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-base64": "^4.3.0",
+            "@smithy/util-middleware": "^4.2.3",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.127.0.tgz",
-          "integrity": "sha512-Ig7XhUikRBlnRTYT5JBGzWfYZp68X5vkFVIFCmsHHt/qVy0Nz9raZpmDHicdS1u67yxDkWgCPn/bNevWnM0GFg==",
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.914.0.tgz",
+          "integrity": "sha512-v7zeMsLkTB0/ZK6DGbM6QUNIeeEtNBd+4DHihXjsHKBKxBESKIJlWF5Bcj+pgCSWcFGClxmqL6NfWCFQ0WdtjQ==",
           "requires": {
-            "@aws-sdk/property-provider": "3.127.0",
-            "@aws-sdk/types": "3.127.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/core": "3.914.0",
+            "@aws-sdk/types": "3.914.0",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-http": {
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.914.0.tgz",
+          "integrity": "sha512-NXS5nBD0Tbk5ltjOAucdcx8EQQcFdVpCGrly56AIbznl0yhuG5Sxq4q2tUSJj9006eEXBK5rt52CdDixCcv3xg==",
+          "requires": {
+            "@aws-sdk/core": "3.914.0",
+            "@aws-sdk/types": "3.914.0",
+            "@smithy/fetch-http-handler": "^5.3.4",
+            "@smithy/node-http-handler": "^4.4.2",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/smithy-client": "^4.9.0",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-stream": "^4.5.3",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.142.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.142.0.tgz",
-          "integrity": "sha512-joMJTxUTNmxURnVmmd7XhtwOwijMjh7z09V8o2EHQMk+ak+rhaRgqb2kTA2nO0J3SRxdO5z5SKkyQgW0d1fY9g==",
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.914.0.tgz",
+          "integrity": "sha512-RcL02V3EE8DRuu8qb5zoV+aVWbUIKZRA3NeHsWKWCD25nxQUYF4CrbQizWQ91vda5+e6PysGGLYROOzapX3Xmw==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.127.0",
-            "@aws-sdk/credential-provider-imds": "3.127.0",
-            "@aws-sdk/credential-provider-sso": "3.142.0",
-            "@aws-sdk/credential-provider-web-identity": "3.127.0",
-            "@aws-sdk/property-provider": "3.127.0",
-            "@aws-sdk/shared-ini-file-loader": "3.127.0",
-            "@aws-sdk/types": "3.127.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/core": "3.914.0",
+            "@aws-sdk/credential-provider-env": "3.914.0",
+            "@aws-sdk/credential-provider-http": "3.914.0",
+            "@aws-sdk/credential-provider-process": "3.914.0",
+            "@aws-sdk/credential-provider-sso": "3.914.0",
+            "@aws-sdk/credential-provider-web-identity": "3.914.0",
+            "@aws-sdk/nested-clients": "3.914.0",
+            "@aws-sdk/types": "3.914.0",
+            "@smithy/credential-provider-imds": "^4.2.3",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/shared-ini-file-loader": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.142.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.142.0.tgz",
-          "integrity": "sha512-JkhCKNkEhCS2vgD/qg5hJPatupNLObqts9FXiDia5CF6w8YcHLH+mWSvhUMCUGkunAOvFHDkQL1uPXfoQuJvPg==",
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.914.0.tgz",
+          "integrity": "sha512-SDUvDKqsJ5UPDkem0rq7/bdZtXKKTnoBeWvRlI20Zuv4CLdYkyIGXU9sSA2mrhsZ/7bt1cduTHpGd1n/UdBQEg==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.127.0",
-            "@aws-sdk/credential-provider-imds": "3.127.0",
-            "@aws-sdk/credential-provider-ini": "3.142.0",
-            "@aws-sdk/credential-provider-process": "3.127.0",
-            "@aws-sdk/credential-provider-sso": "3.142.0",
-            "@aws-sdk/credential-provider-web-identity": "3.127.0",
-            "@aws-sdk/property-provider": "3.127.0",
-            "@aws-sdk/shared-ini-file-loader": "3.127.0",
-            "@aws-sdk/types": "3.127.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/credential-provider-env": "3.914.0",
+            "@aws-sdk/credential-provider-http": "3.914.0",
+            "@aws-sdk/credential-provider-ini": "3.914.0",
+            "@aws-sdk/credential-provider-process": "3.914.0",
+            "@aws-sdk/credential-provider-sso": "3.914.0",
+            "@aws-sdk/credential-provider-web-identity": "3.914.0",
+            "@aws-sdk/types": "3.914.0",
+            "@smithy/credential-provider-imds": "^4.2.3",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/shared-ini-file-loader": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.127.0.tgz",
-          "integrity": "sha512-6v0m2lqkO9J5fNlTl+HjriQNIdfg8mjVST544+5y9EnC/FVmTnIz64vfHveWdNkP/fehFx7wTimNENtoSqCn3A==",
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.914.0.tgz",
+          "integrity": "sha512-34C3CYM3iAVcSg3cX4UfOwabWeTeowjZkqJbWgDZ+I/HNZ8+9YbVuJcOZL5fVhw242UclxlVlddNPNprluZKGg==",
           "requires": {
-            "@aws-sdk/property-provider": "3.127.0",
-            "@aws-sdk/shared-ini-file-loader": "3.127.0",
-            "@aws-sdk/types": "3.127.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/core": "3.914.0",
+            "@aws-sdk/types": "3.914.0",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/shared-ini-file-loader": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.142.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.142.0.tgz",
-          "integrity": "sha512-jJvp/A5xrikaeL0DhjhQTvUc0+eF0hN5Nbo+nxpnUOiOOkyqs329g65NI1TmLp/OzDcqQ/8p5vj2+7ufTGEOXQ==",
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.914.0.tgz",
+          "integrity": "sha512-LfuSyhwvb1qOWN+oN3zyq5D899RZVA0nUrx6czKpDJYarYG0FCTZPO5aPcyoNGAjUu8l+CYUvXcd9ZdZiwv3/A==",
           "requires": {
-            "@aws-sdk/client-sso": "3.142.0",
-            "@aws-sdk/property-provider": "3.127.0",
-            "@aws-sdk/shared-ini-file-loader": "3.127.0",
-            "@aws-sdk/types": "3.127.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/client-sso": "3.914.0",
+            "@aws-sdk/core": "3.914.0",
+            "@aws-sdk/token-providers": "3.914.0",
+            "@aws-sdk/types": "3.914.0",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/shared-ini-file-loader": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.127.0.tgz",
-          "integrity": "sha512-85ahDZnLYB3dqkW+cQ0bWt+NVqOoxomTrJoq3IC2q6muebeFrJ0pyf0JEW/RNRzBiUvvsZujzGdWifzWyQKfVg==",
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.914.0.tgz",
+          "integrity": "sha512-49zJm5x48eG4kiu7/lUGYicwpOPA3lzkuxZ8tdegKKB9Imya6yxdATx4V5UcapFfX79xgpZr750zYHHqSX53Sw==",
           "requires": {
-            "@aws-sdk/property-provider": "3.127.0",
-            "@aws-sdk/types": "3.127.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/core": "3.914.0",
+            "@aws-sdk/nested-clients": "3.914.0",
+            "@aws-sdk/types": "3.914.0",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/shared-ini-file-loader": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.55.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
-          "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
+        "@aws-sdk/region-config-resolver": {
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.914.0.tgz",
+          "integrity": "sha512-KlmHhRbn1qdwXUdsdrJ7S/MAkkC1jLpQ11n+XvxUUUCGAJd1gjC7AjxPZUM7ieQ2zcb8bfEzIU7al+Q3ZT0u7Q==",
           "requires": {
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.914.0",
+            "@smithy/config-resolver": "^4.4.0",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-sdk/property-provider": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-          "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
+        "@aws-sdk/token-providers": {
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.914.0.tgz",
+          "integrity": "sha512-wX8lL5OnCk/54eUPP1L/dCH+Gp/f3MjnHR6rNp+dbGs7+omUAub4dEbM/JMBE4Jsn5coiVgmgqx97Q5cRxh/EA==",
           "requires": {
-            "@aws-sdk/types": "3.127.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/core": "3.914.0",
+            "@aws-sdk/nested-clients": "3.914.0",
+            "@aws-sdk/types": "3.914.0",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/shared-ini-file-loader": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "@aws-sdk/util-base64-browser": {
-          "version": "3.109.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.109.0.tgz",
-          "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+          "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
           "requires": {
-            "tslib": "^2.3.1"
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-sdk/util-base64-node": {
-          "version": "3.55.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.55.0.tgz",
-          "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
+        "@aws-sdk/util-endpoints": {
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.914.0.tgz",
+          "integrity": "sha512-POUBUTjD7WQ/BVoUGluukCIkIDO12IPdwRAvUgFshfbaUdyXFuBllM/6DmdyeR3rJhXnBqe3Uy5e2eXbz/MBTw==",
           "requires": {
-            "@aws-sdk/util-buffer-from": "3.55.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.914.0",
+            "@smithy/types": "^4.8.0",
+            "@smithy/url-parser": "^4.2.3",
+            "@smithy/util-endpoints": "^3.2.3",
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-sdk/util-body-length-browser": {
-          "version": "3.55.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
-          "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+        "@aws-sdk/xml-builder": {
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.914.0.tgz",
+          "integrity": "sha512-k75evsBD5TcIjedycYS7QXQ98AmOtbnxRJOPtCo0IwYRmy7UvqgS/gBL5SmrIqeV6FDSYRQMgdBxSMp6MLmdew==",
           "requires": {
-            "tslib": "^2.3.1"
+            "@smithy/types": "^4.8.0",
+            "fast-xml-parser": "5.2.5",
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-sdk/util-body-length-node": {
-          "version": "3.55.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.55.0.tgz",
-          "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
+        "@smithy/abort-controller": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.3.tgz",
+          "integrity": "sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==",
           "requires": {
-            "tslib": "^2.3.1"
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.55.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
-          "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
+        "@smithy/config-resolver": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.0.tgz",
+          "integrity": "sha512-Kkmz3Mup2PGp/HNJxhCWkLNdlajJORLSjwkcfrj0E7nu6STAEdcMR1ir5P9/xOmncx8xXfru0fbUYLlZog/cFg==",
           "requires": {
-            "@aws-sdk/is-array-buffer": "3.55.0",
-            "tslib": "^2.3.1"
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-config-provider": "^4.2.0",
+            "@smithy/util-endpoints": "^3.2.3",
+            "@smithy/util-middleware": "^4.2.3",
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-sdk/util-utf8-browser": {
-          "version": "3.109.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
-          "integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
+        "@smithy/core": {
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.17.0.tgz",
+          "integrity": "sha512-Tir3DbfoTO97fEGUZjzGeoXgcQAUBRDTmuH9A8lxuP8ATrgezrAJ6cLuRvwdKN4ZbYNlHgKlBX69Hyu3THYhtg==",
           "requires": {
-            "tslib": "^2.3.1"
+            "@smithy/middleware-serde": "^4.2.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-base64": "^4.3.0",
+            "@smithy/util-body-length-browser": "^4.2.0",
+            "@smithy/util-middleware": "^4.2.3",
+            "@smithy/util-stream": "^4.5.3",
+            "@smithy/util-utf8": "^4.2.0",
+            "@smithy/uuid": "^1.1.0",
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-sdk/util-utf8-node": {
-          "version": "3.109.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.109.0.tgz",
-          "integrity": "sha512-Ti/ZBdvz2eSTElsucjzNmzpyg2MwfD1rXmxD0hZuIF8bPON/0+sZYnWd5CbDw9kgmhy28dmKue086tbZ1G0iLQ==",
+        "@smithy/credential-provider-imds": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.3.tgz",
+          "integrity": "sha512-hA1MQ/WAHly4SYltJKitEsIDVsNmXcQfYBRv2e+q04fnqtAX5qXaybxy/fhUeAMCnQIdAjaGDb04fMHQefWRhw==",
           "requires": {
-            "@aws-sdk/util-buffer-from": "3.55.0",
-            "tslib": "^2.3.1"
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/url-parser": "^4.2.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "5.3.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.4.tgz",
+          "integrity": "sha512-bwigPylvivpRLCm+YK9I5wRIYjFESSVwl8JQ1vVx/XhCw0PtCi558NwTnT2DaVCl5pYlImGuQTSwMsZ+pIavRw==",
+          "requires": {
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/querystring-builder": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-base64": "^4.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/hash-node": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.3.tgz",
+          "integrity": "sha512-6+NOdZDbfuU6s1ISp3UOk5Rg953RJ2aBLNLLBEcamLjHAg1Po9Ha7QIB5ZWhdRUVuOUrT8BVFR+O2KIPmw027g==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/invalid-dependency": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.3.tgz",
+          "integrity": "sha512-Cc9W5DwDuebXEDMpOpl4iERo8I0KFjTnomK2RMdhhR87GwrSmUmwMxS4P5JdRf+LsjOdIqumcerwRgYMr/tZ9Q==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-content-length": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.3.tgz",
+          "integrity": "sha512-/atXLsT88GwKtfp5Jr0Ks1CSa4+lB+IgRnkNrrYP0h1wL4swHNb0YONEvTceNKNdZGJsye+W2HH8W7olbcPUeA==",
+          "requires": {
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.4.tgz",
+          "integrity": "sha512-/RJhpYkMOaUZoJEkddamGPPIYeKICKXOu/ojhn85dKDM0n5iDIhjvYAQLP3K5FPhgB203O3GpWzoK2OehEoIUw==",
+          "requires": {
+            "@smithy/core": "^3.17.0",
+            "@smithy/middleware-serde": "^4.2.3",
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/shared-ini-file-loader": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/url-parser": "^4.2.3",
+            "@smithy/util-middleware": "^4.2.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-retry": {
+          "version": "4.4.4",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.4.tgz",
+          "integrity": "sha512-vSgABQAkuUHRO03AhR2rWxVQ1un284lkBn+NFawzdahmzksAoOeVMnXXsuPViL4GlhRHXqFaMlc8Mj04OfQk1w==",
+          "requires": {
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/service-error-classification": "^4.2.3",
+            "@smithy/smithy-client": "^4.9.0",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-middleware": "^4.2.3",
+            "@smithy/util-retry": "^4.2.3",
+            "@smithy/uuid": "^1.1.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.3.tgz",
+          "integrity": "sha512-8g4NuUINpYccxiCXM5s1/V+uLtts8NcX4+sPEbvYQDZk4XoJfDpq5y2FQxfmUL89syoldpzNzA0R9nhzdtdKnQ==",
+          "requires": {
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.3.tgz",
+          "integrity": "sha512-iGuOJkH71faPNgOj/gWuEGS6xvQashpLwWB1HjHq1lNNiVfbiJLpZVbhddPuDbx9l4Cgl0vPLq5ltRfSaHfspA==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz",
+          "integrity": "sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==",
+          "requires": {
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/shared-ini-file-loader": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.2.tgz",
+          "integrity": "sha512-MHFvTjts24cjGo1byXqhXrbqm7uznFD/ESFx8npHMWTFQVdBZjrT1hKottmp69LBTRm/JQzP/sn1vPt0/r6AYQ==",
+          "requires": {
+            "@smithy/abort-controller": "^4.2.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/querystring-builder": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz",
+          "integrity": "sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+          "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.3.tgz",
+          "integrity": "sha512-LOVCGCmwMahYUM/P0YnU/AlDQFjcu+gWbFJooC417QRB/lDJlWSn8qmPSDp+s4YVAHOgtgbNG4sR+SxF/VOcJQ==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-uri-escape": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.3.tgz",
+          "integrity": "sha512-cYlSNHcTAX/wc1rpblli3aUlLMGgKZ/Oqn8hhjFASXMCXjIqeuQBei0cnq2JR8t4RtU9FpG6uyl6PxyArTiwKA==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/service-error-classification": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.3.tgz",
+          "integrity": "sha512-NkxsAxFWwsPsQiwFG2MzJ/T7uIR6AQNh1SzcxSUnmmIqIQMlLRQDKhc17M7IYjiuBXhrQRjQTo3CxX+DobS93g==",
+          "requires": {
+            "@smithy/types": "^4.8.0"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz",
+          "integrity": "sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.3.tgz",
+          "integrity": "sha512-CmSlUy+eEYbIEYN5N3vvQTRfqt0lJlQkaQUIf+oizu7BbDut0pozfDjBGecfcfWf7c62Yis4JIEgqQ/TCfodaA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-hex-encoding": "^4.2.0",
+            "@smithy/util-middleware": "^4.2.3",
+            "@smithy/util-uri-escape": "^4.2.0",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "4.9.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.0.tgz",
+          "integrity": "sha512-qz7RTd15GGdwJ3ZCeBKLDQuUQ88m+skh2hJwcpPm1VqLeKzgZvXf6SrNbxvx7uOqvvkjCMXqx3YB5PDJyk00ww==",
+          "requires": {
+            "@smithy/core": "^3.17.0",
+            "@smithy/middleware-endpoint": "^4.3.4",
+            "@smithy/middleware-stack": "^4.2.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-stream": "^4.5.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+          "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.3.tgz",
+          "integrity": "sha512-I066AigYvY3d9VlU3zG9XzZg1yT10aNqvCaBTw9EPgu5GrsEl1aUkcMvhkIXascYH1A8W0LQo3B1Kr1cJNcQEw==",
+          "requires": {
+            "@smithy/querystring-parser": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+          "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-browser": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+          "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-node": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+          "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "requires": {
+            "@smithy/is-array-buffer": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-config-provider": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+          "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-browser": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.3.tgz",
+          "integrity": "sha512-vqHoybAuZXbFXZqgzquiUXtdY+UT/aU33sxa4GBPkiYklmR20LlCn+d3Wc3yA5ZM13gQ92SZe/D8xh6hkjx+IQ==",
+          "requires": {
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/smithy-client": "^4.9.0",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-node": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.5.tgz",
+          "integrity": "sha512-YQ9GQEC3knSa8oGSNdl5U6TlLynoOlLMIszrehgJxNh80v+ZCBnlXLtjyz0ffOxuM7j9cgviJuvuNkAzUseq6w==",
+          "requires": {
+            "@smithy/config-resolver": "^4.4.0",
+            "@smithy/credential-provider-imds": "^4.2.3",
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/smithy-client": "^4.9.0",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-endpoints": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.3.tgz",
+          "integrity": "sha512-aCfxUOVv0CzBIkU10TubdgKSx5uRvzH064kaiPEWfNIvKOtNpu642P4FP1hgOFkjQIkDObrfIDnKMKkeyrejvQ==",
+          "requires": {
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+          "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.3.tgz",
+          "integrity": "sha512-v5ObKlSe8PWUHCqEiX2fy1gNv6goiw6E5I/PN2aXg3Fb/hse0xeaAnSpXDiWl7x6LamVKq7senB+m5LOYHUAHw==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-retry": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.3.tgz",
+          "integrity": "sha512-lLPWnakjC0q9z+OtiXk+9RPQiYPNAovt2IXD3CP4LkOnd9NpUsxOjMx1SnoUVB7Orb7fZp67cQMtTBKMFDvOGg==",
+          "requires": {
+            "@smithy/service-error-classification": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.3.tgz",
+          "integrity": "sha512-oZvn8a5bwwQBNYHT2eNo0EU8Kkby3jeIg1P2Lu9EQtqDxki1LIjGRJM6dJ5CZUig8QmLxWxqOKWvg3mVoOBs5A==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^5.3.4",
+            "@smithy/node-http-handler": "^4.4.2",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-base64": "^4.3.0",
+            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-hex-encoding": "^4.2.0",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+          "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "requires": {
+            "@smithy/util-buffer-from": "^4.2.0",
+            "tslib": "^2.6.2"
           }
         },
         "fast-xml-parser": {
-          "version": "3.19.0",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-          "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+          "version": "5.2.5",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+          "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+          "requires": {
+            "strnum": "^2.1.0"
+          }
+        },
+        "strnum": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+          "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="
         },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -27676,70 +29004,6 @@
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-crypto/sha256-browser": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-          "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-          "requires": {
-            "@aws-crypto/sha256-js": "^5.2.0",
-            "@aws-crypto/supports-web-crypto": "^5.2.0",
-            "@aws-crypto/util": "^5.2.0",
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-              "requires": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@aws-crypto/sha256-js": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-          "requires": {
-            "@aws-crypto/util": "^5.2.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/supports-web-crypto": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-              "requires": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
         "@aws-sdk/middleware-host-header": {
           "version": "3.649.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.649.0.tgz",
@@ -28713,70 +29977,6 @@
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-crypto/sha256-browser": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-          "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-          "requires": {
-            "@aws-crypto/sha256-js": "^5.2.0",
-            "@aws-crypto/supports-web-crypto": "^5.2.0",
-            "@aws-crypto/util": "^5.2.0",
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-              "requires": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@aws-crypto/sha256-js": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-          "requires": {
-            "@aws-crypto/util": "^5.2.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/supports-web-crypto": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-              "requires": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
         "@aws-sdk/middleware-host-header": {
           "version": "3.649.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.649.0.tgz",
@@ -29336,70 +30536,6 @@
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-crypto/sha256-browser": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-          "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-          "requires": {
-            "@aws-crypto/sha256-js": "^5.2.0",
-            "@aws-crypto/supports-web-crypto": "^5.2.0",
-            "@aws-crypto/util": "^5.2.0",
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-              "requires": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@aws-crypto/sha256-js": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-          "requires": {
-            "@aws-crypto/util": "^5.2.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/supports-web-crypto": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-              "requires": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
         "@aws-sdk/middleware-host-header": {
           "version": "3.649.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.649.0.tgz",
@@ -29960,70 +31096,6 @@
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-crypto/sha256-browser": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-          "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-          "requires": {
-            "@aws-crypto/sha256-js": "^5.2.0",
-            "@aws-crypto/supports-web-crypto": "^5.2.0",
-            "@aws-crypto/util": "^5.2.0",
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-              "requires": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@aws-crypto/sha256-js": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-          "requires": {
-            "@aws-crypto/util": "^5.2.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/supports-web-crypto": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-              "requires": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
         "@aws-sdk/middleware-host-header": {
           "version": "3.649.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.649.0.tgz",
@@ -30534,38 +31606,6 @@
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
           "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
-        }
-      }
-    },
-    "@aws-sdk/config-resolver": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.130.0.tgz",
-      "integrity": "sha512-7dkCHHI9kRcHW6YNr9/2Ub6XkvU9Fu6H/BnlKbaKlDR8jq7QpaFhPhctOVi5D/NDpxJgALifexFne0dvo3piTw==",
-      "requires": {
-        "@aws-sdk/signature-v4": "3.130.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/util-config-provider": "3.109.0",
-        "@aws-sdk/util-middleware": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "@aws-sdk/util-config-provider": {
-          "version": "3.109.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.109.0.tgz",
-          "integrity": "sha512-GrAZl/aBv0A28LkyNyq8SPJ5fmViCwz80fWLMeWx/6q5AbivuILogjlWwEZSvZ9zrlHOcFC0+AnCa5pQrjaslw==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -31150,39 +32190,6 @@
         }
       }
     },
-    "@aws-sdk/credential-provider-imds": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.127.0.tgz",
-      "integrity": "sha512-I6KlIBBzmJn/U1KikiC50PK3SspT9G5lkVLBaW5a6YfOcijqVTXfAN3kYzqhfeS0j4IgfJEwKVsjsZfmprJO5A==",
-      "requires": {
-        "@aws-sdk/node-config-provider": "3.127.0",
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/url-parser": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/property-provider": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-          "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
-          "requires": {
-            "@aws-sdk/types": "3.127.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
     "@aws-sdk/credential-provider-ini": {
       "version": "3.651.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.651.1.tgz",
@@ -31554,98 +32561,6 @@
         }
       }
     },
-    "@aws-sdk/fetch-http-handler": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
-      "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/querystring-builder": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "@aws-sdk/util-base64-browser": {
-          "version": "3.109.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.109.0.tgz",
-          "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
-    "@aws-sdk/hash-node": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.127.0.tgz",
-      "integrity": "sha512-wx7DKlXdKebH4JcMsOevdsm2oDNMVm36kuMm0XWRIrFWQ/oq7OquDpEMJzWvGqWF/IfFUpb7FhAWZZpALwlcwA==",
-      "requires": {
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/util-buffer-from": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.55.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
-          "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.55.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
-          "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.55.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
-    "@aws-sdk/invalid-dependency": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.127.0.tgz",
-      "integrity": "sha512-bxvmtmJ6gIRfOHvh1jAPZBH2mzppEblPjEOFo4mOzXz4U3qPIxeuukCjboMnGK9QEpV2wObWcYYld0vxoRrfiA==",
-      "requires": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
     "@aws-sdk/middleware-bucket-endpoint": {
       "version": "3.430.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.430.0.tgz",
@@ -31664,28 +32579,6 @@
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-content-length": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.127.0.tgz",
-      "integrity": "sha512-AFmMaIEW3Rzg0TaKB9l/RENLowd7ZEEOpm0trYw1CgUUORWW/ydCsDT7pekPlC25CPbhUmWXCSA4xPFSYOVnDw==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -31730,24 +32623,46 @@
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.127.0.tgz",
-      "integrity": "sha512-e2gTLJb5lYP9lRV7hN3rKY2l4jv8OygOoHElZJ3Z8KPZskjHelYPcQ8XbdfhSXXxC3vc/0QqN0ResFt3W3Pplg==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.914.0.tgz",
+      "integrity": "sha512-7r9ToySQ15+iIgXMF/h616PcQStByylVkCshmQqcdeynD/lCn2l667ynckxW4+ql0Q+Bo/URljuhJRxVJzydNA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+          "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+          "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+          "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
         },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -31769,75 +32684,81 @@
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.127.0.tgz",
-      "integrity": "sha512-jMNLcZB/ECA7OfkNBLNeAlrLRehyfnUeNQJHW3kcxs9h1+6VxaF6wY+WKozszLI7/3OBzQrFHBQCfRZV7ykSLg==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.914.0.tgz",
+      "integrity": "sha512-/gaW2VENS5vKvJbcE1umV4Ag3NuiVzpsANxtrqISxT3ovyro29o1RezW/Avz/6oJqjnmgz8soe9J1t65jJdiNg==",
       "requires": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+          "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+          "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
         },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.127.0.tgz",
-      "integrity": "sha512-tB6WX+Z1kUKTnn5h38XFrTCzoqPKjUZLUjN4Wb27/cbeSiTSKGAZcCXHOJm36Ukorl5arlybQTqGe689EU00Hw==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.914.0.tgz",
+      "integrity": "sha512-yiAjQKs5S2JKYc+GrkvGMwkUvhepXDigEXpSJqUseR/IrqHhvGNuOxDxq+8LbDhM4ajEW81wkiBbU+Jl9G82yQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.914.0",
+        "@aws/lambda-invoke-store": "^0.0.1",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+          "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+          "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+          "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
         },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-retry": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.127.0.tgz",
-      "integrity": "sha512-ZSvg/AyGUacWnf3i8ZbyImtiCH+NyafF8uV7bITP7JkwPrG+VdNocJZOr88GRM0c1A0jfkOf7+oq+fInPwwiNA==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/service-error-classification": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/util-middleware": "3.127.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -31861,94 +32782,6 @@
         }
       }
     },
-    "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.130.0.tgz",
-      "integrity": "sha512-FDfs7+ohbhEK3eH3Dshr6JDiL8P72bp3ffeNpPBXuURFqwt4pCmjHuX3SqQR0JIJ2cl3aIdxc17rKaZJfOjtPw==",
-      "requires": {
-        "@aws-sdk/middleware-signing": "3.130.0",
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/signature-v4": "3.130.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/property-provider": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-          "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
-          "requires": {
-            "@aws-sdk/types": "3.127.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-serde": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.127.0.tgz",
-      "integrity": "sha512-xmWMYV/t9M+b9yHjqaD1noDNJJViI2QwOH7TQZ9VbbrvdVtDrFuS9Sf9He80TBCJqeHShwQN9783W1I3Pu/8kw==",
-      "requires": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-signing": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.130.0.tgz",
-      "integrity": "sha512-JePq5XLR9TfRN3RQ0d7Za/bEW5D3xgtD1FNAwHeenWALeozMuQgRPjM5RroCnL/5jY3wuvCZI7cSXeqhawWqmA==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/signature-v4": "3.130.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/property-provider": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-          "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
-          "requires": {
-            "@aws-sdk/types": "3.127.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
     "@aws-sdk/middleware-ssec": {
       "version": "3.428.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.428.0.tgz",
@@ -31966,168 +32799,909 @@
         }
       }
     },
-    "@aws-sdk/middleware-stack": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
-      "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
-      "requires": {
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.127.0.tgz",
-      "integrity": "sha512-CHxgswoOzdkOEoIq7Oyob3Sx/4FYUv6BhUesAX7MNshaDDsTQPbSWjw5bqZDiL/gO+X/34fvqCVVpVD2GvxW/g==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.914.0.tgz",
+      "integrity": "sha512-+grKWKg+htCpkileNOqm7LO9OrE9nVPv49CYbF7dXefQIdIhfQ0pvm+hdSUnh8GFLx86FKoJs2DZSBCYqgjQFw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/util-endpoints": "3.914.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
-    "@aws-sdk/node-config-provider": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.127.0.tgz",
-      "integrity": "sha512-bAHkASMhLZHT1yv2TX6OJGFV9Lc3t1gKfTMEKdXM2O2YhGfSx9A/qLeJm79oDfnILWQtSS2NicxlRDI2lYGf4g==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/shared-ini-file-loader": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/property-provider": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-          "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
+        "@aws-sdk/core": {
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.914.0.tgz",
+          "integrity": "sha512-QMnWdW7PwxVfi5WBV2a6apM1fIizgBf1UHYbqd3e1sXk8B0d3tpysmLZdIx30OY066zhEo6FyAKLAeTSsGrALg==",
           "requires": {
-            "@aws-sdk/types": "3.127.0",
-            "tslib": "^2.3.1"
+            "@aws-sdk/types": "3.914.0",
+            "@aws-sdk/xml-builder": "3.914.0",
+            "@smithy/core": "^3.17.0",
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/signature-v4": "^5.3.3",
+            "@smithy/smithy-client": "^4.9.0",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-base64": "^4.3.0",
+            "@smithy/util-middleware": "^4.2.3",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
-    "@aws-sdk/node-http-handler": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.127.0.tgz",
-      "integrity": "sha512-pyMKvheK8eDwWLgYIRsWy8wiyhsbYYcqkZQs3Eh6upI4E8iCY7eMmhWvHYCibvsO+UjsOwa4cAMOfwnv/Z9s8A==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.127.0",
-        "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/querystring-builder": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
-    "@aws-sdk/protocol-http": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
-      "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
-      "requires": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
-    "@aws-sdk/querystring-builder": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.127.0.tgz",
-      "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
-      "requires": {
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.55.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
-          "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+          "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
           "requires": {
-            "tslib": "^2.3.1"
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
           }
         },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.914.0.tgz",
+          "integrity": "sha512-POUBUTjD7WQ/BVoUGluukCIkIDO12IPdwRAvUgFshfbaUdyXFuBllM/6DmdyeR3rJhXnBqe3Uy5e2eXbz/MBTw==",
+          "requires": {
+            "@aws-sdk/types": "3.914.0",
+            "@smithy/types": "^4.8.0",
+            "@smithy/url-parser": "^4.2.3",
+            "@smithy/util-endpoints": "^3.2.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/xml-builder": {
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.914.0.tgz",
+          "integrity": "sha512-k75evsBD5TcIjedycYS7QXQ98AmOtbnxRJOPtCo0IwYRmy7UvqgS/gBL5SmrIqeV6FDSYRQMgdBxSMp6MLmdew==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "fast-xml-parser": "5.2.5",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/abort-controller": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.3.tgz",
+          "integrity": "sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/core": {
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.17.0.tgz",
+          "integrity": "sha512-Tir3DbfoTO97fEGUZjzGeoXgcQAUBRDTmuH9A8lxuP8ATrgezrAJ6cLuRvwdKN4ZbYNlHgKlBX69Hyu3THYhtg==",
+          "requires": {
+            "@smithy/middleware-serde": "^4.2.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-base64": "^4.3.0",
+            "@smithy/util-body-length-browser": "^4.2.0",
+            "@smithy/util-middleware": "^4.2.3",
+            "@smithy/util-stream": "^4.5.3",
+            "@smithy/util-utf8": "^4.2.0",
+            "@smithy/uuid": "^1.1.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "5.3.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.4.tgz",
+          "integrity": "sha512-bwigPylvivpRLCm+YK9I5wRIYjFESSVwl8JQ1vVx/XhCw0PtCi558NwTnT2DaVCl5pYlImGuQTSwMsZ+pIavRw==",
+          "requires": {
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/querystring-builder": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-base64": "^4.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.4.tgz",
+          "integrity": "sha512-/RJhpYkMOaUZoJEkddamGPPIYeKICKXOu/ojhn85dKDM0n5iDIhjvYAQLP3K5FPhgB203O3GpWzoK2OehEoIUw==",
+          "requires": {
+            "@smithy/core": "^3.17.0",
+            "@smithy/middleware-serde": "^4.2.3",
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/shared-ini-file-loader": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/url-parser": "^4.2.3",
+            "@smithy/util-middleware": "^4.2.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.3.tgz",
+          "integrity": "sha512-8g4NuUINpYccxiCXM5s1/V+uLtts8NcX4+sPEbvYQDZk4XoJfDpq5y2FQxfmUL89syoldpzNzA0R9nhzdtdKnQ==",
+          "requires": {
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.3.tgz",
+          "integrity": "sha512-iGuOJkH71faPNgOj/gWuEGS6xvQashpLwWB1HjHq1lNNiVfbiJLpZVbhddPuDbx9l4Cgl0vPLq5ltRfSaHfspA==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz",
+          "integrity": "sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==",
+          "requires": {
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/shared-ini-file-loader": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.2.tgz",
+          "integrity": "sha512-MHFvTjts24cjGo1byXqhXrbqm7uznFD/ESFx8npHMWTFQVdBZjrT1hKottmp69LBTRm/JQzP/sn1vPt0/r6AYQ==",
+          "requires": {
+            "@smithy/abort-controller": "^4.2.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/querystring-builder": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz",
+          "integrity": "sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+          "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.3.tgz",
+          "integrity": "sha512-LOVCGCmwMahYUM/P0YnU/AlDQFjcu+gWbFJooC417QRB/lDJlWSn8qmPSDp+s4YVAHOgtgbNG4sR+SxF/VOcJQ==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-uri-escape": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.3.tgz",
+          "integrity": "sha512-cYlSNHcTAX/wc1rpblli3aUlLMGgKZ/Oqn8hhjFASXMCXjIqeuQBei0cnq2JR8t4RtU9FpG6uyl6PxyArTiwKA==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz",
+          "integrity": "sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.3.tgz",
+          "integrity": "sha512-CmSlUy+eEYbIEYN5N3vvQTRfqt0lJlQkaQUIf+oizu7BbDut0pozfDjBGecfcfWf7c62Yis4JIEgqQ/TCfodaA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-hex-encoding": "^4.2.0",
+            "@smithy/util-middleware": "^4.2.3",
+            "@smithy/util-uri-escape": "^4.2.0",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "4.9.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.0.tgz",
+          "integrity": "sha512-qz7RTd15GGdwJ3ZCeBKLDQuUQ88m+skh2hJwcpPm1VqLeKzgZvXf6SrNbxvx7uOqvvkjCMXqx3YB5PDJyk00ww==",
+          "requires": {
+            "@smithy/core": "^3.17.0",
+            "@smithy/middleware-endpoint": "^4.3.4",
+            "@smithy/middleware-stack": "^4.2.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-stream": "^4.5.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+          "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.3.tgz",
+          "integrity": "sha512-I066AigYvY3d9VlU3zG9XzZg1yT10aNqvCaBTw9EPgu5GrsEl1aUkcMvhkIXascYH1A8W0LQo3B1Kr1cJNcQEw==",
+          "requires": {
+            "@smithy/querystring-parser": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+          "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-browser": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+          "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "requires": {
+            "@smithy/is-array-buffer": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-endpoints": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.3.tgz",
+          "integrity": "sha512-aCfxUOVv0CzBIkU10TubdgKSx5uRvzH064kaiPEWfNIvKOtNpu642P4FP1hgOFkjQIkDObrfIDnKMKkeyrejvQ==",
+          "requires": {
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+          "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.3.tgz",
+          "integrity": "sha512-v5ObKlSe8PWUHCqEiX2fy1gNv6goiw6E5I/PN2aXg3Fb/hse0xeaAnSpXDiWl7x6LamVKq7senB+m5LOYHUAHw==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.3.tgz",
+          "integrity": "sha512-oZvn8a5bwwQBNYHT2eNo0EU8Kkby3jeIg1P2Lu9EQtqDxki1LIjGRJM6dJ5CZUig8QmLxWxqOKWvg3mVoOBs5A==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^5.3.4",
+            "@smithy/node-http-handler": "^4.4.2",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-base64": "^4.3.0",
+            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-hex-encoding": "^4.2.0",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+          "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "requires": {
+            "@smithy/util-buffer-from": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "5.2.5",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+          "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+          "requires": {
+            "strnum": "^2.1.0"
+          }
+        },
+        "strnum": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+          "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="
+        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
-    "@aws-sdk/querystring-parser": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.127.0.tgz",
-      "integrity": "sha512-Vn/Dv+PqUSepp/DzLqq0LJJD8HdPefJCnLbO5WcHCARHSGlyGlZUFEM45k/oEHpTvgMXj/ORaP3A+tLwLu0AmA==",
+    "@aws-sdk/nested-clients": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.914.0.tgz",
+      "integrity": "sha512-cktvDU5qsvtv9HqJ0uoPgqQ87pttRMZe33fdZ3NQmnkaT6O6AI7x9wQNW5bDH3E6rou/jYle9CBSea1Xum69rQ==",
       "requires": {
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/middleware-host-header": "3.914.0",
+        "@aws-sdk/middleware-logger": "3.914.0",
+        "@aws-sdk/middleware-recursion-detection": "3.914.0",
+        "@aws-sdk/middleware-user-agent": "3.914.0",
+        "@aws-sdk/region-config-resolver": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/util-endpoints": "3.914.0",
+        "@aws-sdk/util-user-agent-browser": "3.914.0",
+        "@aws-sdk/util-user-agent-node": "3.914.0",
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/hash-node": "^4.2.3",
+        "@smithy/invalid-dependency": "^4.2.3",
+        "@smithy/middleware-content-length": "^4.2.3",
+        "@smithy/middleware-endpoint": "^4.3.4",
+        "@smithy/middleware-retry": "^4.4.4",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.3",
+        "@smithy/util-defaults-mode-node": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-retry": "^4.2.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
+        "@aws-sdk/core": {
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.914.0.tgz",
+          "integrity": "sha512-QMnWdW7PwxVfi5WBV2a6apM1fIizgBf1UHYbqd3e1sXk8B0d3tpysmLZdIx30OY066zhEo6FyAKLAeTSsGrALg==",
+          "requires": {
+            "@aws-sdk/types": "3.914.0",
+            "@aws-sdk/xml-builder": "3.914.0",
+            "@smithy/core": "^3.17.0",
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/signature-v4": "^5.3.3",
+            "@smithy/smithy-client": "^4.9.0",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-base64": "^4.3.0",
+            "@smithy/util-middleware": "^4.2.3",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/region-config-resolver": {
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.914.0.tgz",
+          "integrity": "sha512-KlmHhRbn1qdwXUdsdrJ7S/MAkkC1jLpQ11n+XvxUUUCGAJd1gjC7AjxPZUM7ieQ2zcb8bfEzIU7al+Q3ZT0u7Q==",
+          "requires": {
+            "@aws-sdk/types": "3.914.0",
+            "@smithy/config-resolver": "^4.4.0",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
         "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+          "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.914.0.tgz",
+          "integrity": "sha512-POUBUTjD7WQ/BVoUGluukCIkIDO12IPdwRAvUgFshfbaUdyXFuBllM/6DmdyeR3rJhXnBqe3Uy5e2eXbz/MBTw==",
+          "requires": {
+            "@aws-sdk/types": "3.914.0",
+            "@smithy/types": "^4.8.0",
+            "@smithy/url-parser": "^4.2.3",
+            "@smithy/util-endpoints": "^3.2.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/xml-builder": {
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.914.0.tgz",
+          "integrity": "sha512-k75evsBD5TcIjedycYS7QXQ98AmOtbnxRJOPtCo0IwYRmy7UvqgS/gBL5SmrIqeV6FDSYRQMgdBxSMp6MLmdew==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "fast-xml-parser": "5.2.5",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/abort-controller": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.3.tgz",
+          "integrity": "sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/config-resolver": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.0.tgz",
+          "integrity": "sha512-Kkmz3Mup2PGp/HNJxhCWkLNdlajJORLSjwkcfrj0E7nu6STAEdcMR1ir5P9/xOmncx8xXfru0fbUYLlZog/cFg==",
+          "requires": {
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-config-provider": "^4.2.0",
+            "@smithy/util-endpoints": "^3.2.3",
+            "@smithy/util-middleware": "^4.2.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/core": {
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.17.0.tgz",
+          "integrity": "sha512-Tir3DbfoTO97fEGUZjzGeoXgcQAUBRDTmuH9A8lxuP8ATrgezrAJ6cLuRvwdKN4ZbYNlHgKlBX69Hyu3THYhtg==",
+          "requires": {
+            "@smithy/middleware-serde": "^4.2.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-base64": "^4.3.0",
+            "@smithy/util-body-length-browser": "^4.2.0",
+            "@smithy/util-middleware": "^4.2.3",
+            "@smithy/util-stream": "^4.5.3",
+            "@smithy/util-utf8": "^4.2.0",
+            "@smithy/uuid": "^1.1.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/credential-provider-imds": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.3.tgz",
+          "integrity": "sha512-hA1MQ/WAHly4SYltJKitEsIDVsNmXcQfYBRv2e+q04fnqtAX5qXaybxy/fhUeAMCnQIdAjaGDb04fMHQefWRhw==",
+          "requires": {
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/url-parser": "^4.2.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "5.3.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.4.tgz",
+          "integrity": "sha512-bwigPylvivpRLCm+YK9I5wRIYjFESSVwl8JQ1vVx/XhCw0PtCi558NwTnT2DaVCl5pYlImGuQTSwMsZ+pIavRw==",
+          "requires": {
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/querystring-builder": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-base64": "^4.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/hash-node": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.3.tgz",
+          "integrity": "sha512-6+NOdZDbfuU6s1ISp3UOk5Rg953RJ2aBLNLLBEcamLjHAg1Po9Ha7QIB5ZWhdRUVuOUrT8BVFR+O2KIPmw027g==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/invalid-dependency": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.3.tgz",
+          "integrity": "sha512-Cc9W5DwDuebXEDMpOpl4iERo8I0KFjTnomK2RMdhhR87GwrSmUmwMxS4P5JdRf+LsjOdIqumcerwRgYMr/tZ9Q==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-content-length": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.3.tgz",
+          "integrity": "sha512-/atXLsT88GwKtfp5Jr0Ks1CSa4+lB+IgRnkNrrYP0h1wL4swHNb0YONEvTceNKNdZGJsye+W2HH8W7olbcPUeA==",
+          "requires": {
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.4.tgz",
+          "integrity": "sha512-/RJhpYkMOaUZoJEkddamGPPIYeKICKXOu/ojhn85dKDM0n5iDIhjvYAQLP3K5FPhgB203O3GpWzoK2OehEoIUw==",
+          "requires": {
+            "@smithy/core": "^3.17.0",
+            "@smithy/middleware-serde": "^4.2.3",
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/shared-ini-file-loader": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/url-parser": "^4.2.3",
+            "@smithy/util-middleware": "^4.2.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-retry": {
+          "version": "4.4.4",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.4.tgz",
+          "integrity": "sha512-vSgABQAkuUHRO03AhR2rWxVQ1un284lkBn+NFawzdahmzksAoOeVMnXXsuPViL4GlhRHXqFaMlc8Mj04OfQk1w==",
+          "requires": {
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/service-error-classification": "^4.2.3",
+            "@smithy/smithy-client": "^4.9.0",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-middleware": "^4.2.3",
+            "@smithy/util-retry": "^4.2.3",
+            "@smithy/uuid": "^1.1.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.3.tgz",
+          "integrity": "sha512-8g4NuUINpYccxiCXM5s1/V+uLtts8NcX4+sPEbvYQDZk4XoJfDpq5y2FQxfmUL89syoldpzNzA0R9nhzdtdKnQ==",
+          "requires": {
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.3.tgz",
+          "integrity": "sha512-iGuOJkH71faPNgOj/gWuEGS6xvQashpLwWB1HjHq1lNNiVfbiJLpZVbhddPuDbx9l4Cgl0vPLq5ltRfSaHfspA==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz",
+          "integrity": "sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==",
+          "requires": {
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/shared-ini-file-loader": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.2.tgz",
+          "integrity": "sha512-MHFvTjts24cjGo1byXqhXrbqm7uznFD/ESFx8npHMWTFQVdBZjrT1hKottmp69LBTRm/JQzP/sn1vPt0/r6AYQ==",
+          "requires": {
+            "@smithy/abort-controller": "^4.2.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/querystring-builder": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz",
+          "integrity": "sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+          "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.3.tgz",
+          "integrity": "sha512-LOVCGCmwMahYUM/P0YnU/AlDQFjcu+gWbFJooC417QRB/lDJlWSn8qmPSDp+s4YVAHOgtgbNG4sR+SxF/VOcJQ==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-uri-escape": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.3.tgz",
+          "integrity": "sha512-cYlSNHcTAX/wc1rpblli3aUlLMGgKZ/Oqn8hhjFASXMCXjIqeuQBei0cnq2JR8t4RtU9FpG6uyl6PxyArTiwKA==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/service-error-classification": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.3.tgz",
+          "integrity": "sha512-NkxsAxFWwsPsQiwFG2MzJ/T7uIR6AQNh1SzcxSUnmmIqIQMlLRQDKhc17M7IYjiuBXhrQRjQTo3CxX+DobS93g==",
+          "requires": {
+            "@smithy/types": "^4.8.0"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz",
+          "integrity": "sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.3.tgz",
+          "integrity": "sha512-CmSlUy+eEYbIEYN5N3vvQTRfqt0lJlQkaQUIf+oizu7BbDut0pozfDjBGecfcfWf7c62Yis4JIEgqQ/TCfodaA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-hex-encoding": "^4.2.0",
+            "@smithy/util-middleware": "^4.2.3",
+            "@smithy/util-uri-escape": "^4.2.0",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "4.9.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.0.tgz",
+          "integrity": "sha512-qz7RTd15GGdwJ3ZCeBKLDQuUQ88m+skh2hJwcpPm1VqLeKzgZvXf6SrNbxvx7uOqvvkjCMXqx3YB5PDJyk00ww==",
+          "requires": {
+            "@smithy/core": "^3.17.0",
+            "@smithy/middleware-endpoint": "^4.3.4",
+            "@smithy/middleware-stack": "^4.2.3",
+            "@smithy/protocol-http": "^5.3.3",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-stream": "^4.5.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+          "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.3.tgz",
+          "integrity": "sha512-I066AigYvY3d9VlU3zG9XzZg1yT10aNqvCaBTw9EPgu5GrsEl1aUkcMvhkIXascYH1A8W0LQo3B1Kr1cJNcQEw==",
+          "requires": {
+            "@smithy/querystring-parser": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+          "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-browser": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+          "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-node": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+          "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "requires": {
+            "@smithy/is-array-buffer": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-config-provider": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+          "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-browser": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.3.tgz",
+          "integrity": "sha512-vqHoybAuZXbFXZqgzquiUXtdY+UT/aU33sxa4GBPkiYklmR20LlCn+d3Wc3yA5ZM13gQ92SZe/D8xh6hkjx+IQ==",
+          "requires": {
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/smithy-client": "^4.9.0",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-node": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.5.tgz",
+          "integrity": "sha512-YQ9GQEC3knSa8oGSNdl5U6TlLynoOlLMIszrehgJxNh80v+ZCBnlXLtjyz0ffOxuM7j9cgviJuvuNkAzUseq6w==",
+          "requires": {
+            "@smithy/config-resolver": "^4.4.0",
+            "@smithy/credential-provider-imds": "^4.2.3",
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/smithy-client": "^4.9.0",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-endpoints": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.3.tgz",
+          "integrity": "sha512-aCfxUOVv0CzBIkU10TubdgKSx5uRvzH064kaiPEWfNIvKOtNpu642P4FP1hgOFkjQIkDObrfIDnKMKkeyrejvQ==",
+          "requires": {
+            "@smithy/node-config-provider": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+          "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.3.tgz",
+          "integrity": "sha512-v5ObKlSe8PWUHCqEiX2fy1gNv6goiw6E5I/PN2aXg3Fb/hse0xeaAnSpXDiWl7x6LamVKq7senB+m5LOYHUAHw==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-retry": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.3.tgz",
+          "integrity": "sha512-lLPWnakjC0q9z+OtiXk+9RPQiYPNAovt2IXD3CP4LkOnd9NpUsxOjMx1SnoUVB7Orb7fZp67cQMtTBKMFDvOGg==",
+          "requires": {
+            "@smithy/service-error-classification": "^4.2.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.3.tgz",
+          "integrity": "sha512-oZvn8a5bwwQBNYHT2eNo0EU8Kkby3jeIg1P2Lu9EQtqDxki1LIjGRJM6dJ5CZUig8QmLxWxqOKWvg3mVoOBs5A==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^5.3.4",
+            "@smithy/node-http-handler": "^4.4.2",
+            "@smithy/types": "^4.8.0",
+            "@smithy/util-base64": "^4.3.0",
+            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-hex-encoding": "^4.2.0",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+          "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "requires": {
+            "@smithy/util-buffer-from": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "5.2.5",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+          "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+          "requires": {
+            "strnum": "^2.1.0"
+          }
+        },
+        "strnum": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+          "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="
         },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -32172,75 +33746,6 @@
         }
       }
     },
-    "@aws-sdk/service-error-classification": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.127.0.tgz",
-      "integrity": "sha512-wjZY9rnlA8SPrICUumTYicEKtK4/yKB62iadUk66hxe8MrH8JhuHH2NqIad0Pt/bK/YtNVhd3yb4pRapOeY5qQ=="
-    },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.127.0.tgz",
-      "integrity": "sha512-S3Nn4KRTqoJsB/TbRZSWBBUrkckNMR0Juqz7bOB+wupVvddKP6IcpspSC/GX9zgJjVMV8iGisZ6AUsYsC5r+cA==",
-      "requires": {
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        }
-      }
-    },
-    "@aws-sdk/signature-v4": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.130.0.tgz",
-      "integrity": "sha512-g5G1a1NHL2uOoFfC2zQdZcj+wbjgBQPkx6xGdtqNKf9v2kS0n6ap5JUGEaqWE02lUlmWHsoMsS73hXtzwXaBRQ==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/types": "3.127.0",
-        "@aws-sdk/util-hex-encoding": "3.109.0",
-        "@aws-sdk/util-middleware": "3.127.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.55.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
-          "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.109.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
-          "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.55.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
-          "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
     "@aws-sdk/signature-v4-multi-region": {
       "version": "3.428.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.428.0.tgz",
@@ -32257,28 +33762,6 @@
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        }
-      }
-    },
-    "@aws-sdk/smithy-client": {
-      "version": "3.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.142.0.tgz",
-      "integrity": "sha512-G38YWTfSFZb5cOH6IwLct530Uy8pnmJvJFeC1pd1nkKD4PRZb+bI2w4xXSX+znYdLA71RYK620OtVKJlB44PtA==",
-      "requires": {
-        "@aws-sdk/middleware-stack": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -32499,28 +33982,6 @@
         }
       }
     },
-    "@aws-sdk/url-parser": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.127.0.tgz",
-      "integrity": "sha512-njZ7zn41JHRpNfr3BCesVXCLZE0zcWSfEdtRV0ICw0cU1FgYcKELSuY9+gLUB4ci6uc7gq7mPE8+w30FcM4QeA==",
-      "requires": {
-        "@aws-sdk/querystring-parser": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
     "@aws-sdk/util-arn-parser": {
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
@@ -32533,72 +33994,6 @@
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        }
-      }
-    },
-    "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.142.0.tgz",
-      "integrity": "sha512-vVB/CrodMmIfv4v54MyBlKO0sQSI/+Mvs4g5gMyVjmT4a+1gnktJQ9R6ZHQ2/ErGewcra6eH9MU5T0r1kYe0+w==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/property-provider": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-          "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
-          "requires": {
-            "@aws-sdk/types": "3.127.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
-    "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.142.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.142.0.tgz",
-      "integrity": "sha512-13d5RZLO13EDwll3COUq3D4KVsqM63kdf+YjG5mzXR1eXo6GVjghfQfiy0MYM6YbAjTfJxZQkc0nFgWLU8jdyg==",
-      "requires": {
-        "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/node-config-provider": "3.127.0",
-        "@aws-sdk/property-provider": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/property-provider": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
-          "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
-          "requires": {
-            "@aws-sdk/types": "3.127.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -32651,62 +34046,103 @@
         }
       }
     },
-    "@aws-sdk/util-middleware": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
-      "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
-      }
-    },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.127.0.tgz",
-      "integrity": "sha512-uO2oHmJswuYKJS+GiMdYI8izhpC9M7/jFFvnAmLlTEVwpEi1VX9KePAOF+u5AaBC2kzITo/7dg141XfRHZloIQ==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.914.0.tgz",
+      "integrity": "sha512-rMQUrM1ECH4kmIwlGl9UB0BtbHy6ZuKdWFrIknu8yGTRI/saAucqNTh5EI1vWBxZ0ElhK5+g7zOnUuhSmVQYUA==",
       "requires": {
-        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/types": "^4.8.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+          "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+          "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
         },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.127.0.tgz",
-      "integrity": "sha512-3P/M4ZDD2qMeeoCk7TE/Mw7cG5IjB87F6BP8nI8/oHuaz7j6fsI7D49SNpyjl8JApRynZ122Ad6hwQwRj3isYw==",
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.914.0.tgz",
+      "integrity": "sha512-gTkLFUZiNPgJmeFCX8VJRmQWXKfF3Imm5IquFIR5c0sCBfhtMjTXZF0dHDW5BlceZ4tFPwfF9sCqWJ52wbFSBg==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.127.0",
-        "@aws-sdk/types": "3.127.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-user-agent": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.127.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
+          "version": "3.914.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+          "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz",
+          "integrity": "sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==",
+          "requires": {
+            "@smithy/property-provider": "^4.2.3",
+            "@smithy/shared-ini-file-loader": "^4.3.3",
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz",
+          "integrity": "sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz",
+          "integrity": "sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==",
+          "requires": {
+            "@smithy/types": "^4.8.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+          "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
         },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -32739,6 +34175,11 @@
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
+    },
+    "@aws/lambda-invoke-store": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.0.1.tgz",
+      "integrity": "sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw=="
     },
     "@babel/code-frame": {
       "version": "7.27.1",
@@ -36086,6 +37527,21 @@
         }
       }
     },
+    "@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "requires": {
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
     "@swc/helpers": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
@@ -39062,11 +40518,6 @@
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
       }
-    },
-    "entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
     "env-paths": {
       "version": "2.2.1",


### PR DESCRIPTION
## Description of proposed changes

This bumps the package from version 3.143.0 to 3.914.0. The older version would show a segfault when initializing
CognitoIdentityProviderClient.

Command:

    npm update @aws-sdk/client-cognito-identity-provider

## Related issue(s)

Closes #767

## Checklist

- [x] Issue is fixed locally
- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
