### PR TITLE
Add seasonal-flu/open and seasonal-flu/gisaid

### DIFF
--- a/data/manifest_core.json
+++ b/data/manifest_core.json
@@ -865,110 +865,197 @@
         }
       },
       "seasonal-flu": {
-        "lineage": {
-          "h3n2": {
-            "segment": {
-              "ha": {
-                "resolution": {
-                  "6m": "",
-                  "2y": "",
-                  "3y": "",
-                  "6y": "",
-                  "12y": "",
-                  "default": "2y"
+        "data_source": {
+          "gisaid": {
+            "lineage": {
+              "h3n2": {
+                "segment": {
+                  "ha": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "default": "2y"
+                    }
+                  },
+                  "na": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "default": "2y"
+                    }
+                  },
+                  "default": "ha"
                 }
               },
-              "na": {
-                "resolution": {
-                  "6m": "",
-                  "2y": "",
-                  "3y": "",
-                  "6y": "",
-                  "12y": "",
-                  "default": "2y"
+              "h1n1pdm": {
+                "segment": {
+                  "ha": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "pandemic": "",
+                      "default": "2y"
+                    }
+                  },
+                  "na": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "pandemic": "",
+                      "default": "2y"
+                    }
+                  },
+                  "default": "ha"
                 }
               },
-              "default": "ha"
+              "vic": {
+                "segment": {
+                  "ha": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "default": "2y"
+                    }
+                  },
+                  "na": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "default": "2y"
+                    }
+                  },
+                  "default": "ha"
+                }
+              },
+              "yam": {
+                "segment": {
+                  "ha": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "default": "2y"
+                    }
+                  },
+                  "na": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "default": "2y"
+                    }
+                  },
+                  "default": "ha"
+                }
+              },
+              "default": "h3n2"
             }
           },
-          "h1n1pdm": {
-            "segment": {
-              "ha": {
-                "resolution": {
-                  "6m": "",
-                  "2y": "",
-                  "3y": "",
-                  "6y": "",
-                  "12y": "",
-                  "pandemic": "",
-                  "default": "2y"
+          "open":{
+            "lineage": {
+              "h3n2": {
+                "segment": {
+                  "ha": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "default": "2y"
+                    }
+                  },
+                  "na": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "default": "2y"
+                    }
+                  },
+                  "default": "ha"
                 }
               },
-              "na": {
-                "resolution": {
-                  "6m": "",
-                  "2y": "",
-                  "3y": "",
-                  "6y": "",
-                  "12y": "",
-                  "pandemic": "",
-                  "default": "2y"
+              "h1n1pdm": {
+                "segment": {
+                  "ha": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "pandemic": "",
+                      "default": "2y"
+                    }
+                  },
+                  "na": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "pandemic": "",
+                      "default": "2y"
+                    }
+                  },
+                  "default": "ha"
                 }
               },
-              "default": "ha"
+              "vic": {
+                "segment": {
+                  "ha": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "default": "2y"
+                    }
+                  },
+                  "na": {
+                    "resolution": {
+                      "6m": "",
+                      "2y": "",
+                      "3y": "",
+                      "6y": "",
+                      "12y": "",
+                      "default": "2y"
+                    }
+                  },
+                  "default": "ha"
+                }
+              },
+              "default": "h3n2"
             }
           },
-          "vic": {
-            "segment": {
-              "ha": {
-                "resolution": {
-                  "6m": "",
-                  "2y": "",
-                  "3y": "",
-                  "6y": "",
-                  "12y": "",
-                  "default": "2y"
-                }
-              },
-              "na": {
-                "resolution": {
-                  "6m": "",
-                  "2y": "",
-                  "3y": "",
-                  "6y": "",
-                  "12y": "",
-                  "default": "2y"
-                }
-              },
-              "default": "ha"
-            }
-          },
-          "yam": {
-            "segment": {
-              "ha": {
-                "resolution": {
-                  "6m": "",
-                  "2y": "",
-                  "3y": "",
-                  "6y": "",
-                  "12y": "",
-                  "default": "2y"
-                }
-              },
-              "na": {
-                "resolution": {
-                  "6m": "",
-                  "2y": "",
-                  "3y": "",
-                  "6y": "",
-                  "12y": "",
-                  "default": "2y"
-                }
-              },
-              "default": "ha"
-            }
-          },
-          "default": "h3n2"
+          "default": "gisaid"
         }
       },
       "tb": {

--- a/docs/resource-collection.rst
+++ b/docs/resource-collection.rst
@@ -43,7 +43,7 @@ The handling of new revision numbers in Heroku review apps is currently still
 handled manually.
 
 Once you've pushed up the changes to the revision number in the config, run
-the `index-resource.yml workflow <https://github.com/nextstrain/nextstrain.org/actions/workflows/index-resources.yml>__`
+the `index-resource.yml workflow <https://github.com/nextstrain/nextstrain.org/actions/workflows/index-resources.yml>`__
 using your branch.
 
 After the new index resources JSON has been uploaded to S3, then open the PR for

--- a/env/production/config.json
+++ b/env/production/config.json
@@ -110,6 +110,6 @@
   "OIDC_GROUPS_CLAIM": "cognito:groups",
   "SESSION_COOKIE_DOMAIN": "nextstrain.org",
   "GROUPS_DATA_FILE": "groups.json",
-  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v11.json.gz",
+  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v12.json.gz",
   "PLAUSIBLE_ANALYTICS_DOMAIN": "nextstrain.org"
 }

--- a/env/testing/config.json
+++ b/env/testing/config.json
@@ -108,5 +108,5 @@
   "OIDC_USERNAME_CLAIM": "cognito:username",
   "OIDC_GROUPS_CLAIM": "cognito:groups",
   "GROUPS_DATA_FILE": "groups.json",
-  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v11.json.gz"
+  "RESOURCE_INDEX": "s3://nextstrain-inventories/resources/v12.json.gz"
 }

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -172,7 +172,13 @@ const datasetRedirectPatterns = [
      * both under flu/ so that avian-flu is more discoverable
      */
    ['/flu/avian(.*)', '/avian-flu(.*)'],
-   ['/flu/seasonal(.*)', '/seasonal-flu(.*)'],
+   /**
+    * Prior to Sept 2026, the core seasonal-flu build were exclusively GISAID builds.
+    * Since we now have GISAID and open builds, add redirects for the old URLs to
+    * point to the new GISAID URLs.
+    */
+   ['/flu/seasonal/:lineage(h3n2|h1n1pdm|vic|yam)/(.*)', '/seasonal-flu/gisaid/:lineage/(.*)'],
+   ['/seasonal-flu/:lineage(h3n2|h1n1pdm|vic|yam)/(.*)', '/seasonal-flu/gisaid/:lineage/(.*)'],
 
    /**
     * Redirect /flu URL itself. We choose seasonal-flu to mimic historical behaviour

--- a/test/auspice_client_requests.json
+++ b/test/auspice_client_requests.json
@@ -1,7 +1,7 @@
 [
   {
-    "name": "Fetch core Nextstrain dataset (seasonal-flu/h3n2/ha/2y)",
-    "url": "/charon/getDataset?prefix=/seasonal-flu/h3n2/ha/2y",
+    "name": "Fetch core Nextstrain dataset (seasonal-flu/gisaid/h3n2/ha/2y)",
+    "url": "/charon/getDataset?prefix=/seasonal-flu/gisaid/h3n2/ha/2y",
     "expectStatusCode": 200,
     "responseIsJson": true,
     "__comment": "We could define JSON schemas for each API and validate the response here"
@@ -11,7 +11,7 @@
     "url": "/charon/getDataset?prefix=/seasonal-flu",
     "expectStatusCode": 307,
     "responseIsJson": false,
-    "redirectsTo": "/charon/getDataset?prefix=seasonal-flu%2Fh3n2%2Fha%2F2y"
+    "redirectsTo": "/charon/getDataset?prefix=seasonal-flu%2Fgisaid%2Fh3n2%2Fha%2F2y"
   },
   {
     "name": "/flu URLs are not redirected in the charon API (but they are in the RESTful API)",
@@ -94,13 +94,13 @@
   },
   {
     "name": "Check getDataset API for sidecar file tip-frequencies",
-    "url": "/charon/getDataset?prefix=/seasonal-flu/h3n2/ha/2y&type=tip-frequencies",
+    "url": "/charon/getDataset?prefix=/seasonal-flu/gisaid/h3n2/ha/2y&type=tip-frequencies",
     "expectStatusCode": 200,
     "responseIsJson": true
   },
   {
     "name": "Fetch dataset using /fetch URLs (from S3 staging bucket)",
-    "url": "/charon/getDataset?prefix=/fetch/staging.nextstrain.org/seasonal-flu_h3n2_ha_2y.json",
+    "url": "/charon/getDataset?prefix=/fetch/staging.nextstrain.org/seasonal-flu_gisaid_h3n2_ha_2y.json",
     "expectStatusCode": 200,
     "responseIsJson": true
   },
@@ -122,7 +122,7 @@
   },
   {
     "name": "Fetch sidecar file using /fetch URLs (root-sequence JSON from S3 staging bucket)",
-    "url": "/charon/getDataset?prefix=/fetch/staging.nextstrain.org/seasonal-flu_h3n2_ha_2y.json&type=root-sequence",
+    "url": "/charon/getDataset?prefix=/fetch/staging.nextstrain.org/seasonal-flu_gisaid_h3n2_ha_2y.json&type=root-sequence",
     "expectStatusCode": 200,
     "responseIsJson": true
   },

--- a/test/inventory_parsing.test.js
+++ b/test/inventory_parsing.test.js
@@ -34,7 +34,7 @@ test('parsing of nextstrain-data/zika_meta.json inventory', async () => {
 
   const shuffled = await parseInventory({objects: shuffle(zika_meta), versionsExist: true})
   expect(shuffled.map((el) => el.versionId))
-    .toEqual(should_be.map((el) => el.VersionId))  
+    .toEqual(should_be.map((el) => el.VersionId))
 })
 
 test('back-to-back delete markers', async () => {
@@ -48,7 +48,7 @@ test('back-to-back delete markers', async () => {
 
   const shuffled = await parseInventory({objects: shuffle(test_data), versionsExist: true})
     expect(shuffled.map((el) => el.versionId))
-      .toEqual(should_be.map((el) => el.VersionId))   
+      .toEqual(should_be.map((el) => el.VersionId))
 })
 
 /**
@@ -62,9 +62,11 @@ test('core URL redirects (via our manifest) are correctly obtained', async () =>
   const expected_url_redirects = {
     'dengue/denv1': 'dengue/denv1/genome',
     WNV: 'WNV/all-lineages',
-    'seasonal-flu': 'seasonal-flu/h3n2/ha/2y',
-    'seasonal-flu/h3n2': 'seasonal-flu/h3n2/ha/2y',
-    'seasonal-flu/h3n2/ha': 'seasonal-flu/h3n2/ha/2y',
+    'seasonal-flu': 'seasonal-flu/gisaid/h3n2/ha/2y',
+    'seasonal-flu/h3n2': 'seasonal-flu/gisaid/h3n2/ha/2y',
+    'seasonal-flu/h3n2/ha': 'seasonal-flu/gisaid/h3n2/ha/2y',
+    'seasonal-flu/gisaid': 'seasonal-flu/gisaid/h3n2/ha/2y',
+    'seasonal-flu/open': 'seasonal-flu/open/h3n2/ha/2y',
   }
   Object.entries(expected_url_redirects).forEach(([from, to]) => {
     expect(remapCoreUrl(from)).toEqual(to);


### PR DESCRIPTION
## Description of proposed changes

Update manifest to split seasonal-flu into GISAID and open builds. Includes redirects for previous core seasonal-flu builds to redirect to seasonal-flu/gisaid/*. 

## Related issue(s)

Depends on https://github.com/nextstrain/seasonal-flu/pull/348

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [x] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
