### PR TITLE
Define image element in list-resources

### DIFF
--- a/static-site/app/groups/[[...groups]]/group-listing-page.tsx
+++ b/static-site/app/groups/[[...groups]]/group-listing-page.tsx
@@ -18,7 +18,7 @@ import fetchAndParseJSON from "../../../util/fetch-and-parse-json";
 import ScrollableAnchor from "../../../vendored/react-scrollable-anchor/index";
 
 import GroupTiles from "./group-tiles";
-import GroupLogo from "./group-logo";
+import usersIcon from "../../../static/logos/fa-users-solid.svg";
 
 import type { AvailableGroups, DataResource } from "./types";
 
@@ -186,8 +186,9 @@ async function _resourcesCallback(): Promise<Group[]> {
       const filteredResources = resources.filter((r) => r.groupName===groupName);
       return {
         groupName,
-        groupDisplayName: groupName, 
-        groupLogo: <GroupLogo />,
+        groupDisplayName: groupName,
+        groupImgSrc: usersIcon.src,
+        groupImgAlt: "default group logo",
         resources: filteredResources,
         nResources: filteredResources.length,
         nVersions: undefined,

--- a/static-site/app/groups/[[...groups]]/group-logo.tsx
+++ b/static-site/app/groups/[[...groups]]/group-logo.tsx
@@ -1,9 +1,0 @@
-"use client";
-
-import React from "react";
-
-import usersIcon from "../../../static/logos/fa-users-solid.svg";
-
-export default function GroupLogo(): React.ReactElement {
-  return <img alt="default group logo" height="35px" src={usersIcon.src} />;
-}

--- a/static-site/components/list-resources/listResourcesApi.tsx
+++ b/static-site/components/list-resources/listResourcesApi.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { ResourceType, Resource, Group, PathVersionsForGroup, FetchGroupHistory } from "./types";
 import { InternalError } from "../error-boundary";
 import fetchAndParseJSON from "../../util/fetch-and-parse-json";
@@ -84,7 +83,8 @@ function resourceGroup(groupName: string, resources: Resource[]): Group {
 
   const groupInfo: Group = {
     groupName,
-    groupLogo: <NextstrainLogo />,
+    groupImgSrc: nextstrainLogoSmall.src,
+    groupImgAlt: "nextstrain logo",
     resources,
     nResources: resources.length,
     nVersions,
@@ -92,10 +92,6 @@ function resourceGroup(groupName: string, resources: Resource[]): Group {
   };
 
   return groupInfo;
-}
-
-function NextstrainLogo(): React.ReactElement {
-  return <img alt="nextstrain logo" height="35px" src={nextstrainLogoSmall.src} />;
 }
 
 /**

--- a/static-site/components/list-resources/resource-group.tsx
+++ b/static-site/components/list-resources/resource-group.tsx
@@ -142,7 +142,7 @@ function ResourceGroupHeader({
 
   return (
     <div className={styles.headerContainer}>
-      {group.groupLogo}
+      <img alt={group.groupImgAlt} height="35px" src={group.groupImgSrc} />
 
       <div className={styles.flexColumnContainer}>
         <div className={styles.headerRow}>

--- a/static-site/components/list-resources/types.ts
+++ b/static-site/components/list-resources/types.ts
@@ -10,7 +10,8 @@ export type SortMethod = "lastUpdated" | "alphabetical";
 
 export interface Group {
   groupName: string;
-  groupLogo: React.ReactElement;
+  groupImgSrc: string;
+  groupImgAlt: string;
   nResources: number;
   nVersions: number | undefined;
   lastUpdated: string | undefined;


### PR DESCRIPTION
## Description of proposed changes

As mentioned in "Set logo per resource group" (bb73035), passing the element as a component in the data object was meant to support asynchronous fetches of external logos, but we've decided against doing that.

This commit reverts back to defining the image element in the list-resources component, but keeps it customizable by passing the image source and alt text in the data object. Setting the height in the parent component makes more sense anyways.

## Related issue(s)

Follow-up to #1263

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
