### PR TITLE
[charon/getAvailable] snapshots

### DIFF
--- a/src/endpoints/charon/getAvailable.js
+++ b/src/endpoints/charon/getAvailable.js
@@ -1,5 +1,5 @@
 import * as authz from '../../authz/index.js';
-import { CommunitySource } from '../../sources/index.js';
+import { CommunitySource, CoreSource, NextcladeSource } from '../../sources/index.js';
 import * as utils from '../../utils/index.js';
 import { splitPrefixIntoParts, joinPartsIntoPrefix } from '../../utils/prefix.js';
 import * as metaSources from '../../metaSources.js';
@@ -32,6 +32,8 @@ const getAvailable = async (req, res) => {
   return res.json({
     datasets: await Promise.all(datasets.map(async (path) => ({
       request: await joinPartsIntoPrefix({source, prefixParts: [path]}),
+      // snapshots only for core & nextclade sources so far
+      snapshots: source instanceof CoreSource || source instanceof NextcladeSource,
       secondTreeOptions: source.secondTreeOptions(path),
       buildUrl: source instanceof CommunitySource
         ? `https://github.com/${source.repo}`


### PR DESCRIPTION
The new Auspice dataset selector UI <https://github.com/nextstrain/auspice/pull/2030> looks for an optional `snapshots: boolean` in the getAvailable API response to decide whether to expose this in the UI. Over time we may adapt this response (and the UI) to list the known snapshots, but for now a `true` value will result in a freeform text box where you can enter in the desired YYYY-MM-DD snapshot for a given dataset.

Tested locally (Auspice server/client & nextstrain.org server on different localhost ports) -- see https://github.com/nextstrain/auspice/issues/2033.


- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
