### PR TITLE
group page: Split nested resources into multiple sections

### DIFF
--- a/static-site/app/groups/[group]/page.tsx
+++ b/static-site/app/groups/[group]/page.tsx
@@ -120,13 +120,44 @@ export default function IndividualGroupPage({
       };
     });
 
-    return [{
-      groupName: group,
-      resources,
-      nResources: resources.length,
-      nVersions: undefined,
-      lastUpdated: undefined,
-    }];
+    // Check if any resource has more than one name part
+    const nestedResources = resources.some(r => r.nameParts.length > 1);
+
+    if (nestedResources) {
+      // Group by first name part
+      const updatedResources = resources.map((r): Resource => {
+        const firstNamePart = r.nameParts[0];
+        if (firstNamePart === undefined) {
+          // This should never happen
+          throw new Error(`Unexpected: Resource "${r.name}" has no name parts`);
+        }
+        return {
+          ...r,
+          groupName: firstNamePart,
+        };
+      });
+      const firstNameParts = Array.from(new Set(updatedResources.map(r => r.groupName)));
+      const groups = firstNameParts.map((firstNamePart): Group => {
+        const resourcesInGroup = updatedResources.filter(r => r.groupName === firstNamePart);
+        return {
+          groupName: firstNamePart,
+          resources: resourcesInGroup,
+          nResources: resourcesInGroup.length,
+          nVersions: undefined,
+          lastUpdated: undefined,
+        };
+      });
+      return groups;
+    } else {
+      // Return a single resource group
+      return [{
+        groupName: group,
+        resources,
+        nResources: resources.length,
+        nVersions: undefined,
+        lastUpdated: undefined,
+      }];
+    }
   }
 
   let bannerContents: React.ReactElement = <></>;


### PR DESCRIPTION
> [!NOTE]
> Preview: https://dev.nextstrain.org/groups/blab

## Description of proposed changes

This PR contains a prep commit followed by the main commit. Message from main commit:

This aligns with the core pathogens page. The new behavior only applies when the group has at least one nested resource (i.e. with multiple name parts).

## Related issue(s)

Mentioned on [Slack](https://bedfordlab.slack.com/archives/CBVHPFMGX/p1767895604136379?thread_ts=1767885254.302999&cid=CBVHPFMGX)

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
