### PR TITLE
static-site[list-resources]: Fix crash in modal_draw() when bottoming out during radius calculations

### DIFF
--- a/static-site/components/list-resources/modal_draw.js
+++ b/static-site/components/list-resources/modal_draw.js
@@ -92,7 +92,6 @@ export default function modal_draw(ref, resource, lightGrey) {
     heights.marginBelowAxis;
   let radius = 12;
   const padding = 1;
-  let nextRadius = radius;
   let iterCount = 0;
   let beeswarmData;
   let beeswarmHeight = 0;
@@ -100,21 +99,18 @@ export default function modal_draw(ref, resource, lightGrey) {
   const maxIter = 5;
   const radiusJump = 2;
   while (iterCount++ < maxIter && spareHeight > 50) {
-    const nextBeeswarmData = dodge(flatData, {
-      radius: nextRadius * 2 + padding,
+    beeswarmData = dodge(flatData, {
+      radius: radius * 2 + padding,
       x: (d) => x(d["date"]),
     });
-    const nextBeeswarmHeight = d3.max(nextBeeswarmData.map((d) => d.y));
+    beeswarmHeight = d3.max(beeswarmData.map((d) => d.y));
     const nextSpareHeight =
-      availBeeswarmHeight - nextBeeswarmHeight - nextRadius;
+      availBeeswarmHeight - beeswarmHeight - radius;
     if (nextSpareHeight <= spareHeight && nextSpareHeight > 0) {
-      beeswarmData = nextBeeswarmData;
-      beeswarmHeight = nextBeeswarmHeight;
       spareHeight = nextSpareHeight;
-      radius = nextRadius;
-      nextRadius += radiusJump;
+      radius += radiusJump;
     } else {
-      nextRadius -= radiusJump;
+      radius -= radiusJump;
     }
   }
 


### PR DESCRIPTION
Fixes the algorithm which calculates an ideal radius for the points on the beeswarm plot by ensuring that beeswarmData, beeswarmHeight, and radius are all set to their last computed values when bottoming out as well as when topping out.  Simplifies state tracking instead of doubling variables unnecessarily.

Previously when bottoming out on downward iterations, the algorithm would leave beeswarmData unset, which caused errors like this from inside d3:

    TypeError: can't access property Symbol.iterator, items is undefined

This was triggered when many data points were close together causing beeswarm heights to soar.

Bottoming out will mean that some points in the plot are cut off, i.e. above the top of the chart.  This seems preferable to a crash (or unclickably tiny points).  Future improvements could dynamically scale the chart height in such cases, or alternatively the chart width to spread out points horizontally and make the longer timeline scrollable.

Resolves: <https://github.com/nextstrain/nextstrain.org/issues/1252>
## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
