### PR TITLE
Upgrade to Heroku-24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: heroku/heroku:24
+      # The image's default user does not have access to the working directory.
+      # <https://devcenter.heroku.com/articles/heroku-24-stack>
+      options: --user root
     env:
       # Override NODE_ENV=production default in production build (slug)
       NODE_ENV: development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     container:
-      image: heroku/heroku:22
+      image: heroku/heroku:24
     env:
       # Override NODE_ENV=production default in production build (slug)
       NODE_ENV: development

--- a/scripts/heroku-build
+++ b/scripts/heroku-build
@@ -64,11 +64,11 @@ docker run \
   --volume "$(realpath build/cache)":/build/cache:rw \
   --volume "$(realpath build/env)":/build/env:ro \
   --env HOME=/tmp \
-  --env STACK=heroku-22 \
+  --env STACK=heroku-24 \
   --env SOURCE_VERSION \
   --env SOURCE_DESCRIPTION \
   --env NODE_MODULES_CACHE=false \
-  heroku/heroku:22-build bash -c '
+  heroku/heroku:24-build bash -c '
        /build/pack/bin/detect  /build/app \
     && /build/pack/bin/compile /build/app /build/cache /build/env
   '
@@ -115,7 +115,7 @@ jq \
   --argjson procfile "$(<build/app/Procfile.json)" \
   --arg checksum "$(awk '{print "SHA256:" $1}' build/slug.tar.gz.sha256sum)" \
   '{
-    "stack": "heroku-22",
+    "stack": "heroku-24",
     "commit": $ENV.SOURCE_VERSION,
     "commit_description": $ENV.SOURCE_DESCRIPTION,
     "process_types": $procfile,

--- a/scripts/heroku-exec
+++ b/scripts/heroku-exec
@@ -47,5 +47,5 @@ docker run \
   --env HOME=/app \
   --env BASH_ENV=/app/.heroku/BASH_ENV \
   "${docker_args[@]:0}" \
-  heroku/heroku:22 \
+  heroku/heroku:24 \
     bash -c -- 'exec "$@"' "$1" "$@"


### PR DESCRIPTION
Heroku-22 was deprecated last week.

https://help.heroku.com/NQNCQTEJ/heroku-22-end-of-life-faq

See https://github.com/nextstrain/public/issues/42

## Checklist

- [x] Review app looks good
- [x] Checks pass
- [x] Post-merge: [deploy to nextstrain-dev](https://github.com/nextstrain/nextstrain.org/actions/runs/26607478070) (nextstrain-canary gets automatically deployed on merge; nextstrain-server will follow with the next promotion from canary)
- [x] ~Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)~ N/A
