### PR TITLE
Restore "no datasets" message

### DIFF
--- a/static-site/components/list-resources/index.tsx
+++ b/static-site/components/list-resources/index.tsx
@@ -170,7 +170,7 @@ function ListResourcesContent({
 
   const [sortMethod, changeSortMethod] = useState<SortMethod>("alphabetical");
 
-  const [resourceGroups, setResourceGroups] = useState<Group[]>([]);
+  const [resourceGroups, setResourceGroups] = useState<Group[]>();
 
   useSortAndFilter(
     sortMethod,
@@ -193,11 +193,19 @@ function ListResourcesContent({
     );
   }
 
-  if (!resourceGroups?.length) {
+  if (resourceGroups === undefined) {
     return (
       <div>
         <Spinner />
       </div>
+    );
+  }
+
+  if (resourceGroups.length === 0) {
+    return (
+      <h4 className="centered">
+        {`No ${resourceType}s are available for this group.`}
+      </h4>
     );
   }
 

--- a/static-site/components/list-resources/use-filter-options.ts
+++ b/static-site/components/list-resources/use-filter-options.ts
@@ -30,11 +30,13 @@ export function createFilterOption(
  */
 export function useFilterOptions(
   /** the list of groups to create filter options from */
-  resourceGroups: Group[],
+  resourceGroups?: Group[],
 ): FilterOption[] {
   const [state, setState] = useState<FilterOption[]>([]);
 
   useMemo((): void => {
+    if (resourceGroups === undefined) return;
+
     const counts: { [key: string]: number } = {};
 
     const increment = (key: string) => {

--- a/static-site/components/list-resources/use-sort-and-filter.ts
+++ b/static-site/components/list-resources/use-sort-and-filter.ts
@@ -30,7 +30,7 @@ export default function useSortAndFilter(
   selectedFilterOptions: readonly FilterOption[],
 
   /** a setter for a React State */
-  setState: React.Dispatch<React.SetStateAction<Group[]>>,
+  setState: React.Dispatch<React.SetStateAction<Group[] | undefined>>,
 
   /** a list of Group objects */
   originalData?: Group[],


### PR DESCRIPTION
## Description of proposed changes

This was inadvertently removed in "Use new dataset browser on individual group pages" (#1267). Without this check, the ListResources component will display a forever-spinning Nextstrain logo for empty results. Such a scenario has always been possible with URL query filters that return no results, but it became an obvious bug on individual group pages without any datasets.

## Related issue(s)

Follow-up to #1267

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
