### PR TITLE
Restore group name filtering

### DIFF
--- a/static-site/app/groups/available.tsx
+++ b/static-site/app/groups/available.tsx
@@ -83,11 +83,13 @@ export default function Available(): React.ReactElement {
       const parts = dataset.request.split('/').slice(1);
       const groupName = parts[1]
       if (parts[0] !== "groups" || groupName === undefined) return [];
-      const name = parts.slice(2).join('/');
+      const name = parts.slice(1).join('/');
+      const nameParts = name.split('/');
       return [{
         name,
         groupName,
-        nameParts: name.split('/'),
+        nameParts,
+        displayNameParts: nameParts.slice(1),
         sortingName: name,
         url: dataset.request,
       }];

--- a/static-site/components/list-resources/resource-group.tsx
+++ b/static-site/components/list-resources/resource-group.tsx
@@ -279,9 +279,11 @@ function _addDisplayName(
   const sep = "│"; // ASCII 179
 
   return resources.map((r, i) => {
+    const displayParts = r.displayNameParts ?? r.nameParts;
+
     let name: string;
     if (i === 0) {
-      name = r.nameParts.join(sep);
+      name = displayParts.join(sep);
     } else {
       const previousResource = resources[i - 1];
 
@@ -291,23 +293,25 @@ function _addDisplayName(
         );
       }
 
-      let matchIdx = r.nameParts
-        .map((word, j) => word === previousResource.nameParts[j])
+      const prevDisplayParts = previousResource.displayNameParts ?? previousResource.nameParts;
+
+      let matchIdx = displayParts
+        .map((word, j) => word === prevDisplayParts[j])
         .findIndex((v) => !v);
 
       if (matchIdx === -1) {
         // -1 means every word is in the preceding name, but we should display the last word anyway
-        matchIdx = r.nameParts.length - 2;
+        matchIdx = displayParts.length - 2;
       }
 
-      name = r.nameParts
+      name = displayParts
         .map((word, j) => (j < matchIdx ? " ".repeat(word.length) : word))
         .join(sep);
     }
 
     return {
       ...r,
-      displayName: { hovered: r.nameParts.join(sep), default: name },
+      displayName: { hovered: displayParts.join(sep), default: name },
     };
   });
 }

--- a/static-site/components/list-resources/types.ts
+++ b/static-site/components/list-resources/types.ts
@@ -57,6 +57,13 @@ export interface Resource {
   displayName?: ResourceDisplayName;
   groupName: string;
   nameParts: string[];
+
+  /**
+   * Array of name parts to display.
+   * If not provided, nameParts will be used.
+   */
+  displayNameParts?: string[];
+
   sortingName: string;
   url: string;
   lastUpdated?: string; // date


### PR DESCRIPTION
## Description of proposed changes

The commit "Strip group name in resource list" (c7b44980) had the unintended side effect of removing the group name from filter options.

This is a follow-up that keeps the visual change while allowing group names to be used in filtering. It is accomplished by adding a resource-level property to control which name parts are displayed, using that to hide the first name part on the groups page.

## Related issue(s)

Closes #1286

## Checklist

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
