### PR TITLE
individual-group-page: use origin-relative URLs for `ListResources`

### DIFF
--- a/static-site/app/groups/[[...groups]]/individual-group-page.tsx
+++ b/static-site/app/groups/[[...groups]]/individual-group-page.tsx
@@ -118,7 +118,7 @@ export default function IndividualGroupPage({
         groupName: group,
         nameParts: name.split('/'),
         sortingName: name,
-        url: dataset.request.replace(/^groups\//, ''),
+        url: `/${dataset.request}`,
       };
     });
 


### PR DESCRIPTION
## Description of proposed changes

Ensures that we don't get an invalid URLs after being redirected to the individual-group-page when user tries to access a non-existent dataset.

Resolves https://github.com/nextstrain/nextstrain.org/issues/1276

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
