### PR TITLE
adding h7nx to the manifest

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -198,6 +198,59 @@
               "default": "ha"
             }
           },
+          "h7nx": {
+            "segment": {
+              "ha": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "mp": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "na": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "ns": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "np": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "pa": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "pb1": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "pb2": {
+                "resolution": {
+                  "all-time": "",
+                  "default": "all-time"
+                }
+              },
+              "default": "ha"
+            }
+          },
           "h9n2": {
             "segment": {
               "ha": {


### PR DESCRIPTION
## Description of proposed changes

I would like to add H7Nx to the avian builds, and have edited the manifest accordingly. I messed this up one time, so it'd be great if someone could test this and make sure I added it correctly! 

## Related issue(s)

Related to the H7Nx build curation pull request over here: https://github.com/nextstrain/avian-flu/pull/170