### PR TITLE
Update community-datasets.yaml

### DIFF
--- a/static-site/content/community-datasets.yaml
+++ b/static-site/content/community-datasets.yaml
@@ -210,3 +210,7 @@ data:
     contributor: NPPO-NL
     date: '2025-08-04'
     name: Real-time tracking of Tomato brown rugose fruit virus (ToBRFV) outbreaks using Nextstrain
+  - url: https://nextstrain.org/community/batyanight/cdv-phylodynamics@main
+    contributor: Batya Nightingale
+    date: '2026-08-29'
+    name: Phylodynamics of a wildlife-maintained canine distemper virus lineage in North American carnivores


### PR DESCRIPTION
Add CDV phylodynamics community dataset

## Description of proposed changes

Adds a community dataset to `community-datasets.yaml`: a phylodynamic analysis of an
America-2 canine distemper virus lineage circulating in North American carnivores.

- 162 hemagglutinin gene sequences from GenBank, 1992–2023, 95% from wild hosts
  (raccoon, coyote, striped skunk, red fox) across Canada, the USA and Denmark
- Time-calibrated tree inferred in BEAST 2.7 (relaxed lognormal clock, constant-size
  coalescent, two chains of 10⁸ states) with discrete host-state reconstruction
- Auspice v2 JSON generated directly from the BEAST MCC tree rather than via augur

Dataset: https://nextstrain.org/community/batyanight/cdv-phylodynamics@main
Repository: https://github.com/batyanight/cdv-phylodynamics

## Related issue(s)

None.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ x] checks pass; two workflows awaiting maintainer approval
- [ ] Check if changes affect the [resource index JSON revision](https://docs.nextstrain.org/projects/nextstrain-dot-org/en/latest/resource-collection.html#resource-index-revisions)


