### PR TITLE
nextclade: Show ENPEN datasets

### DIFF
--- a/env/production/config.json
+++ b/env/production/config.json
@@ -110,6 +110,6 @@
   "OIDC_GROUPS_CLAIM": "cognito:groups",
   "SESSION_COOKIE_DOMAIN": "nextstrain.org",
   "GROUPS_DATA_FILE": "groups.json",
-  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v9.json.gz",
+  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v10.json.gz",
   "PLAUSIBLE_ANALYTICS_DOMAIN": "nextstrain.org"
 }

--- a/env/testing/config.json
+++ b/env/testing/config.json
@@ -108,5 +108,5 @@
   "OIDC_USERNAME_CLAIM": "cognito:username",
   "OIDC_GROUPS_CLAIM": "cognito:groups",
   "GROUPS_DATA_FILE": "groups.json",
-  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v9.json.gz"
+  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v10.json.gz"
 }

--- a/src/sources/nextclade.js
+++ b/src/sources/nextclade.js
@@ -17,7 +17,7 @@ const NEXTSTRAIN_COLLECTION_PREFIX = re`^${NEXTSTRAIN_COLLECTION_ID}/`;
  * lookup operation.
  *   -trs, 3 Nov 2025
  */
-const COLLECTION_IDS = new Set([NEXTSTRAIN_COLLECTION_ID, "community"]);
+const COLLECTION_IDS = new Set([NEXTSTRAIN_COLLECTION_ID, "community", "enpen"]);
 
 
 /**

--- a/static-site/app/nextclade/resources.tsx
+++ b/static-site/app/nextclade/resources.tsx
@@ -8,7 +8,7 @@ import { listResourcesAPI } from "../../components/list-resources/listResourcesA
 import { Group } from "../../components/list-resources/types";
 import nextstrainLogoSmall from "../../static/logos/nextstrain-logo-small.png";
 
-const NON_NEXTSTRAIN_COLLECTIONS = ["community"];
+const NON_NEXTSTRAIN_COLLECTIONS = ["community", "enpen"];
 
 export default function NextcladeResourceListing(): React.ReactElement {
   return (


### PR DESCRIPTION
## Description of proposed changes

This PR contains 1 prep commit + 1 main commit. Message from main commit:

This updates nextstrain.org/nextclade to show all datasets available on clades.nextstrain.org.

Preview: https://nextstrain-s-victorlin--7ahavb.herokuapp.com/nextclade

<img width="694" height="92" alt="image" src="https://github.com/user-attachments/assets/3ff55972-a529-4ac4-994c-08e1ac9720df" />

## Related issue(s)

#1301

## Checklist

- [x] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
- [x] [Run resource indexer on PR branch as `v10`](https://github.com/nextstrain/nextstrain.org/actions/runs/21188139524)
- [x] ~Consider fetching logo?~ I'll try doing this in the bigger change described in option 2 of #1301
