### PR TITLE
Add /browser-fetch endpoint

### DIFF
--- a/docs/api-restful.rst
+++ b/docs/api-restful.rst
@@ -354,6 +354,8 @@ The following dataset endpoints exist::
 
     {GET, HEAD, OPTIONS} /fetch/*
 
+    {GET, HEAD, OPTIONS} /browser-fetch/*
+
 The following narrative endpoints exist::
 
     {GET, HEAD, PUT, DELETE, OPTIONS} /narratives/*
@@ -365,6 +367,8 @@ The following narrative endpoints exist::
     {GET, HEAD, OPTIONS} /community/narratives/{user}/{repo}/*
 
     {GET, HEAD, OPTIONS} /fetch/narratives/*
+
+    {GET, HEAD, OPTIONS} /browser-fetch/narratives/*
 
 The following group settings endpoints exist::
 

--- a/src/endpoints/sources.js
+++ b/src/endpoints/sources.js
@@ -5,6 +5,7 @@ import { NotFound } from '../httpErrors.js';
 
 import * as authz from '../authz/index.js';
 import { contentTypesProvided, contentTypesConsumed } from '../negotiate.js';
+import { UrlDefinedBrowserSource } from '../sources/index.js';
 import * as options from './options.js';
 import { sendAuspiceEntrypoint } from './auspice.js';
 import { deleteByUrls, proxyFromUpstream, proxyToUpstream } from "../upstream.js";
@@ -317,6 +318,13 @@ function sendSubresource(subresourceExtractor) {
     authz.assertAuthorized(req.user, authz.actions.Read, subresource.resource);
 
     res.set("Content-Disposition", contentDisposition(subresource.conventionalFilename));
+
+    if (subresource.resource.source instanceof UrlDefinedBrowserSource) {
+      /* 307 Temporary Redirect preserves request method, unlike 302 Found, which
+       * is important since this middleware function may be used in non-GET routes.
+       */
+      return res.redirect(307, await subresource.url());
+    }
 
     return await proxyFromUpstream(req, res,
       await subresource.url(),

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -105,6 +105,7 @@ const setup = (app) => {
     "/docs/contributing/development": `${mainReadTheDocs}/guides/contribute/index.html`,
     "/docs/contributing/fetch-data-from-custom-urls": `${mainReadTheDocs}/guides/share/fetch-via-urls.html`,
     "/fetch": `${mainReadTheDocs}/guides/share/fetch-via-urls.html`,
+    "/browser-fetch": `${mainReadTheDocs}/guides/share/fetch-via-urls.html`,
     "/docs/contributing/nextstrain-groups": `${mainReadTheDocs}/guides/share/nextstrain-groups.html`,
     "/docs/contributing/sharing-data": `${mainReadTheDocs}/guides/share/index.html`,
     "/docs/contributing/philosophy": `${mainReadTheDocs}/guides/share/index.html`,

--- a/src/routing/fetch.js
+++ b/src/routing/fetch.js
@@ -13,11 +13,14 @@ const {
 
 const {
   UrlDefinedSource,
+  UrlDefinedBrowserSource,
 } = sources;
 
 export function setup(app) {
   app.use(["/fetch/narratives/:authority", "/fetch/:authority"],
     setSource(req => new UrlDefinedSource(req.params.authority)));
+  app.use(["/browser-fetch/narratives/:authority", "/browser-fetch/:authority"],
+    setSource(req => new UrlDefinedBrowserSource(req.params.authority)));
 
   app.routeAsync("/fetch/narratives/:authority/*")
     .all(setNarrative(req => req.params[0]))
@@ -26,6 +29,18 @@ export function setup(app) {
   ;
 
   app.routeAsync("/fetch/:authority/*")
+    .all(setDataset(req => req.params[0]))
+    .getAsync(getDataset)
+    .optionsAsync(optionsDataset)
+  ;
+
+  app.routeAsync("/browser-fetch/narratives/:authority/*")
+    .all(setNarrative(req => req.params[0]))
+    .getAsync(getNarrative)
+    .optionsAsync(optionsNarrative)
+  ;
+
+  app.routeAsync("/browser-fetch/:authority/*")
     .all(setDataset(req => req.params[0]))
     .getAsync(getDataset)
     .optionsAsync(optionsDataset)

--- a/src/sources/fetch.js
+++ b/src/sources/fetch.js
@@ -45,6 +45,8 @@ class UrlDefinedSource extends Source {
   }
 }
 
+class UrlDefinedBrowserSource extends UrlDefinedSource {}
+
 class UrlDefinedDataset extends Dataset {
   static get Subresource() {
     return UrlDefinedDatasetSubresource;
@@ -133,4 +135,5 @@ class UrlDefinedNarrativeSubresource extends NarrativeSubresource {
 
 export {
   UrlDefinedSource,
+  UrlDefinedBrowserSource,
 };

--- a/src/sources/index.js
+++ b/src/sources/index.js
@@ -3,6 +3,6 @@
 
 export { CoreSource, CoreStagingSource } from './core.js';
 export { CommunitySource } from './community.js';
-export { UrlDefinedSource } from './fetch.js';
+export { UrlDefinedSource, UrlDefinedBrowserSource } from './fetch.js';
 export { GroupSource } from './groups.js';
 export { NextcladeSource } from './nextclade.js';

--- a/src/utils/prefix.js
+++ b/src/utils/prefix.js
@@ -12,6 +12,7 @@ const sourceNameToClass = new Map([
   ["nextclade", sources.NextcladeSource],
   ["community", sources.CommunitySource],
   ["fetch", sources.UrlDefinedSource],
+  ["browser-fetch", sources.UrlDefinedBrowserSource],
   ["groups", sources.GroupSource],
 ]);
 
@@ -47,6 +48,7 @@ const splitPrefixIntoParts = (prefix) => {
     case "staging":
     case "nextclade":
     case "fetch":
+    case "browser-fetch":
       sourceName = prefixParts.shift();
       break;
     case "groups":
@@ -89,8 +91,9 @@ const splitPrefixIntoParts = (prefix) => {
       source = new Source(...prefixParts.splice(0, 2));
       break;
 
-    // UrlDefined source requires a URL authority part
+    // URL-defined sources requires a URL authority part
     case "fetch":
+    case "browser-fetch":
       source = new Source(prefixParts.shift());
       break;
 
@@ -123,6 +126,7 @@ const joinPartsIntoPrefix = async ({source, prefixParts, isNarrative = false}) =
     case "staging":
     case "nextclade":
     case "fetch":
+    case "browser-fetch":
       leadingParts.push(sourceName);
       break;
 
@@ -144,8 +148,9 @@ const joinPartsIntoPrefix = async ({source, prefixParts, isNarrative = false}) =
       leadingParts.push(source.owner, await source.repoNameWithBranch());
       break;
 
-    // UrlDefined source requires a URL authority part
+    // URL-defined sources requires a URL authority part
     case "fetch":
+    case "browser-fetch":
       leadingParts.push(source.authority);
       break;
 

--- a/test/requests.test.js
+++ b/test/requests.test.js
@@ -102,6 +102,27 @@ describe("datasets", () => {
     ]);
   });
 
+  describe("browser-fetch", () => {
+    const path = "/browser-fetch/example.com/path/to/dataset.json";
+
+    testIsAuspice(path);
+    testRedirectsToUpstream({
+      path,
+      accept: "application/json",
+      location: "https://example.com/path/to/dataset.json",
+    });
+    testRedirectsToUpstream({
+      path,
+      accept: "application/vnd.nextstrain.dataset.root-sequence+json",
+      location: "https://example.com/path/to/dataset_root-sequence.json",
+    });
+    testRedirectsToUpstream({
+      path: "/charon/getDataset?prefix=/browser-fetch/example.com/path/to/dataset.json",
+      accept: "application/json",
+      location: "https://example.com/path/to/dataset.json",
+    });
+  });
+
   function testPaths(cases) {
     cases.forEach(testPath);
   }
@@ -232,6 +253,22 @@ describe("narratives", () => {
         testDoesNotExist: false
       },
     ]);
+  });
+
+  describe("browser-fetch", () => {
+    const path = "/browser-fetch/narratives/example.com/path/to/narrative.md";
+
+    testIsAuspice(path);
+    testRedirectsToUpstream({
+      path,
+      accept: "text/markdown",
+      location: "https://example.com/path/to/narrative.md",
+    });
+    testRedirectsToUpstream({
+      path: "/charon/getNarrative?prefix=/browser-fetch/narratives/example.com/path/to/narrative.md&type=md",
+      accept: "text/markdown",
+      location: "https://example.com/path/to/narrative.md",
+    });
   });
 
   function testPaths(cases) {
@@ -376,6 +413,25 @@ function testBadRequest(path) {
       const body = await res.json();
       expect(body).toHaveProperty("error");
       expect(body.error).toMatch(/paths may not include underscores/);
+    });
+  });
+}
+
+function testRedirectsToUpstream({path, accept, location}) {
+  describe(`${path} redirects upstream (accept: ${accept})`, () => {
+    const req = fetch(url(path), {
+      headers: {Accept: accept},
+      redirect: "manual",
+    });
+
+    test("status is 307", async () => {
+      const res = await req;
+      expect(res.status).toBe(307);
+    });
+
+    test("location is the upstream URL", async () => {
+      const res = await req;
+      expect(res.headers.get("Location")).toBe(location);
     });
   });
 }


### PR DESCRIPTION
An alternative to /fetch that, instead of proxying the request through the server, sends a client-side request from the user's web browser.

Note that this only works for upstream URLs that support cross-origin requests.

## Checklist
- [ ] Update documentation [Share Analyses through Nextstrain](https://docs.nextstrain.org/en/latest/guides/share/index.html) and [Share via public URLs](https://docs.nextstrain.org/en/latest/guides/share/fetch-via-urls.html)
- [ ] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)
