### PR TITLE
Use ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ defaults:
 jobs:
   # Lint regardless of build or test status and lint early.
   lint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -51,7 +51,7 @@ jobs:
       - run: node ./scripts/check-resource-index-match.js
 
   type-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -62,7 +62,7 @@ jobs:
 
   # Build into Heroku slug so we can deploy the same build that we test.
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
@@ -81,7 +81,7 @@ jobs:
   test:
     if: github.repository == 'nextstrain/nextstrain.org'
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container:
       image: heroku/heroku:22
     env:
@@ -189,7 +189,7 @@ jobs:
       url: ${{ needs.vars.outputs.heroku-app && format('https://{0}.herokuapp.com', needs.vars.outputs.heroku-app) || 'https://next.nextstrain.org' }}
 
     # Deploy steps
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     env:
       HEROKU_APP: ${{ needs.vars.outputs.heroku-app }}
     steps:

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   merge-auspice-bump:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - id: metadata
         uses: dependabot/fetch-metadata@v2

--- a/.github/workflows/index-resources.yml
+++ b/.github/workflows/index-resources.yml
@@ -31,7 +31,7 @@ defaults:
 
 jobs:
   build-ref-matrix:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       ref-matrix: ${{ steps.ref-matrix.outputs.ref-matrix }}
     steps:
@@ -61,7 +61,7 @@ jobs:
       group: ${{ github.workflow }}-${{ matrix.resource_index }}
     env:
         RESOURCE_INDEX: ${{ matrix.resource_index }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint
       contents: read

--- a/.github/workflows/remind-to-promote.yml
+++ b/.github/workflows/remind-to-promote.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   remind-to-promote:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 jobs:
   fmt:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Terraform
         run: |
@@ -34,7 +34,7 @@ jobs:
         env:
           - env/production
           - env/testing
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Terraform
         run: |


### PR DESCRIPTION
## Description of proposed changes

Swapping to ubuntu-24.04 early allowed us to find and address breakage on our own schedule. Now that ubuntu-24.04 and ubuntu-latest are the same thing, we can use the latter to avoid version bump churn.

## Related issue(s)

Follow-up to https://github.com/nextstrain/.github/issues/113#issuecomment-2722724872

## Checklist

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
