### PR TITLE
Replace deprecated dependabot merge comment

### DIFF
--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -21,7 +21,6 @@ jobs:
       - if: |
           contains(fromJSON(steps.metadata.outputs.updated-dependencies-json).*.dependencyName, 'auspice')
           && steps.metadata.outputs.update-type != 'version-update:semver-major'
-        # Dependabot should ensure CI passes before merging.
-        run: gh pr comment "${{ github.event.pull_request.html_url }}" --body "@dependabot merge"
+        run: gh pr merge
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_REPO }}


### PR DESCRIPTION
Auto-merge via the `@dependabot merge` comment will stop working next week. Replacing it with a GitHub CLI command. This command will no longer wait for checks to pass², but that's fairly low risk when scoped to Auspice version bumps on next.nextstrain.org.

¹ https://github.blog/changelog/2025-10-06-upcoming-changes-to-github-dependabot-pull-request-comment-commands/
² It's possible, but requires setting up a branch protection rule to prevent direct pushes to `master`, which is a big change.

Closes #1248.

## Checklist

- [x] ~Checks pass~ N/A
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
